### PR TITLE
[codex] Improve trajectory viewer interaction and local help

### DIFF
--- a/src/skim/__init__.py
+++ b/src/skim/__init__.py
@@ -52,6 +52,7 @@ HUMAN_TEXT_KEYS = {
     "stdout",
     "text",
 }
+WRAPPER_KEYS = ("arguments", "content", "output", "result", "text")
 SUBMISSION_KEYS = {
     "agentic_grader_guidance",
     "prompt",
@@ -374,30 +375,6 @@ def _function_call_detail_widgets(raw: dict[str, Any]) -> list[Widget]:
 def _function_call_result_detail_widgets(raw: dict[str, Any]) -> list[Widget]:
     widgets = _tool_identity_widgets(raw)
     decoded = _decoded_tool_result(raw.get("output"))
-
-    if isinstance(decoded, dict):
-        handled = False
-        for key in ("returncode", "stdout", "stderr"):
-            if key not in decoded:
-                continue
-            handled = True
-            widgets.append(_detail_heading(key))
-            value = decoded[key]
-            if isinstance(value, str):
-                widgets.extend(_render_string_detail(value))
-            else:
-                widgets.extend(_render_payload_detail(value))
-        rest = {
-            key: value
-            for key, value in decoded.items()
-            if key not in {"returncode", "stdout", "stderr"}
-        }
-        if rest:
-            widgets.append(_detail_heading("Output"))
-            widgets.extend(_render_payload_detail(rest))
-        if handled:
-            return widgets
-
     widgets.extend(_render_payload_detail(decoded))
     return widgets
 
@@ -429,14 +406,12 @@ def _tool_identity_widgets(raw: dict[str, Any]) -> list[Widget]:
 def _render_payload_detail(value: Any) -> list[Widget]:
     decoded = _decode_nested_json(value)
     if isinstance(decoded, dict | list):
+        promoted = _promote_wrapper_value(decoded)
+        if promoted is not None:
+            return _render_structured_detail(promoted)
         if _has_human_text(decoded):
             return _render_structured_detail(decoded)
-        return [
-            Static(
-                Syntax(json.dumps(decoded, indent=2), "json", word_wrap=True),
-                classes="trajectory-detail",
-            )
-        ]
+        return _render_json_block(decoded)
     if decoded is None:
         return [Static(Text(""))]
     return _render_string_detail(str(decoded))
@@ -448,18 +423,65 @@ def _render_string_detail(value: str) -> list[Widget]:
 
     decoded = _try_decode_json(value)
     if isinstance(decoded, dict | list):
+        promoted = _promote_wrapper_value(decoded)
+        if promoted is not None:
+            return _render_structured_detail(promoted)
         if _has_human_text(decoded):
             return _render_structured_detail(decoded)
-        return [
-            Static(
-                Syntax(json.dumps(decoded, indent=2), "json", word_wrap=True),
-                classes="trajectory-detail",
-            )
-        ]
+        return _render_json_block(decoded)
 
     if _looks_like_markdown(value):
         return [Markdown(value, classes="trajectory-markdown")]
+    if _looks_like_preformatted_text(value):
+        return [Static(Syntax(value, "text", word_wrap=True), classes="trajectory-detail")]
     return [Static(Text(value), classes="trajectory-detail")]
+
+
+def _promote_wrapper_value(value: Any) -> Any | None:
+    current = _decode_nested_json(value)
+    while isinstance(current, dict):
+        candidates = [
+            key for key in WRAPPER_KEYS if key in current and _can_promote_wrapper(current, key)
+        ]
+        if not candidates:
+            return None
+        promoted_key = candidates[0]
+        promoted_value = _decode_nested_json(current[promoted_key])
+        siblings = {
+            key: item
+            for key, item in current.items()
+            if key != promoted_key and not _is_empty_value(_decode_nested_json(item))
+        }
+        if siblings:
+            current = {"value": promoted_value, **siblings}
+        else:
+            current = promoted_value
+        current = _decode_nested_json(current)
+    return current if current is not value else None
+
+
+def _can_promote_wrapper(container: dict[str, Any], key: str) -> bool:
+    value = _decode_nested_json(container.get(key))
+    siblings = {
+        sibling_key: _decode_nested_json(item)
+        for sibling_key, item in container.items()
+        if sibling_key != key and not _is_empty_value(_decode_nested_json(item))
+    }
+    if not _is_renderable_leaf(value):
+        return False
+    if not siblings:
+        return True
+    return all(not _has_human_text(item) for item in siblings.values())
+
+
+def _is_renderable_leaf(value: Any) -> bool:
+    if isinstance(value, str):
+        return bool(value.strip())
+    if isinstance(value, list):
+        return any(_is_renderable_leaf(item) for item in value)
+    if isinstance(value, dict):
+        return _has_human_text(value)
+    return False
 
 
 def _render_structured_detail(value: Any) -> list[Widget]:
@@ -504,6 +526,9 @@ def _render_keyed_value(key: str, value: Any) -> list[Widget]:
     if isinstance(value, str):
         return _render_keyed_string(normalized_key, value)
     if isinstance(value, dict):
+        promoted = _promote_wrapper_value(value)
+        if promoted is not None:
+            return _render_structured_detail(promoted)
         if _has_human_text(value):
             return _render_dict_sections(value)
         return _render_json_block(value)
@@ -519,6 +544,9 @@ def _render_keyed_value(key: str, value: Any) -> list[Widget]:
 def _render_keyed_string(key: str, value: str) -> list[Widget]:
     decoded = _try_decode_json(value)
     if isinstance(decoded, dict | list):
+        promoted = _promote_wrapper_value(decoded)
+        if promoted is not None:
+            return _render_structured_detail(promoted)
         return (
             _render_structured_detail(decoded)
             if _has_human_text(decoded)
@@ -555,7 +583,12 @@ def _render_json_block(value: Any) -> list[Widget]:
 
 def _has_human_text(value: Any) -> bool:
     if isinstance(value, str):
-        return "\n" in value or _looks_like_markdown(value) or bool(value.strip())
+        return (
+            "\n" in value
+            or _looks_like_markdown(value)
+            or _looks_like_preformatted_text(value)
+            or bool(value.strip())
+        )
     if isinstance(value, dict):
         return any(
             str(key).lower() in HUMAN_TEXT_KEYS and _has_human_text(item)
@@ -596,6 +629,19 @@ def _looks_like_markdown(value: str) -> bool:
         or line[:3].isdigit()
         for line in lines
     )
+
+
+def _looks_like_preformatted_text(value: str) -> bool:
+    lines = value.splitlines()
+    if len(lines) < 2:
+        return False
+    sample = lines[:30]
+    indented = sum(1 for line in sample if line.startswith(("    ", "\t")))
+    if indented / max(len(sample), 1) > 0.3:
+        return True
+    if value.count("/") > 5 or value.count("\t") > 3:
+        return True
+    return False
 
 
 def _detail_heading(label: str) -> Static:

--- a/src/skim/__init__.py
+++ b/src/skim/__init__.py
@@ -997,6 +997,7 @@ class TrajectoryViewer(Vertical):
         self.step_events = normalize_step_events(trajectory)
         self.step_items = normalize_step_timeline(trajectory)
         self.events = normalize_events(trajectory)
+        self._input_mode = "tree"
         self._summary = Static(Text(_metadata_header(trajectory)), classes="trajectory-summary")
         self._tree: Tree[TrajectoryTreeItem] = Tree("Trajectory", classes="trajectory-tree")
         self._build_tree()
@@ -1004,7 +1005,7 @@ class TrajectoryViewer(Vertical):
         initial_widgets: list[Widget] = []
         if isinstance(first_item, TrajectoryTreeItem):
             initial_widgets = _detail_widgets_for_item(first_item)
-        self._detail_wrap = VerticalScroll(*initial_widgets, classes="trajectory-detail-wrap")
+        self._detail_wrap = FocusableDetailWrap(*initial_widgets, classes="trajectory-detail-wrap")
 
     def compose(self) -> ComposeResult:
         """Compose the trajectory summary, event tree, and detail panel."""
@@ -1029,6 +1030,77 @@ class TrajectoryViewer(Vertical):
     def scroll_detail(self, delta: int) -> None:
         """Scroll the rendered detail panel."""
         self._detail_wrap.scroll_relative(y=delta, animate=False)
+
+    def is_tree_mode(self) -> bool:
+        """Return whether keyboard navigation is driving the left tree."""
+        return self._input_mode == "tree"
+
+    def focus_tree_mode(self) -> None:
+        """Route navigation input to the tree."""
+        self._input_mode = "tree"
+        self._ensure_tree_cursor()
+        if self.is_attached:
+            self._tree.focus(scroll_visible=False)
+
+    def focus_detail_mode(self) -> None:
+        """Route navigation input to the rendered detail pane."""
+        self._input_mode = "detail"
+        if self.is_attached:
+            self._detail_wrap.focus(scroll_visible=False)
+
+    def handle_vertical_key(self, delta: int) -> bool:
+        """Handle up/down keys for the active trajectory sub-view."""
+        if self.is_tree_mode():
+            if delta < 0:
+                self._tree.action_cursor_up()
+            else:
+                self._tree.action_cursor_down()
+            return True
+        self.scroll_detail(delta)
+        return True
+
+    def handle_horizontal_key(self, key: str) -> bool:
+        """Handle left/right tree navigation."""
+        if not self.is_tree_mode():
+            return False
+        node = self._tree.cursor_node
+        if node is None:
+            return False
+        if key == "left":
+            if node.allow_expand and node.is_expanded:
+                node.collapse()
+            elif node.parent is not None:
+                self._tree.move_cursor(node.parent, animate=False)
+            return True
+        if key == "right":
+            if node.allow_expand and node.is_collapsed:
+                node.expand()
+            elif node.children:
+                self._tree.move_cursor(node.children[0], animate=False)
+            return True
+        return False
+
+    def handle_enter_key(self) -> bool:
+        """Select the current tree item and move focus to the detail pane."""
+        if not self.is_tree_mode():
+            return False
+        self._ensure_tree_cursor()
+        self._tree.action_select_cursor()
+        self.focus_detail_mode()
+        return True
+
+    def handle_escape_key(self) -> bool:
+        """Return keyboard control from detail back to the tree."""
+        if self.is_tree_mode():
+            return False
+        self.focus_tree_mode()
+        return True
+
+    def _ensure_tree_cursor(self) -> None:
+        """Keep the tree cursor on the first visible child instead of the root."""
+        cursor = self._tree.cursor_node
+        if (cursor is None or cursor.is_root) and self._tree.root.children:
+            self._tree.move_cursor(self._tree.root.children[0], animate=False)
 
     def _build_tree(self) -> None:
         """Populate the trajectory tree."""
@@ -1104,6 +1176,10 @@ class SubmissionSummary(Static):
         super().__init__(self.summary_text, classes="submission-summary")
 
 
+class FocusableDetailWrap(VerticalScroll, can_focus=True):
+    """Focusable scroll container for trajectory detail rendering."""
+
+
 class PreviewPane(VerticalScroll, can_focus=True):
     """Scrollable panel that shows file contents."""
 
@@ -1122,9 +1198,17 @@ class PreviewPane(VerticalScroll, can_focus=True):
         """Render a file into the pane."""
         self.current_path = path
         self.remove_children()
-        for widget in render_file(path):
+        widgets = render_file(path)
+        for widget in widgets:
             self.mount(widget)
         self.scroll_home(animate=False)
+        if (
+            widgets
+            and isinstance(widgets[0], TrajectoryViewer)
+            and isinstance(self.app, SkimApp)
+            and self.id == self.app.active_pane_id
+        ):
+            self.call_after_refresh(widgets[0].focus_tree_mode)
 
     def on_click(self) -> None:
         """Mark this pane as the active preview when clicked."""
@@ -1139,9 +1223,17 @@ class PreviewPane(VerticalScroll, can_focus=True):
         except NoMatches:
             viewer = None
         if isinstance(viewer, TrajectoryViewer):
-            viewer.scroll_detail(delta)
+            viewer.handle_vertical_key(delta)
         else:
             self.scroll_relative(y=delta, animate=False)
+
+    def active_trajectory_viewer(self) -> TrajectoryViewer | None:
+        """Return the mounted trajectory viewer, if this pane has one."""
+        try:
+            viewer = self.query(TrajectoryViewer).first()
+        except NoMatches:
+            return None
+        return viewer if isinstance(viewer, TrajectoryViewer) else None
 
 
 class SkimApp(App):
@@ -1227,9 +1319,11 @@ class SkimApp(App):
 
     STATUS_TEXT = (
         " [bold]q[/] Quit  "
-        "[bold]↑↓[/] Scroll  "
+        "[bold]↑↓[/] Scroll / JSON tree  "
+        "[bold]←→[/] JSON branches  "
+        "[bold]Esc[/] JSON tree  "
         "[bold]⇧↑↓[/] Tree  "
-        "[bold]Enter[/] Open  "
+        "[bold]Enter[/] Open / Detail  "
         "[bold]s[/]+arrow Split  "
         "[bold]d[/] Close  "
         "[bold]w[/] Next pane"
@@ -1369,6 +1463,31 @@ class SkimApp(App):
             event.prevent_default()
             event.stop()
             return
+
+        viewer: TrajectoryViewer | None = None
+        try:
+            active_pane = self.query_one(f"#{self.active_pane_id}", PreviewPane)
+            viewer = active_pane.active_trajectory_viewer()
+        except Exception:
+            viewer = None
+
+        if viewer is not None and event.key in {"left", "right"}:
+            if viewer.handle_horizontal_key(event.key):
+                event.prevent_default()
+                event.stop()
+                return
+
+        if viewer is not None and event.key == "escape":
+            if viewer.handle_escape_key():
+                event.prevent_default()
+                event.stop()
+                return
+
+        if viewer is not None and event.key == "enter":
+            if viewer.handle_enter_key():
+                event.prevent_default()
+                event.stop()
+                return
 
         # shift+arrows navigate the file tree, enter opens
         if event.key == "shift+down":

--- a/src/skim/__init__.py
+++ b/src/skim/__init__.py
@@ -11,6 +11,7 @@ from rich.text import Text
 from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical, VerticalScroll
+from textual.css.query import NoMatches
 from textual.events import Key
 from textual.widget import Widget
 from textual.widgets import Collapsible, DirectoryTree, Header, Markdown, Static, Tree
@@ -1133,11 +1134,14 @@ class PreviewPane(VerticalScroll, can_focus=True):
 
     def scroll_content(self, delta: int) -> None:
         """Scroll specialized inner content when present, else scroll the pane."""
-        viewer = self.query(TrajectoryViewer).first()
+        try:
+            viewer = self.query(TrajectoryViewer).first()
+        except NoMatches:
+            viewer = None
         if isinstance(viewer, TrajectoryViewer):
             viewer.scroll_detail(delta)
-            return
-        self.scroll_relative(y=delta, animate=False)
+        else:
+            self.scroll_relative(y=delta, animate=False)
 
 
 class SkimApp(App):

--- a/src/skim/__init__.py
+++ b/src/skim/__init__.py
@@ -1025,6 +1025,10 @@ class TrajectoryViewer(Vertical):
         self._detail_wrap.mount(*_detail_widgets_for_item(item))
         self._detail_wrap.scroll_home(animate=False)
 
+    def scroll_detail(self, delta: int) -> None:
+        """Scroll the rendered detail panel."""
+        self._detail_wrap.scroll_relative(y=delta, animate=False)
+
     def _build_tree(self) -> None:
         """Populate the trajectory tree."""
         self._tree.root.expand()
@@ -1126,6 +1130,14 @@ class PreviewPane(VerticalScroll, can_focus=True):
         app = self.app
         if isinstance(app, SkimApp) and self.id is not None:
             app.set_active_pane(self.id)
+
+    def scroll_content(self, delta: int) -> None:
+        """Scroll specialized inner content when present, else scroll the pane."""
+        viewer = self.query(TrajectoryViewer).first()
+        if isinstance(viewer, TrajectoryViewer):
+            viewer.scroll_detail(delta)
+            return
+        self.scroll_relative(y=delta, animate=False)
 
 
 class SkimApp(App):
@@ -1301,7 +1313,7 @@ class SkimApp(App):
             return
         try:
             pane = self.query_one(f"#{self.active_pane_id}", PreviewPane)
-            pane.scroll_relative(y=SCROLL_STEP, animate=False)
+            pane.scroll_content(SCROLL_STEP)
         except Exception:
             pass
 
@@ -1313,7 +1325,7 @@ class SkimApp(App):
             return
         try:
             pane = self.query_one(f"#{self.active_pane_id}", PreviewPane)
-            pane.scroll_relative(y=-SCROLL_STEP, animate=False)
+            pane.scroll_content(-SCROLL_STEP)
         except Exception:
             pass
 

--- a/src/skim/__init__.py
+++ b/src/skim/__init__.py
@@ -549,16 +549,27 @@ def _tool_section_widgets(event: TrajectoryEvent | None, focus: str) -> list[Wid
 
 
 def _decoded_tool_result(output: Any) -> Any:
-    decoded = _decode_nested_json(output)
-    if isinstance(decoded, dict) and set(decoded) == {"text"}:
-        return decoded["text"]
-    if (
-        isinstance(decoded, dict)
-        and isinstance(decoded.get("text"), dict)
-        and any(key in decoded["text"] for key in ("stdout", "stderr", "returncode"))
-    ):
-        return {**decoded, **decoded["text"]}
-    return decoded
+    return _normalize_text_wrapper(_decode_nested_json(output))
+
+
+def _normalize_text_wrapper(value: Any) -> Any:
+    decoded = _decode_nested_json(value)
+    if not isinstance(decoded, dict):
+        return decoded
+    if set(decoded) == {"text"}:
+        return _normalize_text_wrapper(decoded["text"])
+    if isinstance(decoded.get("text"), dict):
+        text_payload = _normalize_text_wrapper(decoded["text"])
+        if isinstance(text_payload, dict) and any(
+            key in text_payload for key in ("stdout", "stderr", "returncode", "pages", "code")
+        ):
+            siblings = {
+                key: _normalize_text_wrapper(item)
+                for key, item in decoded.items()
+                if key != "text" and key not in text_payload
+            }
+            return {**text_payload, **siblings}
+    return {key: _normalize_text_wrapper(item) for key, item in decoded.items()}
 
 
 def _tool_identity_widgets(raw: dict[str, Any]) -> list[Widget]:

--- a/src/skim/__init__.py
+++ b/src/skim/__init__.py
@@ -1006,6 +1006,7 @@ class TrajectoryViewer(Vertical):
         if isinstance(first_item, TrajectoryTreeItem):
             initial_widgets = _detail_widgets_for_item(first_item)
         self._detail_wrap = FocusableDetailWrap(*initial_widgets, classes="trajectory-detail-wrap")
+        self._footer = Static(self._footer_text(), classes="trajectory-footer")
 
     def compose(self) -> ComposeResult:
         """Compose the trajectory summary, event tree, and detail panel."""
@@ -1013,6 +1014,7 @@ class TrajectoryViewer(Vertical):
         with Horizontal(classes="trajectory-body"):
             yield self._tree
             yield self._detail_wrap
+        yield self._footer
 
     def on_tree_node_selected(self, event: Tree.NodeSelected[TrajectoryTreeItem]) -> None:
         """Update detail when a trajectory tree node is selected."""
@@ -1038,6 +1040,7 @@ class TrajectoryViewer(Vertical):
     def focus_tree_mode(self) -> None:
         """Route navigation input to the tree."""
         self._input_mode = "tree"
+        self._update_footer()
         self._ensure_tree_cursor()
         if self.is_attached:
             self._tree.focus(scroll_visible=False)
@@ -1045,6 +1048,7 @@ class TrajectoryViewer(Vertical):
     def focus_detail_mode(self) -> None:
         """Route navigation input to the rendered detail pane."""
         self._input_mode = "detail"
+        self._update_footer()
         if self.is_attached:
             self._detail_wrap.focus(scroll_visible=False)
 
@@ -1101,6 +1105,31 @@ class TrajectoryViewer(Vertical):
         cursor = self._tree.cursor_node
         if (cursor is None or cursor.is_root) and self._tree.root.children:
             self._tree.move_cursor(self._tree.root.children[0], animate=False)
+
+    def _footer_text(self) -> Text:
+        """Build the mode-aware local footer text."""
+        text = Text()
+        if self.is_tree_mode():
+            text.append(" JSON ", style="reverse")
+            text.append(" ")
+            text.append("↑↓", style="bold")
+            text.append(" Move  ")
+            text.append("←→", style="bold")
+            text.append(" Branch  ")
+            text.append("Enter", style="bold")
+            text.append(" Detail")
+        else:
+            text.append(" Detail ", style="reverse")
+            text.append(" ")
+            text.append("↑↓", style="bold")
+            text.append(" Scroll  ")
+            text.append("Esc", style="bold")
+            text.append(" Back to JSON")
+        return text
+
+    def _update_footer(self) -> None:
+        """Refresh the local footer after mode changes."""
+        self._footer.update(self._footer_text())
 
     def _build_tree(self) -> None:
         """Populate the trajectory tree."""
@@ -1283,6 +1312,13 @@ class SkimApp(App):
     .trajectory-detail-field {
         padding: 0 1;
     }
+    .trajectory-footer {
+        height: 1;
+        color: $text-muted;
+        background: $surface-lighten-1;
+        padding: 0 1;
+        margin: 1 0 0 0;
+    }
     Collapsible.trajectory-section {
         margin: 0 0 1 0;
     }
@@ -1319,11 +1355,9 @@ class SkimApp(App):
 
     STATUS_TEXT = (
         " [bold]q[/] Quit  "
-        "[bold]↑↓[/] Scroll / JSON tree  "
-        "[bold]←→[/] JSON branches  "
-        "[bold]Esc[/] JSON tree  "
+        "[bold]↑↓[/] Scroll  "
         "[bold]⇧↑↓[/] Tree  "
-        "[bold]Enter[/] Open / Detail  "
+        "[bold]Enter[/] Open  "
         "[bold]s[/]+arrow Split  "
         "[bold]d[/] Close  "
         "[bold]w[/] Next pane"

--- a/src/skim/__init__.py
+++ b/src/skim/__init__.py
@@ -92,13 +92,39 @@ class TrajectoryEvent:
 
 
 @dataclass(frozen=True)
+class ToolInteraction:
+    """Paired tool call and result linked by call id."""
+
+    index: int
+    tool_name: str
+    short_name: str
+    call_id: str
+    short_call_id: str
+    call_event: TrajectoryEvent | None = None
+    result_event: TrajectoryEvent | None = None
+
+
+@dataclass(frozen=True)
+class StepTimelineItem:
+    """Display row inside one trajectory step."""
+
+    kind: str
+    index: int
+    title: Text
+    event: TrajectoryEvent | None = None
+    interaction: ToolInteraction | None = None
+
+
+@dataclass(frozen=True)
 class TrajectoryTreeItem:
     """Data attached to a trajectory tree node."""
 
     kind: str
     title: str
-    detail: Any
+    detail: Any = None
     event: TrajectoryEvent | None = None
+    interaction: ToolInteraction | None = None
+    focus: str = "full"
 
 
 def render_file(path: Path) -> list[Widget]:
@@ -195,6 +221,88 @@ def normalize_step_events(trajectory: dict[str, Any]) -> list[list[TrajectoryEve
     return groups
 
 
+def normalize_step_timeline(trajectory: dict[str, Any]) -> list[list[StepTimelineItem]]:
+    """Return step items with paired tool interactions."""
+    timeline_groups: list[list[StepTimelineItem]] = []
+    for events in normalize_step_events(trajectory):
+        group: list[StepTimelineItem] = []
+        pending_calls: dict[str, int] = {}
+        for event in events:
+            if event.kind == "function_call":
+                interaction = ToolInteraction(
+                    index=event.index,
+                    tool_name=_tool_name(event.raw),
+                    short_name=_short_tool_name(_tool_name(event.raw)),
+                    call_id=_call_id(event.raw),
+                    short_call_id=_short_call_id(_call_id(event.raw)),
+                    call_event=event,
+                )
+                group.append(
+                    StepTimelineItem(
+                        kind="tool",
+                        index=event.index,
+                        title=_tool_tree_label(interaction),
+                        interaction=interaction,
+                    )
+                )
+                if interaction.call_id:
+                    pending_calls[interaction.call_id] = len(group) - 1
+                continue
+
+            if event.kind == "function_call_result":
+                call_id = _call_id(event.raw)
+                group_index = pending_calls.pop(call_id, None) if call_id else None
+                if group_index is not None:
+                    interaction = group[group_index].interaction
+                    if interaction is None:
+                        continue
+                    updated = ToolInteraction(
+                        index=interaction.index,
+                        tool_name=interaction.tool_name,
+                        short_name=interaction.short_name,
+                        call_id=interaction.call_id,
+                        short_call_id=interaction.short_call_id,
+                        call_event=interaction.call_event,
+                        result_event=event,
+                    )
+                    group[group_index] = StepTimelineItem(
+                        kind="tool",
+                        index=updated.index,
+                        title=_tool_tree_label(updated),
+                        interaction=updated,
+                    )
+                    continue
+
+                orphan = ToolInteraction(
+                    index=event.index,
+                    tool_name=_tool_name(event.raw),
+                    short_name=_short_tool_name(_tool_name(event.raw)),
+                    call_id=call_id,
+                    short_call_id=_short_call_id(call_id),
+                    result_event=event,
+                )
+                group.append(
+                    StepTimelineItem(
+                        kind="tool",
+                        index=event.index,
+                        title=_tool_tree_label(orphan, suffix=" Output"),
+                        interaction=orphan,
+                    )
+                )
+                continue
+
+            group.append(
+                StepTimelineItem(
+                    kind=event.kind,
+                    index=event.index,
+                    title=_standalone_tree_label(event),
+                    event=event,
+                )
+            )
+        timeline_groups.append(group)
+    return timeline_groups
+
+
 def _specialized_json_widget(data: Any) -> Widget | None:
     trajectory = _extract_trajectory(data)
     if trajectory is not None:
@@ -225,6 +333,28 @@ def _event_label(raw: dict[str, Any]) -> str:
         if value:
             return str(value)
     return ""
+
+
+def _tool_name(raw: dict[str, Any]) -> str:
+    value = raw.get("name")
+    return str(value) if value else "tool"
+
+
+def _call_id(raw: dict[str, Any]) -> str:
+    value = raw.get("callId") or raw.get("call_id")
+    return str(value) if value else ""
+
+
+def _short_tool_name(name: str) -> str:
+    if "__" in name:
+        return name.split("__")[-1]
+    return name
+
+
+def _short_call_id(call_id: str) -> str:
+    if not call_id:
+        return ""
+    return call_id[-3:]
 
 
 def _event_excerpt(raw: dict[str, Any]) -> str:
@@ -330,6 +460,8 @@ def _final_output_detail(trajectory: dict[str, Any]) -> str:
 
 
 def _detail_widgets_for_item(item: TrajectoryTreeItem) -> list[Widget]:
+    if item.interaction is not None:
+        return _tool_interaction_detail_widgets(item.interaction, item.focus)
     if item.event is not None:
         return _event_detail_widgets(item.event)
     if isinstance(item.detail, Text):
@@ -340,43 +472,69 @@ def _detail_widgets_for_item(item: TrajectoryTreeItem) -> list[Widget]:
 
 
 def _event_detail_widgets(event: TrajectoryEvent) -> list[Widget]:
-    header = Text(f"{event.index + 1}. {event.kind}")
-    if event.label:
-        header.append(f"\nlabel: {event.label}")
+    header = Text(f"{event.index + 1:03d} ", style="dim")
+    header.append(_standalone_title(event), style="bold")
     widgets: list[Widget] = [Static(header, classes="trajectory-detail-heading")]
 
-    if event.kind == "function_call":
-        widgets.extend(_function_call_detail_widgets(event.raw))
-    elif event.kind == "function_call_result":
-        widgets.extend(_function_call_result_detail_widgets(event.raw))
-    else:
+    if event.kind == "message":
+        widgets.extend(
+            _metadata_fields(
+                [("Role", _message_role(event.raw)), ("Status", _status_value(event.raw))]
+            )
+        )
         text = _event_text(event.raw)
         if text:
             widgets.extend(_render_string_detail(text))
         else:
             widgets.extend(_render_payload_detail(_event_payload(event.raw)))
-    return widgets
-
-
-def _function_call_detail_widgets(raw: dict[str, Any]) -> list[Widget]:
-    widgets = _tool_identity_widgets(raw)
-    decoded = _decode_nested_json(raw.get("arguments"))
-
-    if isinstance(decoded, dict):
-        if _has_human_text(decoded):
-            widgets.extend(_render_dict_sections(decoded))
+    elif event.kind == "reasoning":
+        text = _event_text(event.raw)
+        if text:
+            widgets.extend(_render_string_detail(text))
         else:
-            widgets.extend(_render_payload_detail(decoded))
+            widgets.extend(_render_payload_detail(_event_payload(event.raw)))
     else:
-        widgets.extend(_render_payload_detail(decoded))
+        widgets.extend(_render_payload_detail(_event_payload(event.raw)))
     return widgets
 
 
-def _function_call_result_detail_widgets(raw: dict[str, Any]) -> list[Widget]:
-    widgets = _tool_identity_widgets(raw)
-    decoded = _decoded_tool_result(raw.get("output"))
-    widgets.extend(_render_payload_detail(decoded))
+def _tool_interaction_detail_widgets(
+    interaction: ToolInteraction, focus: str = "full"
+) -> list[Widget]:
+    title = Text(f"{interaction.index + 1:03d} ", style="dim")
+    title.append(interaction.short_name, style="bold cyan")
+    if interaction.short_call_id:
+        title.append(f" #{interaction.short_call_id}", style="magenta")
+    widgets: list[Widget] = [Static(title, classes="trajectory-detail-heading")]
+    widgets.extend(
+        _metadata_fields(
+            [
+                ("Tool", interaction.tool_name),
+                ("Call ID", interaction.call_id),
+                ("Status", _interaction_status(interaction)),
+            ]
+        )
+    )
+
+    if focus == "output":
+        sections = [("Output", interaction.result_event), ("Input", interaction.call_event)]
+    elif focus == "input":
+        sections = [("Input", interaction.call_event), ("Output", interaction.result_event)]
+    else:
+        sections = [("Input", interaction.call_event), ("Output", interaction.result_event)]
+
+    for section_title, event in sections:
+        widgets.append(_detail_heading(section_title))
+        widgets.extend(_tool_section_widgets(event, section_title.lower()))
     return widgets
+
+
+def _tool_section_widgets(event: TrajectoryEvent | None, focus: str) -> list[Widget]:
+    if event is None:
+        return [Static(Text(f"No {focus}"), classes="trajectory-detail")]
+    if focus == "input":
+        return _render_payload_detail(_decode_nested_json(event.raw.get("arguments")))
+    return _render_payload_detail(_decoded_tool_result(event.raw.get("output")))
 
 
 def _decoded_tool_result(output: Any) -> Any:
@@ -398,6 +556,13 @@ def _tool_identity_widgets(raw: dict[str, Any]) -> list[Widget]:
         value = raw.get(key)
         if value:
             lines.append(f"{key}: {value}")
+    if not lines:
+        return []
+    return [Static(Text("\n".join(lines)), classes="trajectory-detail")]
+
+
+def _metadata_fields(fields: list[tuple[str, str | None]]) -> list[Widget]:
+    lines = [f"{label}: {value}" for label, value in fields if value not in (None, "")]
     if not lines:
         return []
     return [Static(Text("\n".join(lines)), classes="trajectory-detail")]
@@ -648,9 +813,60 @@ def _detail_heading(label: str) -> Static:
     return Static(Text(label, style="bold"), classes="trajectory-detail-heading")
 
 
-def _event_tree_label(event: TrajectoryEvent) -> str:
-    label = f" {event.label}" if event.label else ""
-    return f"{event.index + 1:03d} {event.kind}{label} {event.excerpt}"
+def _standalone_title(event: TrajectoryEvent) -> str:
+    if event.kind == "reasoning":
+        return "Reasoning"
+    if event.kind == "message":
+        return _message_role(event.raw)
+    return event.kind.replace("_", " ").title()
+
+
+def _standalone_tree_label(event: TrajectoryEvent) -> Text:
+    label = Text(f"{event.index + 1:03d} ", style="dim")
+    label.append(_standalone_title(event), style=_tree_kind_style(event.kind))
+    if event.excerpt:
+        label.append(f" {_clip(event.excerpt, 64)}", style="default")
+    return label
+
+
+def _tool_tree_label(interaction: ToolInteraction, suffix: str = "") -> Text:
+    label = Text(f"{interaction.index + 1:03d} ", style="dim")
+    label.append(interaction.short_name, style="bold cyan")
+    if interaction.short_call_id:
+        label.append(f" #{interaction.short_call_id}", style="magenta")
+    if suffix:
+        label.append(suffix, style="bold yellow")
+    return label
+
+
+def _message_role(raw: dict[str, Any]) -> str:
+    role = raw.get("role")
+    if not role:
+        return "Message"
+    return str(role).title()
+
+
+def _status_value(raw: dict[str, Any]) -> str | None:
+    value = raw.get("status")
+    return str(value) if value else None
+
+
+def _interaction_status(interaction: ToolInteraction) -> str | None:
+    for event in (interaction.result_event, interaction.call_event):
+        if event is None:
+            continue
+        status = _status_value(event.raw)
+        if status:
+            return status
+    return None
+
+
+def _tree_kind_style(kind: str) -> str:
+    if kind == "reasoning":
+        return "yellow"
+    if kind == "message":
+        return "green"
+    return "cyan"
 
 
 def _format_submission(data: dict[str, Any]) -> Text:
@@ -671,6 +887,7 @@ class TrajectoryViewer(Vertical):
         super().__init__(classes="trajectory-viewer")
         self.trajectory = trajectory
         self.step_events = normalize_step_events(trajectory)
+        self.step_items = normalize_step_timeline(trajectory)
         self.events = normalize_events(trajectory)
         self._summary = Static(Text(_metadata_header(trajectory)), classes="trajectory-summary")
         self._tree: Tree[TrajectoryTreeItem] = Tree("Trajectory", classes="trajectory-tree")
@@ -714,26 +931,55 @@ class TrajectoryViewer(Vertical):
                 "final_output", "Final Output", _final_output_detail(self.trajectory)
             ),
         )
-        for step_index, events in enumerate(self.step_events, start=1):
+        for step_index, items in enumerate(self.step_items, start=1):
             step = self._tree.root.add(
                 f"Step {step_index}",
                 data=TrajectoryTreeItem(
                     "step",
                     f"Step {step_index}",
-                    Text(f"Step {step_index}\n\n{len(events)} events"),
+                    Text(f"Step {step_index}\n\n{len(items)} items"),
                 ),
                 expand=True,
             )
-            for event in events:
-                step.add_leaf(
-                    _event_tree_label(event),
-                    data=TrajectoryTreeItem(
-                        "event",
-                        _event_tree_label(event),
-                        None,
-                        event=event,
-                    ),
-                )
+            for item in items:
+                if item.interaction is not None:
+                    parent = step.add(
+                        item.title,
+                        data=TrajectoryTreeItem(
+                            "tool",
+                            item.title.plain,
+                            interaction=item.interaction,
+                            focus="full",
+                        ),
+                        expand=True,
+                    )
+                    parent.add_leaf(
+                        Text("Input", style="bold yellow"),
+                        data=TrajectoryTreeItem(
+                            "tool_input",
+                            "Input",
+                            interaction=item.interaction,
+                            focus="input",
+                        ),
+                    )
+                    parent.add_leaf(
+                        Text("Output", style="bold yellow"),
+                        data=TrajectoryTreeItem(
+                            "tool_output",
+                            "Output",
+                            interaction=item.interaction,
+                            focus="output",
+                        ),
+                    )
+                elif item.event is not None:
+                    step.add_leaf(
+                        item.title,
+                        data=TrajectoryTreeItem(
+                            "event",
+                            item.title.plain,
+                            event=item.event,
+                        ),
+                    )
 
 
 class SubmissionSummary(Static):

--- a/src/skim/__init__.py
+++ b/src/skim/__init__.py
@@ -13,7 +13,7 @@ from textual.binding import Binding
 from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.events import Key
 from textual.widget import Widget
-from textual.widgets import DirectoryTree, Header, Markdown, Static, Tree
+from textual.widgets import Collapsible, DirectoryTree, Header, Markdown, Static, Tree
 
 SYNTAX_MAP = {
     ".py": "python",
@@ -53,6 +53,8 @@ HUMAN_TEXT_KEYS = {
     "text",
 }
 WRAPPER_KEYS = ("arguments", "content", "output", "result", "text")
+PRIMARY_CONTENT_KEYS = ("stdout", "code", "command", "text", "value")
+SECONDARY_COLLAPSED_KEYS = {"stderr", "pages", "json", "metadata", "other"}
 SUBMISSION_KEYS = {
     "agentic_grader_guidance",
     "prompt",
@@ -506,26 +508,35 @@ def _tool_interaction_detail_widgets(
     if interaction.short_call_id:
         title.append(f" #{interaction.short_call_id}", style="magenta")
     widgets: list[Widget] = [Static(title, classes="trajectory-detail-heading")]
-    widgets.extend(
-        _metadata_fields(
-            [
-                ("Tool", interaction.tool_name),
-                ("Call ID", interaction.call_id),
-                ("Status", _interaction_status(interaction)),
-            ]
+    widgets.append(
+        _section_widget(
+            "Tool",
+            _metadata_fields(
+                [
+                    ("Tool", interaction.tool_name),
+                    ("Call ID", interaction.call_id),
+                    ("Status", _interaction_status(interaction)),
+                ]
+            ),
+            collapsed=False,
         )
     )
-
-    if focus == "output":
-        sections = [("Output", interaction.result_event), ("Input", interaction.call_event)]
-    elif focus == "input":
-        sections = [("Input", interaction.call_event), ("Output", interaction.result_event)]
-    else:
-        sections = [("Input", interaction.call_event), ("Output", interaction.result_event)]
-
-    for section_title, event in sections:
-        widgets.append(_detail_heading(section_title))
-        widgets.extend(_tool_section_widgets(event, section_title.lower()))
+    widgets.append(
+        _section_widget(
+            "Input",
+            _tool_section_widgets(interaction.call_event, "input"),
+            collapsed=False,
+            selected=focus == "input",
+        )
+    )
+    widgets.append(
+        _section_widget(
+            "Output",
+            _tool_section_widgets(interaction.result_event, "output"),
+            collapsed=False,
+            selected=focus == "output",
+        )
+    )
     return widgets
 
 
@@ -562,10 +573,15 @@ def _tool_identity_widgets(raw: dict[str, Any]) -> list[Widget]:
 
 
 def _metadata_fields(fields: list[tuple[str, str | None]]) -> list[Widget]:
-    lines = [f"{label}: {value}" for label, value in fields if value not in (None, "")]
-    if not lines:
-        return []
-    return [Static(Text("\n".join(lines)), classes="trajectory-detail")]
+    widgets: list[Widget] = []
+    for label, value in fields:
+        if value in (None, ""):
+            continue
+        text = Text()
+        text.append(f"{label}: ", style="bold cyan")
+        text.append(str(value), style="white")
+        widgets.append(Static(text, classes="trajectory-detail-field"))
+    return widgets
 
 
 def _render_payload_detail(value: Any) -> list[Widget]:
@@ -573,9 +589,9 @@ def _render_payload_detail(value: Any) -> list[Widget]:
     if isinstance(decoded, dict | list):
         promoted = _promote_wrapper_value(decoded)
         if promoted is not None:
-            return _render_structured_detail(promoted)
+            return _render_structured_detail(promoted, nested=True)
         if _has_human_text(decoded):
-            return _render_structured_detail(decoded)
+            return _render_structured_detail(decoded, nested=True)
         return _render_json_block(decoded)
     if decoded is None:
         return [Static(Text(""))]
@@ -590,9 +606,9 @@ def _render_string_detail(value: str) -> list[Widget]:
     if isinstance(decoded, dict | list):
         promoted = _promote_wrapper_value(decoded)
         if promoted is not None:
-            return _render_structured_detail(promoted)
+            return _render_structured_detail(promoted, nested=True)
         if _has_human_text(decoded):
-            return _render_structured_detail(decoded)
+            return _render_structured_detail(decoded, nested=True)
         return _render_json_block(decoded)
 
     if _looks_like_markdown(value):
@@ -649,28 +665,44 @@ def _is_renderable_leaf(value: Any) -> bool:
     return False
 
 
-def _render_structured_detail(value: Any) -> list[Widget]:
+def _render_structured_detail(value: Any, nested: bool = False) -> list[Widget]:
     if isinstance(value, dict):
-        return _render_dict_sections(value)
+        return _render_dict_sections(value, nested=nested)
     if isinstance(value, list):
-        return _render_list_sections(value)
+        return _render_list_sections(value, nested=nested)
     return _render_payload_detail(value)
 
 
-def _render_dict_sections(value: dict[str, Any]) -> list[Widget]:
+def _render_dict_sections(value: dict[str, Any], nested: bool = True) -> list[Widget]:
     widgets: list[Widget] = []
+    metadata: list[tuple[str, str | None]] = []
+    if "value" in value and not _is_empty_value(_decode_nested_json(value["value"])):
+        widgets.extend(_render_payload_detail(_decode_nested_json(value["value"])))
     for key, item in value.items():
+        if key == "value":
+            continue
         decoded = _decode_nested_json(item)
         if _is_empty_value(decoded):
             continue
-        widgets.append(_detail_heading(str(key)))
-        widgets.extend(_render_keyed_value(str(key), decoded))
+        if _is_scalar_metadata(key, decoded):
+            metadata.append((_display_label(key), str(decoded)))
+            continue
+        widgets.append(
+            _section_widget(
+                _display_label(key),
+                _render_keyed_value(str(key), decoded),
+                collapsed=_section_collapsed(key, nested=nested),
+                secondary=_section_collapsed(key, nested=nested),
+            )
+        )
+    if metadata:
+        widgets = _metadata_fields(metadata) + widgets
     if widgets:
         return widgets
     return _render_json_block(value)
 
 
-def _render_list_sections(value: list[Any]) -> list[Widget]:
+def _render_list_sections(value: list[Any], nested: bool = True) -> list[Widget]:
     if not _has_human_text(value):
         return _render_json_block(value)
 
@@ -679,8 +711,14 @@ def _render_list_sections(value: list[Any]) -> list[Widget]:
         decoded = _decode_nested_json(item)
         if _is_empty_value(decoded):
             continue
-        widgets.append(_detail_heading(f"Item {index}"))
-        widgets.extend(_render_keyed_value("", decoded))
+        widgets.append(
+            _section_widget(
+                f"Item {index}",
+                _render_keyed_value("", decoded),
+                collapsed=nested,
+                secondary=nested,
+            )
+        )
     if widgets:
         return widgets
     return _render_json_block(value)
@@ -693,15 +731,15 @@ def _render_keyed_value(key: str, value: Any) -> list[Widget]:
     if isinstance(value, dict):
         promoted = _promote_wrapper_value(value)
         if promoted is not None:
-            return _render_structured_detail(promoted)
+            return _render_structured_detail(promoted, nested=True)
         if _has_human_text(value):
-            return _render_dict_sections(value)
+            return _render_dict_sections(value, nested=True)
         return _render_json_block(value)
     if isinstance(value, list):
         if normalized_key == "pages":
             return _render_pages(value)
         if _has_human_text(value):
-            return _render_list_sections(value)
+            return _render_list_sections(value, nested=True)
         return _render_json_block(value)
     return [Static(Text(str(value)), classes="trajectory-detail")]
 
@@ -711,9 +749,9 @@ def _render_keyed_string(key: str, value: str) -> list[Widget]:
     if isinstance(decoded, dict | list):
         promoted = _promote_wrapper_value(decoded)
         if promoted is not None:
-            return _render_structured_detail(promoted)
+            return _render_structured_detail(promoted, nested=True)
         return (
-            _render_structured_detail(decoded)
+            _render_structured_detail(decoded, nested=True)
             if _has_human_text(decoded)
             else _render_json_block(decoded)
         )
@@ -732,8 +770,14 @@ def _render_pages(value: list[Any]) -> list[Widget]:
     widgets: list[Widget] = []
     for index, item in enumerate(value, start=1):
         decoded = _decode_nested_json(item)
-        widgets.append(_detail_heading(f"Page {index}"))
-        widgets.extend(_render_keyed_value("text", decoded))
+        widgets.append(
+            _section_widget(
+                f"Page {index}",
+                _render_keyed_value("text", decoded),
+                collapsed=True,
+                secondary=True,
+            )
+        )
     return widgets or _render_json_block(value)
 
 
@@ -811,6 +855,58 @@ def _looks_like_preformatted_text(value: str) -> bool:
 
 def _detail_heading(label: str) -> Static:
     return Static(Text(label, style="bold"), classes="trajectory-detail-heading")
+
+
+def _section_widget(
+    title: str,
+    body: list[Widget],
+    *,
+    collapsed: bool,
+    selected: bool = False,
+    secondary: bool = False,
+) -> Collapsible:
+    if not body:
+        body = [Static(Text("(empty)"), classes="trajectory-detail")]
+    classes = ["trajectory-section"]
+    if selected:
+        classes.append("trajectory-section-selected")
+    if secondary:
+        classes.append("trajectory-section-secondary")
+    return Collapsible(*body, title=title, collapsed=collapsed, classes=" ".join(classes))
+
+
+def _display_label(key: str) -> str:
+    special = {
+        "call_id": "Call ID",
+        "code": "code",
+        "command": "command",
+        "pages": "pages",
+        "returncode": "returncode",
+        "stderr": "stderr",
+        "stdout": "stdout",
+        "text": "text",
+    }
+    if key in special:
+        return special[key]
+    return key
+
+
+def _section_collapsed(key: str, *, nested: bool) -> bool:
+    if key.lower() in PRIMARY_CONTENT_KEYS:
+        return False
+    if key.lower() in SECONDARY_COLLAPSED_KEYS:
+        return True
+    return nested
+
+
+def _is_scalar_metadata(key: str, value: Any) -> bool:
+    if isinstance(value, bool | int | float):
+        return True
+    if isinstance(value, str):
+        if key.lower() in {"stdout", "stderr", "text", "code", "command"}:
+            return False
+        return "\n" not in value and len(value) <= 120
+    return False
 
 
 def _standalone_title(event: TrajectoryEvent) -> str:
@@ -1064,6 +1160,18 @@ class SkimApp(App):
         width: 2fr;
         height: 1fr;
         padding: 0 1;
+    }
+    .trajectory-detail-field {
+        padding: 0 1;
+    }
+    Collapsible.trajectory-section {
+        margin: 0 0 1 0;
+    }
+    Collapsible.trajectory-section-selected {
+        border: round $accent;
+    }
+    Collapsible.trajectory-section-secondary {
+        border: round $panel-lighten-1;
     }
     #status-bar {
         dock: bottom;

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -323,6 +323,48 @@ async def test_tool_result_pages_render_as_readable_sections():
         assert not any('"pages":' in block.code for block in _detail_syntax_blocks(viewer))
 
 
+async def test_nested_output_text_stdout_promotes_inner_content():
+    """Nested output -> text -> stdout payloads promote the inner stdout section."""
+    output = {"text": json.dumps({"stdout": "## Nested\n\nUseful text", "returncode": 0})}
+    viewer = TrajectoryViewer(sample_trajectory(output=output))
+    app = SkimApp(path=".")
+
+    async with app.run_test():
+        pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
+        await pane.mount(viewer)
+        result_node = viewer._tree.root.children[2].children[3]
+        viewer.on_tree_node_selected(Tree.NodeSelected(result_node))
+
+        detail = _detail_text(viewer)
+        assert "stdout" in detail
+        assert len(viewer._detail_wrap.query(Markdown)) >= 1
+        assert not any('"text":' in block.code for block in _detail_syntax_blocks(viewer))
+
+
+async def test_wrapper_promotion_keeps_scalar_sibling_metadata():
+    """Wrapper promotion keeps useful scalar siblings instead of dropping them."""
+    output = {
+        "output": {
+            "text": '{"stdout": "done"}',
+            "mime_type": "text/plain",
+            "returncode": 0,
+        }
+    }
+    viewer = TrajectoryViewer(sample_trajectory(output=output))
+    app = SkimApp(path=".")
+
+    async with app.run_test():
+        pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
+        await pane.mount(viewer)
+        result_node = viewer._tree.root.children[2].children[3]
+        viewer.on_tree_node_selected(Tree.NodeSelected(result_node))
+
+        detail = _detail_text(viewer)
+        assert "mime_type" in detail
+        assert "text/plain" in detail
+        assert "stdout" in detail
+
+
 async def test_machine_shaped_tool_payload_still_renders_as_json():
     """Machine-shaped dicts keep the compact JSON rendering fallback."""
     viewer = TrajectoryViewer(sample_trajectory(arguments={"timeout": 10, "flags": [1, 2]}))

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -407,6 +407,25 @@ async def test_nested_output_text_stdout_promotes_inner_content():
         assert "stdout" in _all_collapsible_titles(viewer)
 
 
+async def test_output_text_wrapper_does_not_duplicate_stdout_stderr_sections():
+    """Decoded output.text payloads should not also render duplicate text-wrapped sections."""
+    output = {"text": {"stdout": "done", "stderr": "warn", "returncode": 0}}
+    viewer = TrajectoryViewer(sample_trajectory(output=output))
+    app = SkimApp(path=".")
+
+    async with app.run_test() as pilot:
+        pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
+        await pane.mount(viewer)
+        result_node = viewer._tree.root.children[2].children[2].children[1]
+        viewer.on_tree_node_selected(Tree.NodeSelected(result_node))
+        await pilot.pause()
+
+        titles = _all_collapsible_titles(viewer)
+        assert titles.count("stdout") == 1
+        assert titles.count("stderr") == 1
+        assert "text" not in titles
+
+
 async def test_wrapper_promotion_keeps_scalar_sibling_metadata():
     """Wrapper promotion keeps useful scalar siblings instead of dropping them."""
     output = {

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -175,22 +175,21 @@ def test_normalize_events_extracts_supported_event_kinds():
 
 
 def test_trajectory_tree_groups_step_events():
-    """Trajectory tree groups low-level events below their step."""
+    """Trajectory tree groups tool calls into paired input/output rows."""
     viewer = TrajectoryViewer(sample_trajectory())
     step = viewer._tree.root.children[2]
 
     assert _tree_labels(viewer._tree) == ["Metadata", "Final Output", "Step 1"]
     event_labels = [child.label.plain for child in step.children]
-    assert event_labels[0].startswith("001 reasoning Need inspect files.")
-    assert event_labels[1].startswith("002 message assistant I will inspect files.")
-    assert event_labels[2].startswith("003 function_call syntara__executeBash")
-    assert "ls -la" in event_labels[2]
-    assert event_labels[3].startswith("004 function_call_result syntara__executeBash")
-    assert "stdout" in event_labels[3]
+    assert event_labels[0].startswith("001 Reasoning")
+    assert event_labels[1].startswith("002 Assistant")
+    assert event_labels[2].startswith("003 executeBash #")
+    tool_node = step.children[2]
+    assert [child.label.plain for child in tool_node.children] == ["Input", "Output"]
 
 
 async def test_selecting_trajectory_tree_node_updates_detail():
-    """Selecting a trajectory tree node updates the detail state."""
+    """Selecting a tool parent shows paired input and output detail."""
     viewer = TrajectoryViewer(sample_trajectory())
     app = SkimApp(path=".")
 
@@ -200,7 +199,9 @@ async def test_selecting_trajectory_tree_node_updates_detail():
         tool_node = viewer._tree.root.children[2].children[2]
         viewer.on_tree_node_selected(Tree.NodeSelected(tool_node))
 
-        assert "function_call" in _detail_text(viewer)
+        assert "Tool:" in _detail_text(viewer)
+        assert "Input" in _detail_text(viewer)
+        assert "Output" in _detail_text(viewer)
         assert "ls -la" in _detail_text(viewer)
 
 
@@ -235,6 +236,44 @@ async def test_message_detail_renders_markdown():
         assert len(viewer._detail_wrap.query(Markdown)) >= 1
 
 
+async def test_selecting_tool_input_keeps_tool_metadata_visible():
+    """Selecting Input keeps paired tool context visible."""
+    viewer = TrajectoryViewer(sample_trajectory())
+    app = SkimApp(path=".")
+
+    async with app.run_test():
+        pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
+        await pane.mount(viewer)
+        input_node = viewer._tree.root.children[2].children[2].children[0]
+        viewer.on_tree_node_selected(Tree.NodeSelected(input_node))
+
+        detail = _detail_text(viewer)
+        assert "Tool:" in detail
+        assert "Call ID:" in detail
+        assert "Input" in detail
+        assert "Output" in detail
+        assert "ls -la" in detail
+
+
+async def test_selecting_tool_output_keeps_tool_metadata_visible():
+    """Selecting Output keeps paired tool context visible."""
+    viewer = TrajectoryViewer(sample_trajectory())
+    app = SkimApp(path=".")
+
+    async with app.run_test():
+        pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
+        await pane.mount(viewer)
+        output_node = viewer._tree.root.children[2].children[2].children[1]
+        viewer.on_tree_node_selected(Tree.NodeSelected(output_node))
+
+        detail = _detail_text(viewer)
+        assert "Tool:" in detail
+        assert "Call ID:" in detail
+        assert "Input" in detail
+        assert "Output" in detail
+        assert "plain terminal output" in detail
+
+
 async def test_tool_result_detail_decodes_stdout_stderr_and_returncode():
     """Tool results expose decoded stdout, stderr, and return code sections."""
     viewer = TrajectoryViewer(sample_trajectory())
@@ -243,7 +282,7 @@ async def test_tool_result_detail_decodes_stdout_stderr_and_returncode():
     async with app.run_test():
         pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
         await pane.mount(viewer)
-        result_node = viewer._tree.root.children[2].children[3]
+        result_node = viewer._tree.root.children[2].children[2].children[1]
         viewer.on_tree_node_selected(Tree.NodeSelected(result_node))
 
         detail = _detail_text(viewer)
@@ -261,7 +300,7 @@ async def test_tool_result_detail_renders_json_stdout_as_syntax():
     async with app.run_test():
         pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
         await pane.mount(viewer)
-        result_node = viewer._tree.root.children[2].children[3]
+        result_node = viewer._tree.root.children[2].children[2].children[1]
         viewer.on_tree_node_selected(Tree.NodeSelected(result_node))
 
         syntax_blocks = [
@@ -281,7 +320,7 @@ async def test_tool_result_detail_renders_markdown_stdout():
     async with app.run_test():
         pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
         await pane.mount(viewer)
-        result_node = viewer._tree.root.children[2].children[3]
+        result_node = viewer._tree.root.children[2].children[2].children[1]
         viewer.on_tree_node_selected(Tree.NodeSelected(result_node))
 
         assert len(viewer._detail_wrap.query(Markdown)) >= 1
@@ -314,7 +353,7 @@ async def test_tool_result_pages_render_as_readable_sections():
     async with app.run_test():
         pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
         await pane.mount(viewer)
-        result_node = viewer._tree.root.children[2].children[3]
+        result_node = viewer._tree.root.children[2].children[2].children[1]
         viewer.on_tree_node_selected(Tree.NodeSelected(result_node))
 
         detail = _detail_text(viewer)
@@ -332,7 +371,7 @@ async def test_nested_output_text_stdout_promotes_inner_content():
     async with app.run_test():
         pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
         await pane.mount(viewer)
-        result_node = viewer._tree.root.children[2].children[3]
+        result_node = viewer._tree.root.children[2].children[2].children[1]
         viewer.on_tree_node_selected(Tree.NodeSelected(result_node))
 
         detail = _detail_text(viewer)
@@ -356,7 +395,7 @@ async def test_wrapper_promotion_keeps_scalar_sibling_metadata():
     async with app.run_test():
         pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
         await pane.mount(viewer)
-        result_node = viewer._tree.root.children[2].children[3]
+        result_node = viewer._tree.root.children[2].children[2].children[1]
         viewer.on_tree_node_selected(Tree.NodeSelected(result_node))
 
         detail = _detail_text(viewer)
@@ -377,6 +416,16 @@ async def test_machine_shaped_tool_payload_still_renders_as_json():
         viewer.on_tree_node_selected(Tree.NodeSelected(tool_node))
 
         assert any('"timeout": 10' in block.code for block in _detail_syntax_blocks(viewer))
+
+
+async def test_unmatched_function_call_result_still_renders_safely():
+    """A result without a matching call still shows as a tool row with output."""
+    viewer = TrajectoryViewer(sample_trajectory(include_call=False))
+    step = viewer._tree.root.children[2]
+
+    assert step.children[2].label.plain.startswith("003 executeBash #")
+    assert step.children[2].label.plain.endswith(" Output")
+    assert [child.label.plain for child in step.children[2].children] == ["Input", "Output"]
 
 
 def test_submission_json_uses_submission_summary(tmp_path):
@@ -424,12 +473,55 @@ def sample_trajectory(
     stdout: str = "plain terminal output",
     arguments: dict | None = None,
     output: dict | None = None,
+    include_call: bool = True,
+    include_result: bool = True,
 ):
     """Return a small raw trajectory fixture."""
     arguments = {"command": "ls -la"} if arguments is None else arguments
     output = (
         {"stdout": stdout, "stderr": "warning text", "returncode": 0} if output is None else output
     )
+    step_output = [
+        {
+            "type": "reasoning",
+            "content": [
+                {
+                    "type": "input_text",
+                    "text": "Need inspect files.\n\n- Check data",
+                }
+            ],
+        },
+        {
+            "type": "message",
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "output_text",
+                    "text": "I will inspect files.\n\n```bash\nls -la\n```",
+                }
+            ],
+        },
+    ]
+    if include_call:
+        step_output.append(
+            {
+                "type": "function_call",
+                "name": "syntara__executeBash",
+                "callId": "tool-1",
+                "status": "completed",
+                "arguments": json.dumps(arguments),
+            }
+        )
+    if include_result:
+        step_output.append(
+            {
+                "type": "function_call_result",
+                "name": "syntara__executeBash",
+                "callId": "tool-1",
+                "status": "completed",
+                "output": {"text": json.dumps(output)},
+            }
+        )
     return {
         "metadata": {
             "trajectory_id": "traj-1",
@@ -441,43 +533,7 @@ def sample_trajectory(
         },
         "context_compaction_events": [{"message_index": 3}],
         "final_output": "## Final\n\nDone.",
-        "steps": [
-            {
-                "output": [
-                    {
-                        "type": "reasoning",
-                        "content": [
-                            {
-                                "type": "input_text",
-                                "text": "Need inspect files.\n\n- Check data",
-                            }
-                        ],
-                    },
-                    {
-                        "type": "message",
-                        "role": "assistant",
-                        "content": [
-                            {
-                                "type": "output_text",
-                                "text": "I will inspect files.\n\n```bash\nls -la\n```",
-                            }
-                        ],
-                    },
-                    {
-                        "type": "function_call",
-                        "name": "syntara__executeBash",
-                        "callId": "tool-1",
-                        "arguments": json.dumps(arguments),
-                    },
-                    {
-                        "type": "function_call_result",
-                        "name": "syntara__executeBash",
-                        "callId": "tool-1",
-                        "output": {"text": json.dumps(output)},
-                    },
-                ]
-            }
-        ],
+        "steps": [{"output": step_output}],
     }
 
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -517,6 +517,24 @@ async def test_split_panes_keep_specialized_preview(tmp_path):
         assert isinstance(pane.query_one(TrajectoryViewer), TrajectoryViewer)
 
 
+async def test_scroll_keys_scroll_generic_preview_pane(tmp_path):
+    """App scroll actions should still scroll a normal preview pane."""
+    test_file = tmp_path / "long.txt"
+    test_file.write_text("\n".join(f"line {index}" for index in range(400)))
+    app = SkimApp(path=str(tmp_path))
+
+    async with app.run_test() as pilot:
+        pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
+        pane.show_file(test_file)
+        await pilot.pause()
+
+        before = pane.scroll_y
+        await pilot.press("down")
+        await pilot.pause()
+
+        assert pane.scroll_y > before
+
+
 async def test_scroll_keys_scroll_trajectory_detail_panel():
     """App scroll actions should scroll the trajectory detail panel, not only the outer pane."""
     stdout = "\n".join(f"line {index}" for index in range(200))

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -4,7 +4,7 @@ import json
 
 from rich.syntax import Syntax
 from rich.text import Text
-from textual.widgets import Markdown, Static, Tree
+from textual.widgets import Collapsible, Markdown, Static, Tree
 
 from skim import (
     PreviewPane,
@@ -193,15 +193,14 @@ async def test_selecting_trajectory_tree_node_updates_detail():
     viewer = TrajectoryViewer(sample_trajectory())
     app = SkimApp(path=".")
 
-    async with app.run_test():
+    async with app.run_test() as pilot:
         pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
         await pane.mount(viewer)
         tool_node = viewer._tree.root.children[2].children[2]
         viewer.on_tree_node_selected(Tree.NodeSelected(tool_node))
+        await pilot.pause()
 
-        assert "Tool:" in _detail_text(viewer)
-        assert "Input" in _detail_text(viewer)
-        assert "Output" in _detail_text(viewer)
+        assert _top_level_collapsible_titles(viewer) == ["Tool", "Input", "Output"]
         assert "ls -la" in _detail_text(viewer)
 
 
@@ -210,7 +209,7 @@ async def test_final_output_only_shows_when_selected():
     viewer = TrajectoryViewer(sample_trajectory())
     app = SkimApp(path=".")
 
-    async with app.run_test():
+    async with app.run_test() as pilot:
         pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
         await pane.mount(viewer)
 
@@ -218,6 +217,7 @@ async def test_final_output_only_shows_when_selected():
 
         final_node = viewer._tree.root.children[1]
         viewer.on_tree_node_selected(Tree.NodeSelected(final_node))
+        await pilot.pause()
 
         assert len(viewer._detail_wrap.query(Markdown)) >= 1
 
@@ -227,11 +227,12 @@ async def test_message_detail_renders_markdown():
     viewer = TrajectoryViewer(sample_trajectory())
     app = SkimApp(path=".")
 
-    async with app.run_test():
+    async with app.run_test() as pilot:
         pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
         await pane.mount(viewer)
         message_node = viewer._tree.root.children[2].children[1]
         viewer.on_tree_node_selected(Tree.NodeSelected(message_node))
+        await pilot.pause()
 
         assert len(viewer._detail_wrap.query(Markdown)) >= 1
 
@@ -241,17 +242,17 @@ async def test_selecting_tool_input_keeps_tool_metadata_visible():
     viewer = TrajectoryViewer(sample_trajectory())
     app = SkimApp(path=".")
 
-    async with app.run_test():
+    async with app.run_test() as pilot:
         pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
         await pane.mount(viewer)
         input_node = viewer._tree.root.children[2].children[2].children[0]
         viewer.on_tree_node_selected(Tree.NodeSelected(input_node))
+        await pilot.pause()
 
         detail = _detail_text(viewer)
         assert "Tool:" in detail
         assert "Call ID:" in detail
-        assert "Input" in detail
-        assert "Output" in detail
+        assert _top_level_collapsible_titles(viewer) == ["Tool", "Input", "Output"]
         assert "ls -la" in detail
 
 
@@ -260,18 +261,33 @@ async def test_selecting_tool_output_keeps_tool_metadata_visible():
     viewer = TrajectoryViewer(sample_trajectory())
     app = SkimApp(path=".")
 
-    async with app.run_test():
+    async with app.run_test() as pilot:
         pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
         await pane.mount(viewer)
         output_node = viewer._tree.root.children[2].children[2].children[1]
         viewer.on_tree_node_selected(Tree.NodeSelected(output_node))
+        await pilot.pause()
 
         detail = _detail_text(viewer)
         assert "Tool:" in detail
         assert "Call ID:" in detail
-        assert "Input" in detail
-        assert "Output" in detail
+        assert _top_level_collapsible_titles(viewer) == ["Tool", "Input", "Output"]
         assert "plain terminal output" in detail
+
+
+async def test_selecting_output_does_not_reorder_sections():
+    """Selecting Output keeps Input above Output in the detail pane."""
+    viewer = TrajectoryViewer(sample_trajectory())
+    app = SkimApp(path=".")
+
+    async with app.run_test() as pilot:
+        pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
+        await pane.mount(viewer)
+        output_node = viewer._tree.root.children[2].children[2].children[1]
+        viewer.on_tree_node_selected(Tree.NodeSelected(output_node))
+        await pilot.pause()
+
+        assert _top_level_collapsible_titles(viewer) == ["Tool", "Input", "Output"]
 
 
 async def test_tool_result_detail_decodes_stdout_stderr_and_returncode():
@@ -279,17 +295,20 @@ async def test_tool_result_detail_decodes_stdout_stderr_and_returncode():
     viewer = TrajectoryViewer(sample_trajectory())
     app = SkimApp(path=".")
 
-    async with app.run_test():
+    async with app.run_test() as pilot:
         pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
         await pane.mount(viewer)
         result_node = viewer._tree.root.children[2].children[2].children[1]
         viewer.on_tree_node_selected(Tree.NodeSelected(result_node))
+        await pilot.pause()
 
         detail = _detail_text(viewer)
         assert "returncode" in detail
         assert "stdout" in detail
         assert "stderr" in detail
         assert "plain terminal output" in detail
+        assert "stdout" in _all_collapsible_titles(viewer)
+        assert "stderr" in _all_collapsible_titles(viewer)
 
 
 async def test_tool_result_detail_renders_json_stdout_as_syntax():
@@ -297,11 +316,12 @@ async def test_tool_result_detail_renders_json_stdout_as_syntax():
     viewer = TrajectoryViewer(sample_trajectory(stdout='{"alpha": [1, 2]}'))
     app = SkimApp(path=".")
 
-    async with app.run_test():
+    async with app.run_test() as pilot:
         pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
         await pane.mount(viewer)
         result_node = viewer._tree.root.children[2].children[2].children[1]
         viewer.on_tree_node_selected(Tree.NodeSelected(result_node))
+        await pilot.pause()
 
         syntax_blocks = [
             _static_content(widget)
@@ -317,11 +337,12 @@ async def test_tool_result_detail_renders_markdown_stdout():
     viewer = TrajectoryViewer(sample_trajectory(stdout=stdout))
     app = SkimApp(path=".")
 
-    async with app.run_test():
+    async with app.run_test() as pilot:
         pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
         await pane.mount(viewer)
         result_node = viewer._tree.root.children[2].children[2].children[1]
         viewer.on_tree_node_selected(Tree.NodeSelected(result_node))
+        await pilot.pause()
 
         assert len(viewer._detail_wrap.query(Markdown)) >= 1
 
@@ -333,15 +354,17 @@ async def test_tool_call_arguments_render_code_string_outside_json_blob():
     )
     app = SkimApp(path=".")
 
-    async with app.run_test():
+    async with app.run_test() as pilot:
         pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
         await pane.mount(viewer)
         tool_node = viewer._tree.root.children[2].children[2]
         viewer.on_tree_node_selected(Tree.NodeSelected(tool_node))
+        await pilot.pause()
 
         syntax_blocks = _detail_syntax_blocks(viewer)
         assert any("import pandas as pd" in block.code for block in syntax_blocks)
         assert not any('"code":' in block.code for block in syntax_blocks)
+        assert "code" in _all_collapsible_titles(viewer)
 
 
 async def test_tool_result_pages_render_as_readable_sections():
@@ -350,16 +373,18 @@ async def test_tool_result_pages_render_as_readable_sections():
     viewer = TrajectoryViewer(sample_trajectory(output=output))
     app = SkimApp(path=".")
 
-    async with app.run_test():
+    async with app.run_test() as pilot:
         pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
         await pane.mount(viewer)
         result_node = viewer._tree.root.children[2].children[2].children[1]
         viewer.on_tree_node_selected(Tree.NodeSelected(result_node))
+        await pilot.pause()
 
-        detail = _detail_text(viewer)
-        assert "Page 1" in detail
+        assert "pages" in _all_collapsible_titles(viewer)
+        assert "Page 1" in _all_collapsible_titles(viewer)
         assert len(viewer._detail_wrap.query(Markdown)) >= 1
         assert not any('"pages":' in block.code for block in _detail_syntax_blocks(viewer))
+        assert _collapsible_by_title(viewer, "pages").collapsed
 
 
 async def test_nested_output_text_stdout_promotes_inner_content():
@@ -368,16 +393,18 @@ async def test_nested_output_text_stdout_promotes_inner_content():
     viewer = TrajectoryViewer(sample_trajectory(output=output))
     app = SkimApp(path=".")
 
-    async with app.run_test():
+    async with app.run_test() as pilot:
         pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
         await pane.mount(viewer)
         result_node = viewer._tree.root.children[2].children[2].children[1]
         viewer.on_tree_node_selected(Tree.NodeSelected(result_node))
+        await pilot.pause()
 
         detail = _detail_text(viewer)
         assert "stdout" in detail
         assert len(viewer._detail_wrap.query(Markdown)) >= 1
         assert not any('"text":' in block.code for block in _detail_syntax_blocks(viewer))
+        assert "stdout" in _all_collapsible_titles(viewer)
 
 
 async def test_wrapper_promotion_keeps_scalar_sibling_metadata():
@@ -392,11 +419,12 @@ async def test_wrapper_promotion_keeps_scalar_sibling_metadata():
     viewer = TrajectoryViewer(sample_trajectory(output=output))
     app = SkimApp(path=".")
 
-    async with app.run_test():
+    async with app.run_test() as pilot:
         pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
         await pane.mount(viewer)
         result_node = viewer._tree.root.children[2].children[2].children[1]
         viewer.on_tree_node_selected(Tree.NodeSelected(result_node))
+        await pilot.pause()
 
         detail = _detail_text(viewer)
         assert "mime_type" in detail
@@ -409,11 +437,12 @@ async def test_machine_shaped_tool_payload_still_renders_as_json():
     viewer = TrajectoryViewer(sample_trajectory(arguments={"timeout": 10, "flags": [1, 2]}))
     app = SkimApp(path=".")
 
-    async with app.run_test():
+    async with app.run_test() as pilot:
         pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
         await pane.mount(viewer)
         tool_node = viewer._tree.root.children[2].children[2]
         viewer.on_tree_node_selected(Tree.NodeSelected(tool_node))
+        await pilot.pause()
 
         assert any('"timeout": 10' in block.code for block in _detail_syntax_blocks(viewer))
 
@@ -564,3 +593,18 @@ def _detail_syntax_blocks(viewer: TrajectoryViewer) -> list[Syntax]:
         for widget in viewer._detail_wrap.query(Static)
         if isinstance(_static_content(widget), Syntax)
     ]
+
+
+def _top_level_collapsible_titles(viewer: TrajectoryViewer) -> list[str]:
+    return [child.title for child in viewer._detail_wrap.children if isinstance(child, Collapsible)]
+
+
+def _all_collapsible_titles(viewer: TrajectoryViewer) -> list[str]:
+    return [widget.title for widget in viewer._detail_wrap.query(Collapsible)]
+
+
+def _collapsible_by_title(viewer: TrajectoryViewer, title: str) -> Collapsible:
+    for widget in viewer._detail_wrap.query(Collapsible):
+        if widget.title == title:
+            return widget
+    raise AssertionError(f"Collapsible with title {title!r} not found")

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -611,6 +611,98 @@ async def test_escape_returns_from_trajectory_detail_to_tree_mode():
         assert viewer._detail_wrap.scroll_y == scrolled
 
 
+async def test_trajectory_viewer_mounts_local_footer():
+    """Trajectory viewer should render its own local command footer."""
+    viewer = TrajectoryViewer(sample_trajectory())
+    app = SkimApp(path=".")
+
+    async with app.run_test() as pilot:
+        pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
+        await pane.mount(viewer)
+        await pilot.pause()
+
+        footer = viewer.query_one(".trajectory-footer", Static)
+        content = _static_content(footer)
+
+        assert isinstance(content, Text)
+        assert "Move" in content.plain
+        assert "Branch" in content.plain
+        assert "Detail" in content.plain
+
+
+async def test_trajectory_footer_switches_between_tree_and_detail_modes():
+    """Trajectory footer should track tree/detail keyboard mode."""
+    viewer = TrajectoryViewer(sample_trajectory())
+    app = SkimApp(path=".")
+
+    async with app.run_test() as pilot:
+        pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
+        await pane.mount(viewer)
+        await pilot.pause()
+        viewer.focus_tree_mode()
+
+        footer = viewer.query_one(".trajectory-footer", Static)
+        tree_content = _static_content(footer)
+        assert isinstance(tree_content, Text)
+        assert "Move" in tree_content.plain
+        assert "Branch" in tree_content.plain
+
+        await pilot.press("enter")
+        await pilot.pause()
+
+        detail_content = _static_content(footer)
+        assert isinstance(detail_content, Text)
+        assert "Scroll" in detail_content.plain
+        assert "Back to JSON" in detail_content.plain
+
+        await pilot.press("escape")
+        await pilot.pause()
+
+        reset_content = _static_content(footer)
+        assert isinstance(reset_content, Text)
+        assert "Move" in reset_content.plain
+        assert "Branch" in reset_content.plain
+
+
+async def test_global_footer_only_shows_app_wide_commands():
+    """Global footer should not include trajectory-specific commands."""
+    app = SkimApp(path=".")
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        footer = app.query_one("#status-bar", Static)
+        content = _static_content(footer)
+
+        assert isinstance(content, str)
+        assert "Scroll" in content
+        assert "Open" in content
+        assert "JSON" not in content
+        assert "Branch" not in content
+        assert "Detail" not in content
+        assert "Esc" not in content
+
+
+async def test_non_trajectory_previews_do_not_mount_local_footer(tmp_path):
+    """Only trajectory previews should render a local footer."""
+    generic = tmp_path / "data.json"
+    generic.write_text('{"alpha": 1}')
+    submission = tmp_path / "submission.json"
+    submission.write_text('{"task_name": "Task", "submission_type": "worker", "prompt": "Prompt"}')
+    app = SkimApp(path=str(tmp_path))
+
+    async with app.run_test() as pilot:
+        pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
+
+        pane.show_file(generic)
+        await pilot.pause()
+        assert not pane.query(".trajectory-footer")
+
+        pane.show_file(submission)
+        await pilot.pause()
+        assert not pane.query(".trajectory-footer")
+
+
 def sample_trajectory(
     stdout: str = "plain terminal output",
     arguments: dict | None = None,

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -545,7 +545,9 @@ async def test_scroll_keys_scroll_trajectory_detail_panel():
         pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
         await pane.mount(viewer)
         output_node = viewer._tree.root.children[2].children[2].children[1]
-        viewer.on_tree_node_selected(Tree.NodeSelected(output_node))
+        await pilot.pause()
+        viewer._tree.move_cursor(output_node, animate=False)
+        await pilot.press("enter")
         await pilot.pause()
 
         before = viewer._detail_wrap.scroll_y
@@ -553,6 +555,60 @@ async def test_scroll_keys_scroll_trajectory_detail_panel():
         await pilot.pause()
 
         assert viewer._detail_wrap.scroll_y > before
+
+
+async def test_trajectory_viewer_arrows_drive_tree_until_enter():
+    """Trajectory previews should use arrows for tree navigation before entering detail mode."""
+    viewer = TrajectoryViewer(sample_trajectory())
+    app = SkimApp(path=".")
+
+    async with app.run_test() as pilot:
+        pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
+        await pane.mount(viewer)
+        await pilot.pause()
+        viewer.focus_tree_mode()
+
+        assert viewer.is_tree_mode()
+        assert viewer._tree.cursor_node is viewer._tree.root.children[0]
+
+        await pilot.press("down")
+        await pilot.pause()
+
+        assert viewer._tree.cursor_node is viewer._tree.root.children[1]
+        assert viewer._detail_wrap.scroll_y == 0
+
+
+async def test_escape_returns_from_trajectory_detail_to_tree_mode():
+    """Escape should return keyboard control from detail scrolling back to the tree."""
+    stdout = "\n".join(f"line {index}" for index in range(200))
+    viewer = TrajectoryViewer(sample_trajectory(stdout=stdout))
+    app = SkimApp(path=".")
+
+    async with app.run_test() as pilot:
+        pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
+        await pane.mount(viewer)
+        output_node = viewer._tree.root.children[2].children[2].children[1]
+        await pilot.pause()
+
+        viewer._tree.move_cursor(output_node, animate=False)
+        await pilot.press("enter")
+        await pilot.pause()
+        assert not viewer.is_tree_mode()
+
+        await pilot.press("down")
+        await pilot.pause()
+        scrolled = viewer._detail_wrap.scroll_y
+        assert scrolled > 0
+
+        await pilot.press("escape")
+        await pilot.pause()
+        assert viewer.is_tree_mode()
+
+        await pilot.press("up")
+        await pilot.pause()
+
+        assert viewer._tree.cursor_node is viewer._tree.root.children[2].children[2].children[0]
+        assert viewer._detail_wrap.scroll_y == scrolled
 
 
 def sample_trajectory(

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -517,6 +517,26 @@ async def test_split_panes_keep_specialized_preview(tmp_path):
         assert isinstance(pane.query_one(TrajectoryViewer), TrajectoryViewer)
 
 
+async def test_scroll_keys_scroll_trajectory_detail_panel():
+    """App scroll actions should scroll the trajectory detail panel, not only the outer pane."""
+    stdout = "\n".join(f"line {index}" for index in range(200))
+    viewer = TrajectoryViewer(sample_trajectory(stdout=stdout))
+    app = SkimApp(path=".")
+
+    async with app.run_test() as pilot:
+        pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
+        await pane.mount(viewer)
+        output_node = viewer._tree.root.children[2].children[2].children[1]
+        viewer.on_tree_node_selected(Tree.NodeSelected(output_node))
+        await pilot.pause()
+
+        before = viewer._detail_wrap.scroll_y
+        await pilot.press("down")
+        await pilot.pause()
+
+        assert viewer._detail_wrap.scroll_y > before
+
+
 def sample_trajectory(
     stdout: str = "plain terminal output",
     arguments: dict | None = None,


### PR DESCRIPTION
## Summary
- improve the trajectory viewer tree/detail interaction for local JSON trajectories
- refine tool call/result rendering and viewer structure for easier review
- move trajectory-specific key hints into a local viewer footer and keep the app footer global

## What Changed
- pair tool calls and results into a single tree interaction with `Input` and `Output` children
- add collapsible semantic detail sections and better wrapper promotion for nested payloads
- render nested string content more readably for markdown, code, stdout/stderr, pages, and structured payloads
- add explicit tree/detail keyboard mode for the trajectory viewer
- route preview scrolling correctly for both trajectory and non-trajectory panes
- add a trajectory-local footer that shows the relevant viewer commands by mode

## Why
The initial trajectory JSON preview worked, but it made review harder than it needed to be:
- tool calls and results were split apart
- nested payload strings often stayed trapped inside JSON blobs
- the viewer-specific controls were mixed into the global footer
- pane scrolling and tree navigation behavior regressed as the viewer became more specialized

This PR makes the trajectory review flow more legible and keeps the outer browser shell unchanged.

## Validation
- `uv run pytest`
- `uv run ruff check .`
- `uv run ruff format --check .`
