### PR TITLE
[codex] Add cross-terminal drag and file tree fallbacks

### DIFF
--- a/src/skim/__init__.py
+++ b/src/skim/__init__.py
@@ -1278,6 +1278,19 @@ class SkimApp(App):
         max-width: 40;
         border-right: solid $primary-background;
     }
+    DirectoryTree,
+    PreviewPane,
+    .trajectory-tree,
+    .trajectory-detail-wrap {
+        scrollbar-gutter: stable;
+        scrollbar-size-vertical: 3;
+        scrollbar-background: $surface-lighten-1;
+        scrollbar-background-hover: $surface-lighten-1;
+        scrollbar-background-active: $surface-lighten-1;
+        scrollbar-color: $accent;
+        scrollbar-color-hover: $accent;
+        scrollbar-color-active: $accent;
+    }
     #preview-area {
         width: 3fr;
     }

--- a/src/skim/__init__.py
+++ b/src/skim/__init__.py
@@ -8,13 +8,25 @@ from typing import Any
 
 from rich.syntax import Syntax
 from rich.text import Text
+from textual import events
 from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.css.query import NoMatches
 from textual.events import Key
 from textual.widget import Widget
-from textual.widgets import Collapsible, DirectoryTree, Header, Markdown, Static, Tree
+from textual.widgets import (
+    Collapsible,
+    Header,
+    Markdown,
+    Static,
+)
+from textual.widgets import (
+    DirectoryTree as TextualDirectoryTree,
+)
+from textual.widgets import (
+    Tree as TextualTree,
+)
 
 SYNTAX_MAP = {
     ".py": "python",
@@ -40,6 +52,7 @@ MAX_FILE_SIZE = 1_000_000
 MAX_ROWS = 2
 MAX_COLS = 3
 SCROLL_STEP = 3
+DRAG_SCROLL_THRESHOLD = 2
 HUMAN_TEXT_KEYS = {
     "arguments",
     "code",
@@ -128,6 +141,94 @@ class TrajectoryTreeItem:
     event: TrajectoryEvent | None = None
     interaction: ToolInteraction | None = None
     focus: str = "full"
+
+
+class DragScrollMixin:
+    """Add thresholded click-and-drag vertical scrolling to a scrollable widget."""
+
+    _drag_scroll_start_y: float | None
+    _drag_scroll_origin_y: int | None
+    _drag_scrolling: bool
+
+    def _init_drag_scroll(self) -> None:
+        """Initialize internal drag-scroll state."""
+        self._drag_scroll_start_y = None
+        self._drag_scroll_origin_y = None
+        self._drag_scrolling = False
+
+    def _drag_scroll_requires_self_target(self) -> bool:
+        """Return whether drag-scrolling should only start from the container itself."""
+        return False
+
+    def _can_start_drag_scroll(self, event: events.MouseDown) -> bool:
+        """Return whether a drag-scroll gesture should start for this event."""
+        if event.button != 1 or self.max_scroll_y <= 0:  # type: ignore[attr-defined]
+            return False
+        if self._drag_scroll_requires_self_target() and event.widget is not self:
+            return False
+        return True
+
+    async def on_mouse_down(self, event: events.MouseDown) -> None:
+        """Capture mouse input so a vertical drag can scroll the widget."""
+        if not self._can_start_drag_scroll(event):
+            return
+        self._drag_scroll_start_y = self.scroll_y  # type: ignore[attr-defined]
+        self._drag_scroll_origin_y = event.screen_y
+        self._drag_scrolling = False
+        self.capture_mouse()  # type: ignore[attr-defined]
+
+    async def on_mouse_move(self, event: events.MouseMove) -> None:
+        """Translate vertical mouse movement into vertical scrolling."""
+        if self.app.mouse_captured is not self or self._drag_scroll_origin_y is None:
+            return
+        delta = event.screen_y - self._drag_scroll_origin_y
+        if not self._drag_scrolling and abs(delta) < DRAG_SCROLL_THRESHOLD:
+            return
+        self._drag_scrolling = True
+        start_y = self._drag_scroll_start_y or 0
+        self.scroll_to(  # type: ignore[attr-defined]
+            y=start_y - delta,
+            animate=False,
+            force=True,
+            immediate=True,
+        )
+        event.stop()
+
+    async def on_mouse_up(self, event: events.MouseUp) -> None:
+        """Release captured drag-scroll state."""
+        if self.app.mouse_captured is self:
+            self.release_mouse()  # type: ignore[attr-defined]
+        if self._drag_scrolling:
+            event.stop()
+        self._drag_scroll_start_y = None
+        self._drag_scroll_origin_y = None
+        self._drag_scrolling = False
+
+    def on_hide(self) -> None:
+        """Release mouse capture if the widget hides mid-drag."""
+        if self.app.mouse_captured is self:
+            self.release_mouse()  # type: ignore[attr-defined]
+        self._drag_scroll_start_y = None
+        self._drag_scroll_origin_y = None
+        self._drag_scrolling = False
+
+
+class DirectoryTree(DragScrollMixin, TextualDirectoryTree):
+    """Directory tree with drag-to-scroll support."""
+
+    def __init__(self, path: str, **kwargs: Any) -> None:
+        """Initialize the directory tree."""
+        super().__init__(path, **kwargs)
+        self._init_drag_scroll()
+
+
+class DragTree(DragScrollMixin, TextualTree[TrajectoryTreeItem]):
+    """Trajectory tree with drag-to-scroll support."""
+
+    def __init__(self, label: str, **kwargs: Any) -> None:
+        """Initialize the drag-scroll tree."""
+        super().__init__(label, **kwargs)
+        self._init_drag_scroll()
 
 
 def render_file(path: Path) -> list[Widget]:
@@ -227,10 +328,10 @@ def normalize_step_events(trajectory: dict[str, Any]) -> list[list[TrajectoryEve
 def normalize_step_timeline(trajectory: dict[str, Any]) -> list[list[StepTimelineItem]]:
     """Return step items with paired tool interactions."""
     timeline_groups: list[list[StepTimelineItem]] = []
-    for events in normalize_step_events(trajectory):
+    for step_events in normalize_step_events(trajectory):
         group: list[StepTimelineItem] = []
         pending_calls: dict[str, int] = {}
-        for event in events:
+        for event in step_events:
             if event.kind == "function_call":
                 interaction = ToolInteraction(
                     index=event.index,
@@ -999,7 +1100,7 @@ class TrajectoryViewer(Vertical):
         self.events = normalize_events(trajectory)
         self._input_mode = "tree"
         self._summary = Static(Text(_metadata_header(trajectory)), classes="trajectory-summary")
-        self._tree: Tree[TrajectoryTreeItem] = Tree("Trajectory", classes="trajectory-tree")
+        self._tree: DragTree = DragTree("Trajectory", classes="trajectory-tree")
         self._build_tree()
         first_item = self._tree.root.children[0].data
         initial_widgets: list[Widget] = []
@@ -1016,7 +1117,7 @@ class TrajectoryViewer(Vertical):
             yield self._detail_wrap
         yield self._footer
 
-    def on_tree_node_selected(self, event: Tree.NodeSelected[TrajectoryTreeItem]) -> None:
+    def on_tree_node_selected(self, event: TextualTree.NodeSelected[TrajectoryTreeItem]) -> None:
         """Update detail when a trajectory tree node is selected."""
         item = event.node.data
         if isinstance(item, TrajectoryTreeItem):
@@ -1205,16 +1306,26 @@ class SubmissionSummary(Static):
         super().__init__(self.summary_text, classes="submission-summary")
 
 
-class FocusableDetailWrap(VerticalScroll, can_focus=True):
+class FocusableDetailWrap(DragScrollMixin, VerticalScroll, can_focus=True):
     """Focusable scroll container for trajectory detail rendering."""
 
+    def __init__(self, *children: Widget, **kwargs: Any) -> None:
+        """Initialize the detail wrapper."""
+        super().__init__(*children, **kwargs)
+        self._init_drag_scroll()
 
-class PreviewPane(VerticalScroll, can_focus=True):
+    def _drag_scroll_requires_self_target(self) -> bool:
+        """Only start drag-scroll from the detail container background."""
+        return True
+
+
+class PreviewPane(DragScrollMixin, VerticalScroll, can_focus=True):
     """Scrollable panel that shows file contents."""
 
     def __init__(self, **kwargs) -> None:
         """Initialize an empty preview pane."""
         super().__init__(**kwargs)
+        self._init_drag_scroll()
         self.current_path: Path | None = None
 
     def show_placeholder(self, message: str = "Select a file") -> None:
@@ -1277,19 +1388,6 @@ class SkimApp(App):
         width: 1fr;
         max-width: 40;
         border-right: solid $primary-background;
-    }
-    DirectoryTree,
-    PreviewPane,
-    .trajectory-tree,
-    .trajectory-detail-wrap {
-        scrollbar-gutter: stable;
-        scrollbar-size-vertical: 3;
-        scrollbar-background: $surface-lighten-1;
-        scrollbar-background-hover: $surface-lighten-1;
-        scrollbar-background-active: $surface-lighten-1;
-        scrollbar-color: $accent;
-        scrollbar-color-hover: $accent;
-        scrollbar-color-active: $accent;
     }
     #preview-area {
         width: 3fr;

--- a/src/skim/__init__.py
+++ b/src/skim/__init__.py
@@ -1459,20 +1459,11 @@ class SkimApp(App):
         Binding("down", "scroll_down", show=False, priority=True),
         Binding("j", "scroll_down", show=False, priority=True),
         Binding("k", "scroll_up", show=False, priority=True),
+        Binding("f", "focus_file_tree", show=False),
         Binding("s", "enter_split", show=False),
         Binding("d", "close_pane", show=False),
         Binding("w", "cycle_pane", show=False),
     ]
-
-    STATUS_TEXT = (
-        " [bold]q[/] Quit  "
-        "[bold]↑↓[/] Scroll  "
-        "[bold]⇧↑↓[/] Tree  "
-        "[bold]Enter[/] Open  "
-        "[bold]s[/]+arrow Split  "
-        "[bold]d[/] Close  "
-        "[bold]w[/] Next pane"
-    )
 
     def __init__(self, path: str | Path = "."):
         """Initialize the app for a directory path."""
@@ -1483,6 +1474,7 @@ class SkimApp(App):
         self.grid: list[list[str]] = []
         self.pane_files: dict[str, Path | None] = {}
         self.split_mode = False
+        self.file_tree_mode = False
 
     def _new_pane_id(self) -> str:
         pid = f"pane-{self.pane_counter}"
@@ -1505,16 +1497,16 @@ class SkimApp(App):
         with Horizontal(id="outer"):
             yield DirectoryTree(str(self.browse_path))
             yield Vertical(id="preview-area")
-        yield Static(self.STATUS_TEXT, id="status-bar")
+        yield Static("", id="status-bar")
 
     def on_mount(self) -> None:
-        """Create the first preview pane and focus the tree."""
+        """Create the first preview pane and start in preview focus mode."""
         pid = self._new_pane_id()
         self.grid = [[pid]]
         self.pane_files[pid] = None
         self.active_pane_id = pid
         self._rebuild_layout()
-        self.query_one(DirectoryTree).focus()
+        self.exit_file_tree_mode()
 
     def _rebuild_layout(self) -> None:
         """Rebuild the preview pane grid from current state."""
@@ -1546,6 +1538,49 @@ class SkimApp(App):
         except Exception:
             pass
 
+    def _status_text(self) -> str:
+        """Return status-bar text for the current app mode."""
+        if self.file_tree_mode:
+            return (
+                " [bold]q[/] Quit  "
+                "[bold]↑↓[/] Move tree  "
+                "[bold]Enter[/] Open  "
+                "[bold]Esc[/] Back  "
+                "[bold]⇧↑↓[/] Tree shortcut  "
+                "[bold]s[/]+arrow Split  "
+                "[bold]d[/] Close  "
+                "[bold]w[/] Next pane"
+            )
+        return (
+            " [bold]q[/] Quit  "
+            "[bold]↑↓[/] Scroll  "
+            "[bold]f[/] File tree  "
+            "[bold]⇧↑↓[/] Tree shortcut  "
+            "[bold]Enter[/] Open  "
+            "[bold]s[/]+arrow Split  "
+            "[bold]d[/] Close  "
+            "[bold]w[/] Next pane"
+        )
+
+    def _update_status_bar(self) -> None:
+        """Refresh the global status bar text."""
+        self.query_one("#status-bar", Static).update(self._status_text())
+
+    def action_focus_file_tree(self) -> None:
+        """Enter file-tree focus mode."""
+        self.file_tree_mode = True
+        self.query_one(DirectoryTree).focus(scroll_visible=False)
+        self._update_status_bar()
+
+    def exit_file_tree_mode(self) -> None:
+        """Leave file-tree focus mode and return to the active preview pane."""
+        self.file_tree_mode = False
+        try:
+            self.query_one(f"#{self.active_pane_id}", PreviewPane).focus(scroll_visible=False)
+        except Exception:
+            pass
+        self._update_status_bar()
+
     # --- scrolling the active pane ---
 
     def action_scroll_down(self) -> None:
@@ -1553,6 +1588,9 @@ class SkimApp(App):
         if self.split_mode:
             self.split_mode = False
             self._split("down")
+            return
+        if self.file_tree_mode:
+            self.action_tree_down()
             return
         try:
             pane = self.query_one(f"#{self.active_pane_id}", PreviewPane)
@@ -1565,6 +1603,9 @@ class SkimApp(App):
         if self.split_mode:
             self.split_mode = False
             self._split("up")
+            return
+        if self.file_tree_mode:
+            self.action_tree_up()
             return
         try:
             pane = self.query_one(f"#{self.active_pane_id}", PreviewPane)
@@ -1608,6 +1649,28 @@ class SkimApp(App):
             event.prevent_default()
             event.stop()
             return
+
+        if self.file_tree_mode:
+            if event.key in {"up", "k"}:
+                self.action_tree_up()
+                event.prevent_default()
+                event.stop()
+                return
+            if event.key in {"down", "j"}:
+                self.action_tree_down()
+                event.prevent_default()
+                event.stop()
+                return
+            if event.key == "enter":
+                self.action_tree_select()
+                event.prevent_default()
+                event.stop()
+                return
+            if event.key == "escape":
+                self.exit_file_tree_mode()
+                event.prevent_default()
+                event.stop()
+                return
 
         viewer: TrajectoryViewer | None = None
         try:
@@ -1656,6 +1719,8 @@ class SkimApp(App):
         pane = self.query_one(f"#{self.active_pane_id}", PreviewPane)
         pane.show_file(path)
         self.pane_files[self.active_pane_id] = path
+        if self.file_tree_mode:
+            self.exit_file_tree_mode()
 
     # --- split ---
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -111,6 +111,130 @@ async def test_file_preview(tmp_path):
         assert pane.current_path == test_file
 
 
+async def test_f_enters_file_tree_mode(tmp_path):
+    """Pressing f should focus the file tree and enter tree mode."""
+    (tmp_path / "one.txt").write_text("x")
+    app = SkimApp(path=str(tmp_path))
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
+        tree = app.query_one("DirectoryTree")
+
+        assert app.focused is pane
+        assert not app.file_tree_mode
+
+        await pilot.press("f")
+        await pilot.pause()
+
+        assert app.file_tree_mode
+        assert app.focused is tree
+
+
+async def test_file_tree_mode_up_down_moves_tree_cursor(tmp_path):
+    """While file-tree mode is active, up/down should move the tree cursor."""
+    for index in range(4):
+        (tmp_path / f"file_{index}.txt").write_text("x")
+    app = SkimApp(path=str(tmp_path))
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        tree = app.query_one("DirectoryTree")
+
+        await pilot.press("f")
+        await pilot.pause()
+        before = tree.cursor_line
+        await pilot.press("down")
+        await pilot.pause()
+
+        assert tree.cursor_line > before
+
+
+async def test_file_tree_mode_enter_opens_file_and_returns_to_pane(tmp_path):
+    """Entering a file from tree mode should open it and restore pane focus."""
+    test_file = tmp_path / "open-me.txt"
+    test_file.write_text("hello")
+    app = SkimApp(path=str(tmp_path))
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
+
+        await pilot.press("f")
+        await pilot.pause()
+        await pilot.press("down")
+        await pilot.pause()
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert pane.current_path == test_file
+        assert not app.file_tree_mode
+        assert app.focused is pane
+
+
+async def test_file_tree_mode_escape_returns_to_active_pane(tmp_path):
+    """Escape should leave file-tree mode and return focus to the preview pane."""
+    (tmp_path / "one.txt").write_text("x")
+    app = SkimApp(path=str(tmp_path))
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
+        footer = app.query_one("#status-bar", Static)
+
+        await pilot.press("f")
+        await pilot.pause()
+        assert app.file_tree_mode
+        assert "Back" in _static_content(footer)
+
+        await pilot.press("escape")
+        await pilot.pause()
+
+        assert not app.file_tree_mode
+        assert app.focused is pane
+        assert "File tree" in _static_content(footer)
+
+
+async def test_down_outside_file_tree_mode_still_scrolls_preview_pane(tmp_path):
+    """Outside file-tree mode, down should keep scrolling the active pane."""
+    test_file = tmp_path / "long.txt"
+    test_file.write_text("\n".join(f"line {index}" for index in range(400)))
+    (tmp_path / "other.txt").write_text("x")
+    app = SkimApp(path=str(tmp_path))
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
+        tree = app.query_one("DirectoryTree")
+        pane.show_file(test_file)
+        await pilot.pause()
+
+        before_scroll = pane.scroll_y
+        before_cursor = tree.cursor_line
+        await pilot.press("down")
+        await pilot.pause()
+
+        assert pane.scroll_y > before_scroll
+        assert tree.cursor_line == before_cursor
+
+
+async def test_shift_down_still_moves_file_tree_cursor(tmp_path):
+    """Shift+down should remain a convenience shortcut for tree navigation."""
+    for index in range(4):
+        (tmp_path / f"file_{index}.txt").write_text("x")
+    app = SkimApp(path=str(tmp_path))
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        tree = app.query_one("DirectoryTree")
+        before = tree.cursor_line
+
+        await pilot.press("shift+down")
+        await pilot.pause()
+
+        assert tree.cursor_line > before
+
+
 def test_generic_json_uses_syntax_preview(tmp_path):
     """Generic JSON keeps the syntax-highlighted preview."""
     test_file = tmp_path / "plain.json"
@@ -677,6 +801,7 @@ async def test_global_footer_only_shows_app_wide_commands():
 
         assert isinstance(content, str)
         assert "Scroll" in content
+        assert "File tree" in content
         assert "Open" in content
         assert "JSON" not in content
         assert "Branch" not in content

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,6 +1,7 @@
 """Tests for skim."""
 
 import json
+from typing import Any
 
 from rich.syntax import Syntax
 from rich.text import Text
@@ -703,38 +704,48 @@ async def test_non_trajectory_previews_do_not_mount_local_footer(tmp_path):
         assert not pane.query(".trajectory-footer")
 
 
-async def test_preview_pane_uses_stable_scrollbar_styles(tmp_path):
-    """Preview panes should reserve draggable scrollbar gutter space."""
+async def test_mouse_drag_scrolls_preview_pane(tmp_path):
+    """Dragging inside a preview pane should scroll long generic content."""
     test_file = tmp_path / "long.txt"
-    test_file.write_text("\n".join(f"line {index}" for index in range(200)))
+    test_file.write_text("\n".join(f"line {index}" for index in range(400)))
     app = SkimApp(path=str(tmp_path))
 
     async with app.run_test() as pilot:
         pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
         pane.show_file(test_file)
         await pilot.pause()
+        before = pane.scroll_y
 
-        assert pane.styles.scrollbar_gutter == "stable"
-        assert pane.styles.scrollbar_size_vertical == 3
+        await pilot.mouse_down(pane, offset=(5, 10))
+        await pilot.hover(pane, offset=(5, 1))
+        await pilot.mouse_up(pane, offset=(5, 1))
+        await pilot.pause()
+
+        assert pane.scroll_y > before
 
 
-async def test_directory_tree_uses_stable_scrollbar_styles(tmp_path):
-    """The file tree should expose the same draggable scrollbar affordance."""
-    for index in range(40):
+async def test_mouse_drag_scrolls_directory_tree(tmp_path):
+    """Dragging inside the file tree should scroll the tree."""
+    for index in range(80):
         (tmp_path / f"file_{index}.txt").write_text("x")
     app = SkimApp(path=str(tmp_path))
 
     async with app.run_test() as pilot:
         await pilot.pause()
         tree = app.query_one("DirectoryTree")
+        before = tree.scroll_y
 
-        assert tree.styles.scrollbar_gutter == "stable"
-        assert tree.styles.scrollbar_size_vertical == 3
+        await pilot.mouse_down(tree, offset=(5, 10))
+        await pilot.hover(tree, offset=(5, 1))
+        await pilot.mouse_up(tree, offset=(5, 1))
+        await pilot.pause()
+
+        assert tree.scroll_y > before
 
 
-async def test_trajectory_tree_uses_stable_scrollbar_styles():
-    """Trajectory tree should reserve gutter space for a draggable scrollbar."""
-    viewer = TrajectoryViewer(sample_trajectory())
+async def test_mouse_drag_scrolls_trajectory_tree():
+    """Dragging inside the trajectory tree should scroll long step lists."""
+    viewer = TrajectoryViewer(multi_step_trajectory(20))
     app = SkimApp(path=".")
 
     async with app.run_test() as pilot:
@@ -742,24 +753,37 @@ async def test_trajectory_tree_uses_stable_scrollbar_styles():
         await pane.mount(viewer)
         await pilot.pause()
         tree = viewer.query_one(".trajectory-tree", Tree)
+        before = tree.scroll_y
 
-        assert tree.styles.scrollbar_gutter == "stable"
-        assert tree.styles.scrollbar_size_vertical == 3
+        await pilot.mouse_down(tree, offset=(5, 10))
+        await pilot.hover(tree, offset=(5, 1))
+        await pilot.mouse_up(tree, offset=(5, 1))
+        await pilot.pause()
+
+        assert tree.scroll_y > before
 
 
-async def test_trajectory_detail_uses_stable_scrollbar_styles():
-    """Trajectory detail pane should reserve gutter space for a draggable scrollbar."""
+async def test_mouse_drag_scrolls_trajectory_detail():
+    """Dragging on the detail pane background should scroll long detail output."""
     viewer = TrajectoryViewer(sample_trajectory())
     app = SkimApp(path=".")
 
     async with app.run_test() as pilot:
         pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
         await pane.mount(viewer)
+        output_node = viewer._tree.root.children[2].children[2].children[1]
+        viewer._tree.move_cursor(output_node, animate=False)
+        await pilot.press("enter")
         await pilot.pause()
         detail = viewer.query_one(".trajectory-detail-wrap")
+        before = detail.scroll_y
 
-        assert detail.styles.scrollbar_gutter == "stable"
-        assert detail.styles.scrollbar_size_vertical == 3
+        await pilot.mouse_down(detail, offset=(0, 10))
+        await pilot.hover(detail, offset=(0, 1))
+        await pilot.mouse_up(detail, offset=(0, 1))
+        await pilot.pause()
+
+        assert detail.scroll_y > before
 
 
 def sample_trajectory(
@@ -828,6 +852,14 @@ def sample_trajectory(
         "final_output": "## Final\n\nDone.",
         "steps": [{"output": step_output}],
     }
+
+
+def multi_step_trajectory(step_count: int) -> dict[str, Any]:
+    """Return a trajectory with repeated steps to force tree overflow."""
+    trajectory = sample_trajectory()
+    step = trajectory["steps"][0]
+    trajectory["steps"] = [step for _ in range(step_count)]
+    return trajectory
 
 
 def _static_content(widget: Static):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -703,6 +703,65 @@ async def test_non_trajectory_previews_do_not_mount_local_footer(tmp_path):
         assert not pane.query(".trajectory-footer")
 
 
+async def test_preview_pane_uses_stable_scrollbar_styles(tmp_path):
+    """Preview panes should reserve draggable scrollbar gutter space."""
+    test_file = tmp_path / "long.txt"
+    test_file.write_text("\n".join(f"line {index}" for index in range(200)))
+    app = SkimApp(path=str(tmp_path))
+
+    async with app.run_test() as pilot:
+        pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
+        pane.show_file(test_file)
+        await pilot.pause()
+
+        assert pane.styles.scrollbar_gutter == "stable"
+        assert pane.styles.scrollbar_size_vertical == 3
+
+
+async def test_directory_tree_uses_stable_scrollbar_styles(tmp_path):
+    """The file tree should expose the same draggable scrollbar affordance."""
+    for index in range(40):
+        (tmp_path / f"file_{index}.txt").write_text("x")
+    app = SkimApp(path=str(tmp_path))
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        tree = app.query_one("DirectoryTree")
+
+        assert tree.styles.scrollbar_gutter == "stable"
+        assert tree.styles.scrollbar_size_vertical == 3
+
+
+async def test_trajectory_tree_uses_stable_scrollbar_styles():
+    """Trajectory tree should reserve gutter space for a draggable scrollbar."""
+    viewer = TrajectoryViewer(sample_trajectory())
+    app = SkimApp(path=".")
+
+    async with app.run_test() as pilot:
+        pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
+        await pane.mount(viewer)
+        await pilot.pause()
+        tree = viewer.query_one(".trajectory-tree", Tree)
+
+        assert tree.styles.scrollbar_gutter == "stable"
+        assert tree.styles.scrollbar_size_vertical == 3
+
+
+async def test_trajectory_detail_uses_stable_scrollbar_styles():
+    """Trajectory detail pane should reserve gutter space for a draggable scrollbar."""
+    viewer = TrajectoryViewer(sample_trajectory())
+    app = SkimApp(path=".")
+
+    async with app.run_test() as pilot:
+        pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
+        await pane.mount(viewer)
+        await pilot.pause()
+        detail = viewer.query_one(".trajectory-detail-wrap")
+
+        assert detail.styles.scrollbar_gutter == "stable"
+        assert detail.styles.scrollbar_size_vertical == 3
+
+
 def sample_trajectory(
     stdout: str = "plain terminal output",
     arguments: dict | None = None,


### PR DESCRIPTION
## Summary
- add drag-scrolling support for skim panels where the terminal forwards mouse drag events
- add a file-tree focus mode fallback so tree navigation does not depend on `Shift+Up/Down`
- keep trajectory viewer keyboard behavior intact while improving cross-terminal usability

## What Changed
- add thresholded drag-scroll handling for preview panes, the file tree, the trajectory tree, and the trajectory detail container
- keep the trajectory viewer's tree/detail keyboard mode unchanged
- add `f` to enter file-tree focus mode
- in file-tree mode, use `Up/Down` to move, `Enter` to open, and `Esc` to return to the active preview pane
- keep `Shift+Up/Down` as a secondary convenience path where the terminal supports it
- update the global footer to document the reliable file-tree fallback path
- add regression tests for drag-scroll gestures and file-tree focus-mode behavior

## Why
Mouse and key handling differs across terminal hosts:
- plain terminals can forward drag gestures, but integrated terminals may not behave the same way
- some terminals do not reliably deliver distinct `Shift+Up/Down` sequences for file-tree navigation

This PR adds app-level fallbacks we control instead of relying on terminal-specific behavior alone.

## Validation
- `uv run pytest`
- `uv run ruff check .`
- `uv run ruff format --check .`
