### PR TITLE
Unify JSON previews under inspector

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ You can have up to 6 panes arranged in a 2 row by 3 column grid. Press `s` follo
 
 ## Supported file types
 
-Syntax highlighting works for Python, JSON, JavaScript, TypeScript, HTML, CSS, YAML, TOML, Bash, Rust, Go, SQL, XML, and CSV. Markdown files are rendered with formatting. JSON files are pretty printed automatically. Files over 1MB are skipped to keep things responsive.
+Syntax highlighting works for Python, JSON, JavaScript, TypeScript, HTML, CSS, YAML, TOML, Bash, Rust, Go, SQL, and XML. Markdown files are rendered with formatting. JSON files are pretty printed automatically. CSV files render as a compact table preview with the raw CSV available below it. Files over 1MB are skipped to keep things responsive.
 
 ## License
 

--- a/src/skim/__init__.py
+++ b/src/skim/__init__.py
@@ -6,13 +6,13 @@ widgets, and trajectory viewer types so callers can continue using simple
 """
 
 from .app import SkimApp, dev, main
-from .preview import PreviewPane, SubmissionSummary, render_file
-from .trajectory import TrajectoryViewer, normalize_events
+from .preview import PreviewPane, render_file
+from .trajectory import JsonInspector, TrajectoryViewer, normalize_events
 
 __all__ = [
+    "JsonInspector",
     "PreviewPane",
     "SkimApp",
-    "SubmissionSummary",
     "TrajectoryViewer",
     "dev",
     "main",

--- a/src/skim/app.py
+++ b/src/skim/app.py
@@ -19,7 +19,7 @@ from textual.widgets import Header, Static
 
 from .preview import PreviewPane
 from .scrolling import DirectoryTree
-from .trajectory import TrajectoryViewer
+from .trajectory import JsonInspector, TrajectoryViewer
 
 MAX_ROWS = 2
 MAX_COLS = 3
@@ -57,7 +57,7 @@ class SkimApp(App):
     PreviewPane.active-pane {
         border: round $accent;
     }
-    TrajectoryViewer {
+    TrajectoryViewer, JsonInspector {
         width: 1fr;
     }
     .trajectory-body {
@@ -327,10 +327,10 @@ class SkimApp(App):
                 event.stop()
                 return
 
-        viewer: TrajectoryViewer | None = None
+        viewer: JsonInspector | TrajectoryViewer | None = None
         try:
             active_pane = self.query_one(f"#{self.active_pane_id}", PreviewPane)
-            viewer = active_pane.active_trajectory_viewer()
+            viewer = active_pane.active_json_navigator()
         except Exception:
             viewer = None
 

--- a/src/skim/preview.py
+++ b/src/skim/preview.py
@@ -23,7 +23,7 @@ from textual.widget import Widget
 from textual.widgets import Collapsible, Markdown, Static
 
 from .scrolling import DragScrollMixin
-from .trajectory import TrajectoryViewer, extract_trajectory
+from .trajectory import JsonInspector, TrajectoryViewer
 
 SYNTAX_MAP = {
     ".py": "python",
@@ -45,68 +45,10 @@ SYNTAX_MAP = {
 }
 MARKDOWN_EXTENSIONS = {".md", ".markdown", ".mdown"}
 MAX_FILE_SIZE = 1_000_000
+MAX_JSON_FILE_SIZE = 10_000_000
 MAX_CSV_ROWS = 20
 MAX_CSV_COLS = 8
 MAX_CSV_CELL_WIDTH = 24
-SUBMISSION_KEYS = {
-    "agentic_grader_guidance",
-    "prompt",
-    "quick_scores",
-    "submission_type",
-    "task_name",
-}
-SUBMISSION_SECTIONS = [
-    ("task_name", "Task"),
-    ("submission_type", "Submission"),
-    ("quick_scores", "Quick Scores"),
-    ("quick_stats", "Quick Stats"),
-    ("task_data_review", "Task Data Review"),
-    ("prompt", "Prompt"),
-    ("agentic_grader_guidance", "Grader Guidance"),
-    ("task_solution", "Task Solution"),
-    ("task_performance", "Task Performance"),
-    ("grader_reliability", "Grader Reliability"),
-    ("grader_reliability_explanation", "Grader Reliability Explanation"),
-    ("load_trajectories_s3", "Trajectory URL"),
-    ("setup_files_url", "Setup Files URL"),
-    ("load_trajectories_s3_agentic_grader_results", "Grader Results URL"),
-    ("evaluation_files_url", "Evaluation Files URL"),
-    ("context_files_draft", "Context Files URL"),
-]
-
-
-def _decode_nested_json(value: Any) -> Any:
-    """Best-effort decode nested JSON strings inside lists and dictionaries."""
-    if isinstance(value, str):
-        try:
-            return _decode_nested_json(json.loads(value))
-        except json.JSONDecodeError:
-            return value
-    if isinstance(value, list):
-        return [_decode_nested_json(item) for item in value]
-    if isinstance(value, dict):
-        return {key: _decode_nested_json(item) for key, item in value.items()}
-    return value
-
-
-def _format_payload(value: Any) -> str:
-    """Format a decoded payload for readable fallback text output."""
-    decoded = _decode_nested_json(value)
-    if isinstance(decoded, dict | list):
-        return json.dumps(decoded, indent=2)
-    if decoded is None:
-        return ""
-    return str(decoded)
-
-
-class SubmissionSummary(Static):
-    """Structured preview for a worker submission JSON artifact."""
-
-    def __init__(self, data: dict[str, Any]) -> None:
-        """Initialize the submission summary."""
-        self.data = data
-        self.summary_text = _format_submission(data)
-        super().__init__(self.summary_text, classes="submission-summary")
 
 
 class CsvPreview(Vertical):
@@ -151,7 +93,7 @@ class PreviewPane(DragScrollMixin, VerticalScroll, can_focus=True):
         self.scroll_home(animate=False)
         if (
             widgets
-            and isinstance(widgets[0], TrajectoryViewer)
+            and isinstance(widgets[0], (JsonInspector, TrajectoryViewer))
             and self.id == getattr(self.app, "active_pane_id", None)
         ):
             self.call_after_refresh(widgets[0].focus_tree_mode)
@@ -163,19 +105,23 @@ class PreviewPane(DragScrollMixin, VerticalScroll, can_focus=True):
 
     def scroll_content(self, delta: int) -> None:
         """Scroll specialized inner content when present, else scroll the pane."""
-        viewer = self.active_trajectory_viewer()
+        viewer = self.active_json_navigator()
         if viewer is not None:
             viewer.handle_vertical_key(delta)
         else:
             self.scroll_relative(y=delta, animate=False)
 
-    def active_trajectory_viewer(self) -> TrajectoryViewer | None:
-        """Return the mounted trajectory viewer, if this pane has one."""
+    def active_json_navigator(self) -> JsonInspector | TrajectoryViewer | None:
+        """Return the mounted JSON tree/detail navigator, if present."""
         try:
-            viewer = self.query(TrajectoryViewer).first()
+            viewer = self.query(JsonInspector).first()
         except NoMatches:
-            return None
-        return viewer if isinstance(viewer, TrajectoryViewer) else None
+            try:
+                viewer = self.query(TrajectoryViewer).first()
+            except NoMatches:
+                return None
+            return viewer if isinstance(viewer, TrajectoryViewer) else None
+        return viewer if isinstance(viewer, JsonInspector) else None
 
 
 def render_file(path: Path) -> list[Widget]:
@@ -183,8 +129,10 @@ def render_file(path: Path) -> list[Widget]:
     if not path.is_file():
         return [Static(Text(f"Not a file: {path.name}", style="red"))]
 
+    suffix = path.suffix.lower()
     size = path.stat().st_size
-    if size > MAX_FILE_SIZE:
+    max_size = MAX_JSON_FILE_SIZE if suffix == ".json" else MAX_FILE_SIZE
+    if size > max_size:
         return [Static(Text(f"{path.name} is too large ({size:,} bytes)", style="red"))]
 
     try:
@@ -192,18 +140,13 @@ def render_file(path: Path) -> list[Widget]:
     except Exception as error:
         return [Static(Text(f"Could not read {path.name}: {error}", style="red"))]
 
-    suffix = path.suffix.lower()
-
     if suffix in MARKDOWN_EXTENSIONS:
         return [Markdown(content)]
 
     if suffix == ".json":
         try:
             parsed = json.loads(content)
-            widget = _specialized_json_widget(parsed)
-            if widget is not None:
-                return [widget]
-            content = json.dumps(parsed, indent=2)
+            return [JsonInspector(parsed)]
         except json.JSONDecodeError:
             pass
 
@@ -311,29 +254,3 @@ def _raw_csv_section(content: str, *, collapsed: bool = True) -> Collapsible:
         collapsed=collapsed,
         classes="csv-raw-section",
     )
-
-
-def _specialized_json_widget(data: Any) -> Widget | None:
-    """Return a specialized preview widget for supported JSON shapes."""
-    trajectory = extract_trajectory(data)
-    if trajectory is not None:
-        return TrajectoryViewer(trajectory)
-    if _is_submission(data):
-        return SubmissionSummary(data)
-    return None
-
-
-def _is_submission(data: Any) -> bool:
-    """Return whether a JSON object looks like a worker submission artifact."""
-    return isinstance(data, dict) and any(key in data for key in SUBMISSION_KEYS)
-
-
-def _format_submission(data: dict[str, Any]) -> Text:
-    """Render the submission summary as plain text sections."""
-    lines = ["Submission Summary"]
-    for key, title in SUBMISSION_SECTIONS:
-        value = data.get(key)
-        if value in (None, ""):
-            continue
-        lines.extend(["", title, _format_payload(value)])
-    return Text("\n".join(lines))

--- a/src/skim/preview.py
+++ b/src/skim/preview.py
@@ -7,16 +7,20 @@ outer multi-pane app behavior or trajectory-specific rendering internals.
 
 from __future__ import annotations
 
+import csv
 import json
+from io import StringIO
 from pathlib import Path
 from typing import Any
 
 from rich.syntax import Syntax
+from rich.table import Table
 from rich.text import Text
-from textual.containers import VerticalScroll
+from textual.app import ComposeResult
+from textual.containers import Vertical, VerticalScroll
 from textual.css.query import NoMatches
 from textual.widget import Widget
-from textual.widgets import Markdown, Static
+from textual.widgets import Collapsible, Markdown, Static
 
 from .scrolling import DragScrollMixin
 from .trajectory import TrajectoryViewer, extract_trajectory
@@ -41,6 +45,9 @@ SYNTAX_MAP = {
 }
 MARKDOWN_EXTENSIONS = {".md", ".markdown", ".mdown"}
 MAX_FILE_SIZE = 1_000_000
+MAX_CSV_ROWS = 20
+MAX_CSV_COLS = 8
+MAX_CSV_CELL_WIDTH = 24
 SUBMISSION_KEYS = {
     "agentic_grader_guidance",
     "prompt",
@@ -100,6 +107,23 @@ class SubmissionSummary(Static):
         self.data = data
         self.summary_text = _format_submission(data)
         super().__init__(self.summary_text, classes="submission-summary")
+
+
+class CsvPreview(Vertical):
+    """Dual CSV preview with a readable table and raw text fallback."""
+
+    def __init__(self, content: str) -> None:
+        """Initialize the CSV preview from raw file content."""
+        super().__init__(classes="csv-preview")
+        parsed = _parse_csv(content)
+        if isinstance(parsed, str):
+            self._widgets = _csv_parse_error_widgets(content, parsed)
+        else:
+            self._widgets = _csv_preview_widgets(content, parsed)
+
+    def compose(self) -> ComposeResult:
+        """Compose the CSV preview widgets."""
+        yield from self._widgets
 
 
 class PreviewPane(DragScrollMixin, VerticalScroll, can_focus=True):
@@ -183,10 +207,110 @@ def render_file(path: Path) -> list[Widget]:
         except json.JSONDecodeError:
             pass
 
+    if suffix == ".csv":
+        return [CsvPreview(content)]
+
     lexer = SYNTAX_MAP.get(suffix)
     if lexer:
         return [Static(Syntax(content, lexer, line_numbers=True, word_wrap=True))]
     return [Static(Text(content))]
+
+
+def _parse_csv(content: str) -> list[list[str]] | str:
+    """Parse CSV content into rows, returning an error message on failure."""
+    try:
+        reader = csv.reader(StringIO(content), strict=True)
+        return [list(row) for row in reader]
+    except csv.Error as error:
+        return str(error)
+
+
+def _csv_preview_widgets(content: str, rows: list[list[str]]) -> list[Widget]:
+    """Build the normal CSV preview widgets."""
+    if not rows:
+        return [
+            Static(Text("Empty CSV file", style="dim italic")),
+            _raw_csv_section(content),
+        ]
+
+    header = rows[0]
+    body = rows[1:]
+    table = _csv_table(header, body)
+    summary = Static(_csv_summary_text(header, body), classes="csv-summary")
+    return [
+        summary,
+        Static(table, classes="csv-table"),
+        _raw_csv_section(content),
+    ]
+
+
+def _csv_parse_error_widgets(content: str, error: str) -> list[Widget]:
+    """Build the CSV preview widgets for malformed CSV input."""
+    return [
+        Static(
+            Text(f"CSV parse error: {error}", style="bold red"),
+            classes="csv-parse-error",
+        ),
+        _raw_csv_section(content, collapsed=False),
+    ]
+
+
+def _csv_summary_text(header: list[str], body: list[list[str]]) -> Text:
+    """Return a short summary for the CSV preview."""
+    text = Text()
+    text.append("CSV Preview", style="bold")
+    text.append(
+        f"  {len(body):,} rows x {len(header):,} columns",
+        style="dim",
+    )
+    if len(body) > MAX_CSV_ROWS or len(header) > MAX_CSV_COLS:
+        row_count = min(len(body), MAX_CSV_ROWS)
+        column_count = min(len(header), MAX_CSV_COLS)
+        text.append(
+            f"  showing first {row_count} rows and {column_count} columns",
+            style="yellow",
+        )
+    return text
+
+
+def _csv_table(header: list[str], rows: list[list[str]]) -> Table:
+    """Return a capped rich table for a CSV preview."""
+    display_header = header[:MAX_CSV_COLS]
+    table = Table(expand=True)
+    for column in display_header:
+        table.add_column(_clip_csv_cell(column), overflow="fold")
+    if len(header) > MAX_CSV_COLS:
+        table.add_column("…", overflow="fold")
+
+    for row in rows[:MAX_CSV_ROWS]:
+        display_row = [
+            _clip_csv_cell(row[index] if index < len(row) else "")
+            for index in range(len(display_header))
+        ]
+        if len(header) > MAX_CSV_COLS:
+            overflow_values = row[MAX_CSV_COLS:]
+            display_row.append(_clip_csv_cell(" | ".join(overflow_values)))
+        table.add_row(*display_row)
+
+    return table
+
+
+def _clip_csv_cell(value: str) -> str:
+    """Clip one CSV cell to a conservative width for TUI readability."""
+    value = " ".join(value.splitlines())
+    if len(value) <= MAX_CSV_CELL_WIDTH:
+        return value
+    return value[: MAX_CSV_CELL_WIDTH - 1].rstrip() + "…"
+
+
+def _raw_csv_section(content: str, *, collapsed: bool = True) -> Collapsible:
+    """Return the raw CSV section for a CSV preview."""
+    return Collapsible(
+        Static(Syntax(content, "csv", line_numbers=True, word_wrap=True), classes="csv-raw"),
+        title="Raw CSV",
+        collapsed=collapsed,
+        classes="csv-raw-section",
+    )
 
 
 def _specialized_json_widget(data: Any) -> Widget | None:

--- a/src/skim/trajectory.py
+++ b/src/skim/trajectory.py
@@ -25,14 +25,20 @@ HUMAN_TEXT_KEYS = {
     "arguments",
     "code",
     "command",
+    "conversations",
     "content",
+    "final_output",
     "markdown",
     "output",
     "pages",
+    "prompt",
     "result",
     "stderr",
     "stdout",
+    "task",
+    "task_solution",
     "text",
+    "trajectory",
 }
 WRAPPER_KEYS = ("arguments", "content", "output", "result", "text")
 PRIMARY_CONTENT_KEYS = ("stdout", "code", "command", "text", "value")
@@ -795,14 +801,25 @@ def _section_widget(
 
 def _display_label(key: str) -> str:
     special = {
+        "agentic_grader_guidance": "Grader Guidance",
         "call_id": "Call ID",
         "code": "code",
         "command": "command",
+        "final_output": "Final Output",
+        "load_trajectories_s3": "Trajectory URL",
         "pages": "pages",
+        "prompt": "Prompt",
+        "quick_scores": "Quick Scores",
+        "quick_stats": "Quick Stats",
         "returncode": "returncode",
         "stderr": "stderr",
         "stdout": "stdout",
+        "submission_type": "Submission Type",
+        "task": "Task",
+        "task_name": "Task Name",
+        "task_solution": "Task Solution",
         "text": "text",
+        "trajectory": "Trajectory",
     }
     if key in special:
         return special[key]
@@ -1089,3 +1106,705 @@ class TrajectoryViewer(Vertical):
                             event=item.event,
                         ),
                     )
+
+
+@dataclass(frozen=True)
+class JsonInspectorItem:
+    """Data attached to one JSON-inspector tree node."""
+
+    kind: str
+    title: str
+    raw_path: tuple[str | int, ...]
+    raw_value: Any
+    key: str = ""
+    detail: Any = None
+    trajectory_item: TrajectoryTreeItem | None = None
+    synthetic: bool = False
+    annotation_path: tuple[str | int, ...] | None = None
+
+
+class JsonInspector(Vertical):
+    """Unified structural inspector for JSON files with semantic overlays."""
+
+    def __init__(self, data: Any) -> None:
+        """Initialize the JSON inspector for parsed JSON content."""
+        super().__init__(classes="trajectory-viewer")
+        self.data = data
+        self._input_mode = "tree"
+        self._tree: DragTree = DragTree("JSON", classes="trajectory-tree")
+        self._build_tree()
+        first_item = self._tree.root.children[0].data if self._tree.root.children else None
+        initial_widgets: list[Widget] = []
+        if isinstance(first_item, JsonInspectorItem):
+            initial_widgets = _json_detail_widgets(first_item)
+        self._detail_wrap = FocusableDetailWrap(*initial_widgets, classes="trajectory-detail-wrap")
+        self._footer = Static(self._footer_text(), classes="trajectory-footer")
+
+    def compose(self) -> ComposeResult:
+        """Compose the JSON tree, detail panel, and local footer."""
+        with Horizontal(classes="trajectory-body"):
+            yield self._tree
+            yield self._detail_wrap
+        yield self._footer
+
+    def on_tree_node_selected(self, event: TextualTree.NodeSelected[JsonInspectorItem]) -> None:
+        """Update detail when a JSON tree node is selected."""
+        item = event.node.data
+        if isinstance(item, JsonInspectorItem):
+            self._show_detail(item)
+        event.stop()
+
+    def _show_detail(self, item: JsonInspectorItem) -> None:
+        """Replace the detail pane with widgets for the selected tree item."""
+        self._detail_wrap.remove_children()
+        self._detail_wrap.mount(*_json_detail_widgets(item))
+        self._detail_wrap.scroll_home(animate=False)
+
+    def scroll_detail(self, delta: int) -> None:
+        """Scroll the rendered detail panel."""
+        self._detail_wrap.scroll_relative(y=delta, animate=False)
+
+    def is_tree_mode(self) -> bool:
+        """Return whether keyboard navigation is driving the left tree."""
+        return self._input_mode == "tree"
+
+    def focus_tree_mode(self) -> None:
+        """Route navigation input to the tree."""
+        self._input_mode = "tree"
+        self._update_footer()
+        self._ensure_tree_cursor()
+        if self.is_attached:
+            self._tree.focus(scroll_visible=False)
+
+    def focus_detail_mode(self) -> None:
+        """Route navigation input to the rendered detail pane."""
+        self._input_mode = "detail"
+        self._update_footer()
+        if self.is_attached:
+            self._detail_wrap.focus(scroll_visible=False)
+
+    def handle_vertical_key(self, delta: int) -> bool:
+        """Handle up/down keys for the active JSON sub-view."""
+        if self.is_tree_mode():
+            if delta < 0:
+                self._tree.action_cursor_up()
+            else:
+                self._tree.action_cursor_down()
+            return True
+        self.scroll_detail(delta)
+        return True
+
+    def handle_horizontal_key(self, key: str) -> bool:
+        """Handle left/right tree navigation."""
+        if not self.is_tree_mode():
+            return False
+        node = self._tree.cursor_node
+        if node is None:
+            return False
+        if key == "left":
+            if node.allow_expand and node.is_expanded:
+                node.collapse()
+            elif node.parent is not None:
+                self._tree.move_cursor(node.parent, animate=False)
+            return True
+        if key == "right":
+            if node.allow_expand and node.is_collapsed:
+                node.expand()
+            elif node.children:
+                self._tree.move_cursor(node.children[0], animate=False)
+            return True
+        return False
+
+    def handle_enter_key(self) -> bool:
+        """Select the current tree item and move focus to the detail pane."""
+        if not self.is_tree_mode():
+            return False
+        self._ensure_tree_cursor()
+        self._tree.action_select_cursor()
+        self.focus_detail_mode()
+        return True
+
+    def handle_escape_key(self) -> bool:
+        """Return keyboard control from detail back to the tree."""
+        if self.is_tree_mode():
+            return False
+        self.focus_tree_mode()
+        return True
+
+    def _ensure_tree_cursor(self) -> None:
+        """Keep the tree cursor on the first visible child instead of the root."""
+        cursor = self._tree.cursor_node
+        if (cursor is None or cursor.is_root) and self._tree.root.children:
+            self._tree.move_cursor(self._tree.root.children[0], animate=False)
+
+    def _footer_text(self) -> Text:
+        """Build the mode-aware local footer text."""
+        text = Text()
+        if self.is_tree_mode():
+            text.append(" JSON ", style="reverse")
+            text.append(" ")
+            text.append("↑↓", style="bold")
+            text.append(" Move  ")
+            text.append("←→", style="bold")
+            text.append(" Branch  ")
+            text.append("Enter", style="bold")
+            text.append(" Detail")
+        else:
+            text.append(" Detail ", style="reverse")
+            text.append(" ")
+            text.append("↑↓", style="bold")
+            text.append(" Scroll  ")
+            text.append("Esc", style="bold")
+            text.append(" Back to JSON")
+        return text
+
+    def _update_footer(self) -> None:
+        """Refresh the local footer after mode changes."""
+        self._footer.update(self._footer_text())
+
+    def _build_tree(self) -> None:
+        """Populate the unified JSON tree."""
+        self._tree.root.expand()
+        self._add_overlay_children(self._tree.root, self.data, ())
+        self._add_raw_children(self._tree.root, self.data, ())
+
+    def _add_overlay_children(
+        self,
+        parent: TextualTree.Node[JsonInspectorItem],
+        value: Any,
+        raw_path: tuple[str | int, ...],
+    ) -> None:
+        """Add synthetic schema-aware nodes before the raw children."""
+        if raw_path == () and _looks_like_bundle(value):
+            parent.add_leaf(
+                Text("Bundle Summary", style="bold cyan"),
+                data=JsonInspectorItem(
+                    kind="bundle_summary",
+                    title="Bundle Summary",
+                    raw_path=raw_path,
+                    raw_value=value,
+                    detail=_bundle_summary(value),
+                    synthetic=True,
+                ),
+            )
+            return
+
+        if raw_path == () and _looks_like_submission(value):
+            parent.add_leaf(
+                Text("Submission Summary", style="bold cyan"),
+                data=JsonInspectorItem(
+                    kind="submission_summary",
+                    title="Submission Summary",
+                    raw_path=raw_path,
+                    raw_value=value,
+                    detail=_submission_summary_payload(value),
+                    synthetic=True,
+                ),
+            )
+            return
+
+        if raw_path == () and _looks_like_hermes(value):
+            parent.add_leaf(
+                Text("Transcript Summary", style="bold cyan"),
+                data=JsonInspectorItem(
+                    kind="transcript_summary",
+                    title="Transcript Summary",
+                    raw_path=raw_path,
+                    raw_value=value,
+                    detail=_hermes_summary(value),
+                    synthetic=True,
+                ),
+            )
+            return
+
+        trajectory, base_path = _overlay_trajectory_target(self.data, value, raw_path)
+        if trajectory is not None:
+            self._add_trajectory_overlay(parent, trajectory, base_path)
+
+    def _add_trajectory_overlay(
+        self,
+        parent: TextualTree.Node[JsonInspectorItem],
+        trajectory: dict[str, Any],
+        base_path: tuple[str | int, ...],
+    ) -> None:
+        """Add summary and step nodes for a trajectory object."""
+        parent.add_leaf(
+            Text("Metadata", style="bold cyan"),
+            data=JsonInspectorItem(
+                kind="trajectory_metadata",
+                title="Metadata",
+                raw_path=base_path + ("metadata",),
+                raw_value=trajectory.get("metadata"),
+                trajectory_item=TrajectoryTreeItem(
+                    "metadata",
+                    "Metadata",
+                    _metadata_detail(trajectory),
+                ),
+                synthetic=True,
+            ),
+        )
+        parent.add_leaf(
+            Text("Final Output", style="bold cyan"),
+            data=JsonInspectorItem(
+                kind="trajectory_final_output",
+                title="Final Output",
+                raw_path=base_path + ("final_output",),
+                raw_value=trajectory.get("final_output"),
+                trajectory_item=TrajectoryTreeItem(
+                    "final_output",
+                    "Final Output",
+                    _final_output_detail(trajectory),
+                ),
+                synthetic=True,
+            ),
+        )
+
+        step_items = normalize_step_timeline(trajectory)
+        step_events = normalize_step_events(trajectory)
+        steps = trajectory.get("steps", []) if isinstance(trajectory.get("steps"), list) else []
+        for step_index, (items, events) in enumerate(zip(step_items, step_events, strict=False)):
+            step_path = base_path + ("steps", step_index)
+            step_raw_value = steps[step_index] if step_index < len(steps) else None
+            step = parent.add(
+                Text(f"Step {step_index + 1}", style="bold yellow"),
+                data=JsonInspectorItem(
+                    kind="trajectory_step",
+                    title=f"Step {step_index + 1}",
+                    raw_path=step_path,
+                    raw_value=step_raw_value,
+                    trajectory_item=TrajectoryTreeItem(
+                        "step",
+                        f"Step {step_index + 1}",
+                        Text(f"Step {step_index + 1}\n\n{len(items)} items"),
+                    ),
+                    synthetic=True,
+                ),
+                expand=True,
+            )
+            for item in items:
+                if item.interaction is not None:
+                    call_event = item.interaction.call_event
+                    result_event = item.interaction.result_event
+                    call_path = _trajectory_event_path(base_path, step_index, events, call_event)
+                    result_path = _trajectory_event_path(
+                        base_path, step_index, events, result_event
+                    )
+                    parent_path = call_path or result_path or step_path
+                    tool = step.add(
+                        item.title,
+                        data=JsonInspectorItem(
+                            kind="trajectory_tool",
+                            title=item.title.plain,
+                            raw_path=parent_path,
+                            raw_value=_interaction_payload(item.interaction),
+                            trajectory_item=TrajectoryTreeItem(
+                                "tool",
+                                item.title.plain,
+                                interaction=item.interaction,
+                                focus="full",
+                            ),
+                            synthetic=True,
+                            annotation_path=parent_path,
+                        ),
+                        expand=True,
+                    )
+                    tool.add_leaf(
+                        Text("Input", style="bold yellow"),
+                        data=JsonInspectorItem(
+                            kind="trajectory_tool_input",
+                            title="Input",
+                            raw_path=call_path or parent_path,
+                            raw_value=call_event.raw if call_event else None,
+                            trajectory_item=TrajectoryTreeItem(
+                                "tool_input",
+                                "Input",
+                                interaction=item.interaction,
+                                focus="input",
+                            ),
+                            synthetic=True,
+                            annotation_path=call_path or parent_path,
+                        ),
+                    )
+                    tool.add_leaf(
+                        Text("Output", style="bold yellow"),
+                        data=JsonInspectorItem(
+                            kind="trajectory_tool_output",
+                            title="Output",
+                            raw_path=result_path or parent_path,
+                            raw_value=result_event.raw if result_event else None,
+                            trajectory_item=TrajectoryTreeItem(
+                                "tool_output",
+                                "Output",
+                                interaction=item.interaction,
+                                focus="output",
+                            ),
+                            synthetic=True,
+                            annotation_path=result_path or parent_path,
+                        ),
+                    )
+                    continue
+
+                if item.event is not None:
+                    event_path = _trajectory_event_path(base_path, step_index, events, item.event)
+                    step.add_leaf(
+                        item.title,
+                        data=JsonInspectorItem(
+                            kind="trajectory_event",
+                            title=item.title.plain,
+                            raw_path=event_path or step_path,
+                            raw_value=item.event.raw,
+                            trajectory_item=TrajectoryTreeItem(
+                                "event",
+                                item.title.plain,
+                                event=item.event,
+                            ),
+                            synthetic=True,
+                            annotation_path=event_path or step_path,
+                        ),
+                    )
+
+    def _add_raw_children(
+        self,
+        parent: TextualTree.Node[JsonInspectorItem],
+        value: Any,
+        raw_path: tuple[str | int, ...],
+    ) -> None:
+        """Recursively add raw JSON structure nodes to the tree."""
+        if isinstance(value, dict):
+            for key, child in value.items():
+                child_path = raw_path + (key,)
+                item = JsonInspectorItem(
+                    kind="raw_dict_key",
+                    title=_json_display_key(key),
+                    raw_path=child_path,
+                    raw_value=child,
+                    key=key,
+                )
+                label = _dict_tree_label(key, child)
+                if isinstance(child, dict | list):
+                    node = parent.add(label, data=item)
+                    self._add_overlay_children(node, child, child_path)
+                    self._add_raw_children(node, child, child_path)
+                else:
+                    parent.add_leaf(label, data=item)
+            return
+
+        if isinstance(value, list):
+            for index, child in enumerate(value):
+                child_path = raw_path + (index,)
+                item = JsonInspectorItem(
+                    kind="raw_list_item",
+                    title=_list_item_title(self.data, raw_path, index, child),
+                    raw_path=child_path,
+                    raw_value=child,
+                    key=str(index),
+                )
+                label = _list_tree_label(self.data, raw_path, index, child)
+                if isinstance(child, dict | list):
+                    node = parent.add(label, data=item)
+                    self._add_overlay_children(node, child, child_path)
+                    self._add_raw_children(node, child, child_path)
+                else:
+                    parent.add_leaf(label, data=item)
+
+
+def _json_detail_widgets(item: JsonInspectorItem) -> list[Widget]:
+    """Return detail widgets for a selected JSON-inspector node."""
+    path = _format_raw_path(item.annotation_path or item.raw_path)
+    if item.trajectory_item is not None:
+        return _metadata_fields([("Path", path)]) + _detail_widgets_for_item(item.trajectory_item)
+
+    title = Text(item.title or "JSON", style="bold")
+    widgets: list[Widget] = [Static(title, classes="trajectory-detail-heading")]
+    widgets.extend(
+        _metadata_fields(
+            [
+                ("Path", path),
+                ("Type", _json_type_name(item.raw_value)),
+            ]
+        )
+    )
+
+    value = item.detail if item.synthetic and item.detail is not None else item.raw_value
+    if item.synthetic and isinstance(value, dict | list):
+        widgets.extend(_render_structured_detail(value, nested=False))
+        return widgets
+    if item.key:
+        widgets.extend(_render_keyed_value(item.key, value))
+    else:
+        widgets.extend(_render_payload_detail(value))
+    return widgets
+
+
+def _json_type_name(value: Any) -> str:
+    """Return a short JSON-oriented type name."""
+    if isinstance(value, dict):
+        return "object"
+    if isinstance(value, list):
+        return "array"
+    if isinstance(value, str):
+        return "string"
+    if isinstance(value, bool):
+        return "boolean"
+    if value is None:
+        return "null"
+    return type(value).__name__
+
+
+def _format_raw_path(path: tuple[str | int, ...]) -> str:
+    """Format a stable raw path for display."""
+    if not path:
+        return "$"
+    result = "$"
+    for segment in path:
+        if isinstance(segment, int):
+            result += f"[{segment}]"
+        elif segment.isidentifier():
+            result += f".{segment}"
+        else:
+            escaped = segment.replace("\\", "\\\\").replace('"', '\\"')
+            result += f'["{escaped}"]'
+    return result
+
+
+def _json_display_key(key: str) -> str:
+    """Return a user-facing label for a raw JSON field."""
+    special = {
+        "agentic_grader_guidance": "Grader Guidance",
+        "callId": "Call ID",
+        "completed": "Completed",
+        "context_files_draft": "Context Files URL",
+        "conversations": "Conversations",
+        "export_task_data_json": "Exported Task Data",
+        "final_output": "Final Output",
+        "from": "From",
+        "load_trajectories_s3": "Trajectory URL",
+        "model": "Model",
+        "prompt": "Prompt",
+        "quick_scores": "Quick Scores",
+        "quick_stats": "Quick Stats",
+        "setup_files_url": "Setup Files URL",
+        "submission_type": "Submission Type",
+        "task_data_review_report": "Task Data Review Report",
+        "task_name": "Task Name",
+        "task_solution": "Task Solution",
+        "timestamp": "Timestamp",
+        "trajectory": "Trajectory",
+        "value": "Value",
+    }
+    if key in special:
+        return special[key]
+    return key.replace("_", " ").title()
+
+
+def _dict_tree_label(key: str, value: Any) -> Text:
+    """Return a styled tree label for a dictionary child."""
+    label = Text(_json_display_key(key), style="bold cyan")
+    excerpt = _raw_excerpt(value)
+    if excerpt:
+        label.append(f" {excerpt}", style="default")
+    return label
+
+
+def _list_tree_label(
+    root_data: Any,
+    parent_path: tuple[str | int, ...],
+    index: int,
+    value: Any,
+) -> Text:
+    """Return a styled tree label for a list child."""
+    title = _list_item_title(root_data, parent_path, index, value)
+    label = Text(title, style="bold cyan")
+    excerpt = _raw_excerpt(value)
+    if excerpt and title == f"[{index}]":
+        label.append(f" {excerpt}", style="default")
+    return label
+
+
+def _list_item_title(
+    root_data: Any,
+    parent_path: tuple[str | int, ...],
+    index: int,
+    value: Any,
+) -> str:
+    """Return a human-facing title for one list item."""
+    if parent_path == () and _looks_like_bundle(root_data):
+        return _bundle_item_title(index, value)
+    if parent_path == ("conversations",) and _looks_like_hermes(root_data):
+        return _hermes_item_title(index, value)
+    return f"[{index}]"
+
+
+def _bundle_item_title(index: int, value: Any) -> str:
+    """Return a human label for one trajectory bundle item."""
+    if not isinstance(value, dict):
+        return f"[{index}]"
+    trajectory = _try_decode_json(str(value.get("trajectory", "")))
+    if not isinstance(trajectory, dict):
+        return f"[{index}] Run"
+    metadata = trajectory.get("metadata", {})
+    model = metadata.get("llm_model") or metadata.get("llm_provider") or "run"
+    trajectory_id = str(metadata.get("trajectory_id") or "")
+    suffix = trajectory_id[-6:] if trajectory_id else str(index + 1)
+    return f"[{index}] {model} #{suffix}"
+
+
+def _hermes_item_title(index: int, value: Any) -> str:
+    """Return a human label for one Hermes conversation item."""
+    if not isinstance(value, dict):
+        return f"[{index}]"
+    speaker = str(value.get("from") or "entry").title()
+    excerpt = _clip(_single_line(str(value.get("value") or "")), 48)
+    return f"[{index}] {speaker}" if not excerpt else f"[{index}] {speaker} {excerpt}"
+
+
+def _raw_excerpt(value: Any) -> str:
+    """Return a short inline excerpt for raw JSON tree labels."""
+    if isinstance(value, str):
+        return _clip(_single_line(value), 48)
+    if isinstance(value, bool):
+        return str(value).lower()
+    if value is None:
+        return "null"
+    if isinstance(value, int | float):
+        return str(value)
+    if isinstance(value, list):
+        return f"[{len(value)}]"
+    if isinstance(value, dict):
+        return f"{{{len(value)}}}"
+    return ""
+
+
+def _overlay_trajectory_target(
+    root_data: Any,
+    value: Any,
+    raw_path: tuple[str | int, ...],
+) -> tuple[dict[str, Any] | None, tuple[str | int, ...]]:
+    """Return a trajectory value and raw base path for synthetic overlays."""
+    if raw_path == ():
+        if isinstance(root_data, dict) and not _is_bare_trajectory(root_data):
+            wrapped = extract_trajectory(root_data)
+            if wrapped is not None:
+                return wrapped, ("trajectory",)
+        if _is_bare_trajectory(value):
+            return value, raw_path
+        return None, raw_path
+
+    if raw_path == ("trajectory",) and isinstance(root_data, dict):
+        return None, raw_path
+
+    if _is_bare_trajectory(value):
+        return value, raw_path
+    return None, raw_path
+
+
+def _is_bare_trajectory(value: Any) -> bool:
+    """Return whether a dictionary is a bare trajectory object."""
+    return isinstance(value, dict) and isinstance(value.get("steps"), list)
+
+
+def _looks_like_submission(value: Any) -> bool:
+    """Return whether a JSON value looks like a submission artifact."""
+    keys = {
+        "agentic_grader_guidance",
+        "prompt",
+        "quick_scores",
+        "submission_type",
+        "task_name",
+    }
+    return isinstance(value, dict) and any(key in value for key in keys)
+
+
+def _looks_like_bundle(value: Any) -> bool:
+    """Return whether a JSON value looks like a trajectory bundle array."""
+    return (
+        isinstance(value, list)
+        and bool(value)
+        and all(
+            isinstance(item, dict)
+            and isinstance(item.get("task"), str)
+            and isinstance(item.get("trajectory"), str)
+            for item in value
+        )
+    )
+
+
+def _looks_like_hermes(value: Any) -> bool:
+    """Return whether a JSON value looks like the Hermes transcript sample."""
+    return (
+        isinstance(value, dict)
+        and isinstance(value.get("conversations"), list)
+        and any(key in value for key in ("model", "timestamp", "completed"))
+    )
+
+
+def _submission_summary_payload(value: dict[str, Any]) -> dict[str, Any]:
+    """Return a compact submission summary payload for detail rendering."""
+    summary: dict[str, Any] = {}
+    for key in (
+        "task_name",
+        "submission_type",
+        "quick_scores",
+        "quick_stats",
+        "prompt",
+        "agentic_grader_guidance",
+        "task_solution",
+        "load_trajectories_s3",
+        "export_task_data_json",
+    ):
+        if key in value and value[key] not in (None, ""):
+            summary[key] = value[key]
+    return summary
+
+
+def _bundle_summary(value: list[Any]) -> dict[str, Any]:
+    """Return a compact summary for a trajectory bundle file."""
+    models: list[str] = []
+    for item in value:
+        if not isinstance(item, dict):
+            continue
+        trajectory = _try_decode_json(str(item.get("trajectory", "")))
+        if not isinstance(trajectory, dict):
+            continue
+        model = trajectory.get("metadata", {}).get("llm_model")
+        if model and model not in models:
+            models.append(str(model))
+    return {
+        "runs": len(value),
+        "models": ", ".join(models) if models else "(unknown)",
+    }
+
+
+def _hermes_summary(value: dict[str, Any]) -> dict[str, Any]:
+    """Return a compact summary for a Hermes transcript."""
+    return {
+        "model": value.get("model"),
+        "timestamp": value.get("timestamp"),
+        "completed": value.get("completed"),
+        "conversations": len(value.get("conversations", [])),
+    }
+
+
+def _trajectory_event_path(
+    base_path: tuple[str | int, ...],
+    step_index: int,
+    events: list[TrajectoryEvent],
+    event: TrajectoryEvent | None,
+) -> tuple[str | int, ...] | None:
+    """Return the raw path for one normalized trajectory event."""
+    if event is None:
+        return None
+    for output_index, candidate in enumerate(events):
+        if candidate.raw is event.raw:
+            return base_path + ("steps", step_index, "output", output_index)
+    return None
+
+
+def _interaction_payload(interaction: ToolInteraction) -> dict[str, Any]:
+    """Return a compact combined payload for one tool interaction."""
+    return {
+        "tool": interaction.tool_name,
+        "call_id": interaction.call_id,
+        "input": interaction.call_event.raw if interaction.call_event else None,
+        "output": interaction.result_event.raw if interaction.result_event else None,
+    }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ from rich.syntax import Syntax
 from rich.text import Text
 from textual.widgets import Collapsible, Static, Tree
 
-from skim import TrajectoryViewer
+from skim import JsonInspector, TrajectoryViewer
 
 
 def sample_trajectory(
@@ -102,8 +102,8 @@ def _tree_labels(tree: Tree) -> list[str]:
     return [child.label.plain for child in tree.root.children]
 
 
-def _detail_text(viewer: TrajectoryViewer) -> str:
-    """Collect textual content from the rendered trajectory detail pane."""
+def _detail_text(viewer: TrajectoryViewer | JsonInspector) -> str:
+    """Collect textual content from the rendered detail pane."""
     parts = []
     for widget in viewer._detail_wrap.query(Static):
         content = _static_content(widget)
@@ -116,7 +116,7 @@ def _detail_text(viewer: TrajectoryViewer) -> str:
     return "\n".join(parts)
 
 
-def _detail_syntax_blocks(viewer: TrajectoryViewer) -> list[Syntax]:
+def _detail_syntax_blocks(viewer: TrajectoryViewer | JsonInspector) -> list[Syntax]:
     """Return all Syntax renderables mounted inside the detail pane."""
     return [
         _static_content(widget)
@@ -125,17 +125,17 @@ def _detail_syntax_blocks(viewer: TrajectoryViewer) -> list[Syntax]:
     ]
 
 
-def _top_level_collapsible_titles(viewer: TrajectoryViewer) -> list[str]:
+def _top_level_collapsible_titles(viewer: TrajectoryViewer | JsonInspector) -> list[str]:
     """Return titles for top-level collapsible sections in the detail pane."""
     return [child.title for child in viewer._detail_wrap.children if isinstance(child, Collapsible)]
 
 
-def _all_collapsible_titles(viewer: TrajectoryViewer) -> list[str]:
+def _all_collapsible_titles(viewer: TrajectoryViewer | JsonInspector) -> list[str]:
     """Return titles for all collapsible sections in the detail pane."""
     return [widget.title for widget in viewer._detail_wrap.query(Collapsible)]
 
 
-def _collapsible_by_title(viewer: TrajectoryViewer, title: str) -> Collapsible:
+def _collapsible_by_title(viewer: TrajectoryViewer | JsonInspector, title: str) -> Collapsible:
     """Return the first collapsible section with the requested title."""
     for widget in viewer._detail_wrap.query(Collapsible):
         if widget.title == title:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,6 +92,62 @@ def multi_step_trajectory(step_count: int) -> dict[str, Any]:
     return trajectory
 
 
+def sample_submission() -> dict[str, Any]:
+    """Return a small worker-submission fixture for the JSON inspector."""
+    return {
+        "task_name": "Factors affecting WHPs",
+        "submission_type": "Complete task",
+        "prompt": "Compare spray diary information.",
+        "quick_scores": "Model A: 32%",
+        "quick_stats": "2 strong signals",
+        "agentic_grader_guidance": "Identify Chlorpyrifos.",
+        "task_solution": "Chlorpyrifos appears slower to decay than expected.",
+        "load_trajectories_s3": "https://example.invalid/trajectory.json",
+        "export_task_data_json": json.dumps(
+            {
+                "task_name": "Factors affecting WHPs",
+                "notes": ["Look for repeated residue issues."],
+            }
+        ),
+    }
+
+
+def sample_bundle() -> list[dict[str, str]]:
+    """Return a small bundle fixture with embedded task and trajectory JSON strings."""
+    trajectory = sample_trajectory()
+    trajectory["metadata"]["trajectory_id"] = "bundle-traj-c98cf3"
+    trajectory["metadata"]["llm_model"] = "claude-opus-4-6"
+    return [
+        {
+            "version": "1.0.0",
+            "task": json.dumps(
+                {
+                    "task_id": "bundle-task-1",
+                    "prompt": "Compare industry spray diary information.",
+                }
+            ),
+            "trajectory": json.dumps(trajectory),
+            "setup_files_url": "https://example.invalid/setup.zip",
+        }
+    ]
+
+
+def sample_hermes_transcript() -> dict[str, Any]:
+    """Return a small Hermes-style transcript fixture."""
+    return {
+        "model": "anthropic/claude-sonnet-4.6",
+        "timestamp": "2026-04-14T22:00:00Z",
+        "completed": True,
+        "conversations": [
+            {"from": "system", "value": "You are a structured reviewer."},
+            {"from": "human", "value": "Please inspect the trajectories."},
+            {"from": "assistant", "value": "I will start with the summary."},
+            {"from": "tool", "value": '{"stdout": "Report line 1\\nReport line 2"}'},
+            {"from": "assistant", "value": "The key issue is Chlorpyrifos."},
+        ],
+    }
+
+
 def _static_content(widget: Static) -> object:
     """Return the private Static content object for focused test inspection."""
     return widget._Static__content

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -6,12 +6,17 @@ interaction tests or trajectory-detail rendering behavior.
 """
 
 import json
+from pathlib import Path
 
+import pytest
 from conftest import _static_content, _tree_labels, sample_trajectory
 from rich.syntax import Syntax
-from textual.widgets import Static
+from textual.widgets import Collapsible, Markdown, Static
 
 from skim import PreviewPane, SkimApp, SubmissionSummary, TrajectoryViewer, render_file
+from skim.preview import CsvPreview
+
+DATA_DIR = Path(__file__).resolve().parents[1] / "data"
 
 
 def test_generic_json_uses_syntax_preview(tmp_path):
@@ -24,6 +29,71 @@ def test_generic_json_uses_syntax_preview(tmp_path):
     assert len(widgets) == 1
     assert isinstance(widgets[0], Static)
     assert isinstance(_static_content(widgets[0]), Syntax)
+
+
+def test_csv_uses_specialized_preview(tmp_path):
+    """CSV files should use the specialized CSV preview widget."""
+    test_file = tmp_path / "example.csv"
+    test_file.write_text((DATA_DIR / "example.csv").read_text())
+
+    widgets = render_file(test_file)
+
+    assert len(widgets) == 1
+    assert isinstance(widgets[0], CsvPreview)
+
+
+def test_csv_preview_shows_table_and_raw_section():
+    """CSV preview should show a table summary plus a raw CSV section."""
+    widgets = render_file(DATA_DIR / "example.csv")
+
+    assert len(widgets) == 1
+    preview = widgets[0]
+    assert isinstance(preview, CsvPreview)
+    assert isinstance(preview._widgets[1], Static)
+    assert isinstance(_static_content(preview._widgets[1]), object)
+    raw = preview._widgets[2]
+    assert isinstance(raw, Collapsible)
+    assert raw.title == "Raw CSV"
+    assert raw.collapsed
+
+
+def test_csv_parse_error_shows_error_and_raw_content(tmp_path):
+    """Malformed CSV should stay visible with an explicit parse-error note."""
+    test_file = tmp_path / "broken.csv"
+    test_file.write_text('name,value\n"broken,1\n')
+
+    widgets = render_file(test_file)
+
+    assert len(widgets) == 1
+    preview = widgets[0]
+    assert isinstance(preview, CsvPreview)
+    error = preview._widgets[0]
+    assert isinstance(error, Static)
+    assert "CSV parse error:" in _static_content(error).plain
+    raw = preview._widgets[1]
+    assert isinstance(raw, Collapsible)
+    assert raw.title == "Raw CSV"
+    assert not raw.collapsed
+
+
+def test_csv_preview_caps_wide_and_long_content(tmp_path):
+    """CSV preview should cap rows, columns, and oversized cell values."""
+    test_file = tmp_path / "wide.csv"
+    header = ",".join(f"col_{index}" for index in range(10))
+    long_cell = "x" * 80
+    rows = [",".join([long_cell, *[f"value_{index}" for index in range(1, 10)]]) for _ in range(25)]
+    test_file.write_text("\n".join([header, *rows]))
+
+    widgets = render_file(test_file)
+
+    preview = widgets[0]
+    assert isinstance(preview, CsvPreview)
+    table = _static_content(preview._widgets[1])
+    assert len(table.columns) == 9
+    assert table.row_count == 20
+    first_cell = table.columns[0]._cells[0]
+    assert first_cell.endswith("…")
+    assert len(first_cell) == 24
 
 
 def test_invalid_json_falls_back_to_syntax_preview(tmp_path):
@@ -86,6 +156,72 @@ def test_submission_json_uses_submission_summary(tmp_path):
     text = widgets[0].summary_text.plain
     assert "Factors affecting WHPs" in text
     assert "https://example.invalid/trajectory.json" in text
+
+
+@pytest.mark.parametrize(
+    ("sample_name", "lexer"),
+    [
+        ("example.xml", "xml"),
+        ("example.toml", "toml"),
+        ("example.css", "css"),
+        ("example.html", "html"),
+        ("example.sql", "sql"),
+        ("example.yaml", "yaml"),
+    ],
+)
+def test_sample_backed_text_formats_use_expected_syntax_preview(sample_name, lexer):
+    """Sample-backed README formats should route to the expected syntax preview."""
+    widgets = render_file(DATA_DIR / sample_name)
+
+    assert len(widgets) == 1
+    assert isinstance(widgets[0], Static)
+    content = _static_content(widgets[0])
+    assert isinstance(content, Syntax)
+    assert content.lexer.name.lower() == lexer
+
+
+@pytest.mark.parametrize(
+    "sample_name",
+    [
+        "review_note.md",
+        "review_decision.md",
+        "review_instruction.md",
+        "score_submission.md",
+    ],
+)
+def test_sample_backed_markdown_formats_render_markdown(sample_name):
+    """Markdown samples should render through the Markdown widget."""
+    widgets = render_file(DATA_DIR / sample_name)
+
+    assert len(widgets) == 1
+    assert isinstance(widgets[0], Markdown)
+
+
+@pytest.mark.parametrize(
+    ("suffix", "lexer", "content"),
+    [
+        (".py", "python", "print('hello')\n"),
+        (".js", "javascript", "const x = 1;\n"),
+        (".ts", "typescript", "const x: number = 1;\n"),
+        (".sh", "bash", "echo hello\n"),
+        (".rs", "rust", "fn main() {}\n"),
+        (".go", "go", "package main\nfunc main() {}\n"),
+    ],
+)
+def test_synthetic_readme_formats_route_to_expected_syntax_preview(
+    tmp_path, suffix, lexer, content
+):
+    """README-listed formats without sample files should still use the expected lexer."""
+    test_file = tmp_path / f"example{suffix}"
+    test_file.write_text(content)
+
+    widgets = render_file(test_file)
+
+    assert len(widgets) == 1
+    assert isinstance(widgets[0], Static)
+    renderable = _static_content(widgets[0])
+    assert isinstance(renderable, Syntax)
+    assert renderable.lexer.name.lower() == lexer
 
 
 async def test_split_panes_keep_specialized_preview(tmp_path):

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -2,21 +2,27 @@
 
 This module covers how files are classified and routed into generic previews,
 the unified JSON inspector, or specialized non-JSON widgets such as CSV. It
-does not own app-shell interaction tests or trajectory-detail rendering behavior.
+uses tracked synthetic fixtures instead of ignored local sample files so CI and
+local runs exercise the same inputs.
 """
 
 import json
-from pathlib import Path
 
 import pytest
-from conftest import _detail_text, _static_content, _tree_labels, sample_trajectory
+from conftest import (
+    _detail_text,
+    _static_content,
+    _tree_labels,
+    sample_bundle,
+    sample_hermes_transcript,
+    sample_submission,
+    sample_trajectory,
+)
 from rich.syntax import Syntax
 from textual.widgets import Collapsible, Markdown, Static, Tree
 
 from skim import JsonInspector, PreviewPane, SkimApp, render_file
 from skim.preview import CsvPreview
-
-DATA_DIR = Path(__file__).resolve().parents[1] / "data"
 
 
 def test_generic_json_uses_json_inspector(tmp_path):
@@ -34,7 +40,7 @@ def test_generic_json_uses_json_inspector(tmp_path):
 def test_csv_uses_specialized_preview(tmp_path):
     """CSV files should use the specialized CSV preview widget."""
     test_file = tmp_path / "example.csv"
-    test_file.write_text((DATA_DIR / "example.csv").read_text())
+    test_file.write_text("name,value\napple,4\norange,7\n")
 
     widgets = render_file(test_file)
 
@@ -42,9 +48,12 @@ def test_csv_uses_specialized_preview(tmp_path):
     assert isinstance(widgets[0], CsvPreview)
 
 
-def test_csv_preview_shows_table_and_raw_section():
+def test_csv_preview_shows_table_and_raw_section(tmp_path):
     """CSV preview should show a table summary plus a raw CSV section."""
-    widgets = render_file(DATA_DIR / "example.csv")
+    test_file = tmp_path / "example.csv"
+    test_file.write_text("name,value\napple,4\norange,7\n")
+
+    widgets = render_file(test_file)
 
     assert len(widgets) == 1
     preview = widgets[0]
@@ -163,9 +172,11 @@ def test_submission_json_uses_json_inspector(tmp_path):
     assert "Trajectory URL https://example.invalid/trajectory.json" in labels
 
 
-async def test_submission_summary_node_renders_summary_detail():
+async def test_submission_summary_node_renders_summary_detail(tmp_path):
     """Selecting the submission summary node should keep the summary in the inspector."""
-    widgets = render_file(DATA_DIR / "Factors affecting WHPs - v2.json")
+    test_file = tmp_path / "submission.json"
+    test_file.write_text(json.dumps(sample_submission()))
+    widgets = render_file(test_file)
     inspector = widgets[0]
     assert isinstance(inspector, JsonInspector)
 
@@ -183,9 +194,11 @@ async def test_submission_summary_node_renders_summary_detail():
         assert "Grader Guidance" in detail
 
 
-def test_bundle_json_uses_json_inspector_with_human_run_labels():
+def test_bundle_json_uses_json_inspector_with_human_run_labels(tmp_path):
     """Trajectory bundles should use the inspector with human-labeled array items."""
-    widgets = render_file(DATA_DIR / "trajectories.json")
+    test_file = tmp_path / "trajectories.json"
+    test_file.write_text(json.dumps(sample_bundle()))
+    widgets = render_file(test_file)
 
     assert len(widgets) == 1
     inspector = widgets[0]
@@ -195,9 +208,11 @@ def test_bundle_json_uses_json_inspector_with_human_run_labels():
     assert labels[1].startswith("[0] claude-opus-4-6 #")
 
 
-async def test_bundle_item_detail_decodes_embedded_task_and_trajectory():
+async def test_bundle_item_detail_decodes_embedded_task_and_trajectory(tmp_path):
     """Selecting a bundle item should decode embedded JSON strings in the detail pane."""
-    widgets = render_file(DATA_DIR / "trajectories.json")
+    test_file = tmp_path / "trajectories.json"
+    test_file.write_text(json.dumps(sample_bundle()))
+    widgets = render_file(test_file)
     inspector = widgets[0]
     assert isinstance(inspector, JsonInspector)
 
@@ -216,9 +231,11 @@ async def test_bundle_item_detail_decodes_embedded_task_and_trajectory():
         assert "Final Output" in detail
 
 
-def test_hermes_json_uses_json_inspector_with_transcript_labels():
+def test_hermes_json_uses_json_inspector_with_transcript_labels(tmp_path):
     """Hermes transcripts should use the inspector with smart conversation labels."""
-    widgets = render_file(DATA_DIR / "hermes_trajectory.json")
+    test_file = tmp_path / "hermes_trajectory.json"
+    test_file.write_text(json.dumps(sample_hermes_transcript()))
+    widgets = render_file(test_file)
 
     assert len(widgets) == 1
     inspector = widgets[0]
@@ -226,37 +243,51 @@ def test_hermes_json_uses_json_inspector_with_transcript_labels():
     labels = _tree_labels(inspector._tree)
     assert labels[0] == "Transcript Summary"
     assert "Conversations [5]" in labels
-    conversation_labels = [child.label.plain for child in inspector._tree.root.children[1].children]
+    conversations_node = next(
+        child
+        for child in inspector._tree.root.children
+        if child.label.plain.startswith("Conversations ")
+    )
+    conversation_labels = [child.label.plain for child in conversations_node.children]
     assert conversation_labels[0].startswith("[0] System")
     assert conversation_labels[1].startswith("[1] Human")
 
 
-async def test_output_json_exposes_raw_path_on_selectable_nodes():
+async def test_output_json_exposes_raw_path_on_selectable_nodes(tmp_path):
     """Each selectable JSON-inspector node should carry a stable raw path."""
-    widgets = render_file(DATA_DIR / "output.json")
+    test_file = tmp_path / "output.json"
+    test_file.write_text(json.dumps({"trajectory": sample_trajectory()}))
+    widgets = render_file(test_file)
     inspector = widgets[0]
     assert isinstance(inspector, JsonInspector)
 
     metadata_node = inspector._tree.root.children[0]
-    trajectory_node = inspector._tree.root.children[6]
+    trajectory_node = next(
+        child
+        for child in inspector._tree.root.children
+        if child.label.plain.startswith("Trajectory ")
+    )
     assert metadata_node.data.raw_path == ("trajectory", "metadata")
     assert trajectory_node.data.raw_path == ("trajectory",)
 
 
 @pytest.mark.parametrize(
-    ("sample_name", "lexer"),
+    ("filename", "lexer", "content"),
     [
-        ("example.xml", "xml"),
-        ("example.toml", "toml"),
-        ("example.css", "css"),
-        ("example.html", "html"),
-        ("example.sql", "sql"),
-        ("example.yaml", "yaml"),
+        ("example.xml", "xml", "<root><item>value</item></root>\n"),
+        ("example.toml", "toml", 'title = "skim"\n[tool]\nname = "preview"\n'),
+        ("example.css", "css", "body { color: #333; }\n"),
+        ("example.html", "html", "<!doctype html><html><body>skim</body></html>\n"),
+        ("example.sql", "sql", "select * from trajectories;\n"),
+        ("example.yaml", "yaml", "name: skim\nmode: preview\n"),
     ],
 )
-def test_sample_backed_text_formats_use_expected_syntax_preview(sample_name, lexer):
-    """Sample-backed README formats should route to the expected syntax preview."""
-    widgets = render_file(DATA_DIR / sample_name)
+def test_text_formats_use_expected_syntax_preview(tmp_path, filename, lexer, content):
+    """Tracked synthetic text fixtures should route to the expected syntax preview."""
+    test_file = tmp_path / filename
+    test_file.write_text(content)
+
+    widgets = render_file(test_file)
 
     assert len(widgets) == 1
     assert isinstance(widgets[0], Static)
@@ -266,7 +297,7 @@ def test_sample_backed_text_formats_use_expected_syntax_preview(sample_name, lex
 
 
 @pytest.mark.parametrize(
-    "sample_name",
+    "filename",
     [
         "review_note.md",
         "review_decision.md",
@@ -274,9 +305,12 @@ def test_sample_backed_text_formats_use_expected_syntax_preview(sample_name, lex
         "score_submission.md",
     ],
 )
-def test_sample_backed_markdown_formats_render_markdown(sample_name):
-    """Markdown samples should render through the Markdown widget."""
-    widgets = render_file(DATA_DIR / sample_name)
+def test_markdown_formats_render_markdown(tmp_path, filename):
+    """Tracked synthetic markdown fixtures should render through Markdown."""
+    test_file = tmp_path / filename
+    test_file.write_text("# Heading\n\n- item one\n- item two\n")
+
+    widgets = render_file(test_file)
 
     assert len(widgets) == 1
     assert isinstance(widgets[0], Markdown)

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -1,34 +1,34 @@
 """Preview-routing tests for skim.
 
 This module covers how files are classified and routed into generic previews,
-submission summaries, or specialized trajectory viewers. It does not own app-shell
-interaction tests or trajectory-detail rendering behavior.
+the unified JSON inspector, or specialized non-JSON widgets such as CSV. It
+does not own app-shell interaction tests or trajectory-detail rendering behavior.
 """
 
 import json
 from pathlib import Path
 
 import pytest
-from conftest import _static_content, _tree_labels, sample_trajectory
+from conftest import _detail_text, _static_content, _tree_labels, sample_trajectory
 from rich.syntax import Syntax
-from textual.widgets import Collapsible, Markdown, Static
+from textual.widgets import Collapsible, Markdown, Static, Tree
 
-from skim import PreviewPane, SkimApp, SubmissionSummary, TrajectoryViewer, render_file
+from skim import JsonInspector, PreviewPane, SkimApp, render_file
 from skim.preview import CsvPreview
 
 DATA_DIR = Path(__file__).resolve().parents[1] / "data"
 
 
-def test_generic_json_uses_syntax_preview(tmp_path):
-    """Generic JSON keeps the syntax-highlighted preview."""
+def test_generic_json_uses_json_inspector(tmp_path):
+    """Generic JSON now uses the unified JSON inspector."""
     test_file = tmp_path / "plain.json"
     test_file.write_text(json.dumps({"hello": "world"}))
 
     widgets = render_file(test_file)
 
     assert len(widgets) == 1
-    assert isinstance(widgets[0], Static)
-    assert isinstance(_static_content(widgets[0]), Syntax)
+    assert isinstance(widgets[0], JsonInspector)
+    assert _tree_labels(widgets[0]._tree) == ["Hello world"]
 
 
 def test_csv_uses_specialized_preview(tmp_path):
@@ -108,33 +108,37 @@ def test_invalid_json_falls_back_to_syntax_preview(tmp_path):
     assert isinstance(_static_content(widgets[0]), Syntax)
 
 
-def test_wrapped_trajectory_json_uses_trajectory_viewer(tmp_path):
-    """A wrapped raw trajectory uses the trajectory viewer."""
+def test_wrapped_trajectory_json_uses_json_inspector(tmp_path):
+    """A wrapped raw trajectory uses the unified JSON inspector."""
     test_file = tmp_path / "output.json"
     test_file.write_text(json.dumps({"trajectory": sample_trajectory()}))
 
     widgets = render_file(test_file)
 
     assert len(widgets) == 1
-    assert isinstance(widgets[0], TrajectoryViewer)
-    assert len(widgets[0].events) == 4
-    assert _tree_labels(widgets[0]._tree) == ["Metadata", "Final Output", "Step 1"]
+    assert isinstance(widgets[0], JsonInspector)
+    assert _tree_labels(widgets[0]._tree)[:4] == [
+        "Metadata",
+        "Final Output",
+        "Step 1",
+        "Trajectory {4}",
+    ]
 
 
-def test_bare_trajectory_json_uses_trajectory_viewer(tmp_path):
-    """A bare trajectory object uses the trajectory viewer."""
+def test_bare_trajectory_json_uses_json_inspector(tmp_path):
+    """A bare trajectory object uses the unified JSON inspector."""
     test_file = tmp_path / "trajectory.json"
     test_file.write_text(json.dumps(sample_trajectory()))
 
     widgets = render_file(test_file)
 
     assert len(widgets) == 1
-    assert isinstance(widgets[0], TrajectoryViewer)
-    assert len(widgets[0].events) == 4
+    assert isinstance(widgets[0], JsonInspector)
+    assert _tree_labels(widgets[0]._tree)[:3] == ["Metadata", "Final Output", "Step 1"]
 
 
-def test_submission_json_uses_submission_summary(tmp_path):
-    """Worker submission JSON uses the submission summary viewer."""
+def test_submission_json_uses_json_inspector(tmp_path):
+    """Worker submission JSON uses the unified inspector with summary nodes."""
     test_file = tmp_path / "submission.json"
     test_file.write_text(
         json.dumps(
@@ -152,10 +156,91 @@ def test_submission_json_uses_submission_summary(tmp_path):
     widgets = render_file(test_file)
 
     assert len(widgets) == 1
-    assert isinstance(widgets[0], SubmissionSummary)
-    text = widgets[0].summary_text.plain
-    assert "Factors affecting WHPs" in text
-    assert "https://example.invalid/trajectory.json" in text
+    assert isinstance(widgets[0], JsonInspector)
+    labels = _tree_labels(widgets[0]._tree)
+    assert labels[0] == "Submission Summary"
+    assert "Task Name Factors affecting WHPs" in labels
+    assert "Trajectory URL https://example.invalid/trajectory.json" in labels
+
+
+async def test_submission_summary_node_renders_summary_detail():
+    """Selecting the submission summary node should keep the summary in the inspector."""
+    widgets = render_file(DATA_DIR / "Factors affecting WHPs - v2.json")
+    inspector = widgets[0]
+    assert isinstance(inspector, JsonInspector)
+
+    app = SkimApp(path=".")
+    async with app.run_test() as pilot:
+        pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
+        await pane.mount(inspector)
+        summary_node = inspector._tree.root.children[0]
+        inspector.on_tree_node_selected(Tree.NodeSelected(summary_node))
+        await pilot.pause()
+
+        detail = _detail_text(inspector)
+        assert "Task Name:" in detail
+        assert "Submission Type:" in detail
+        assert "Grader Guidance" in detail
+
+
+def test_bundle_json_uses_json_inspector_with_human_run_labels():
+    """Trajectory bundles should use the inspector with human-labeled array items."""
+    widgets = render_file(DATA_DIR / "trajectories.json")
+
+    assert len(widgets) == 1
+    inspector = widgets[0]
+    assert isinstance(inspector, JsonInspector)
+    labels = _tree_labels(inspector._tree)
+    assert labels[0] == "Bundle Summary"
+    assert labels[1].startswith("[0] claude-opus-4-6 #")
+
+
+async def test_bundle_item_detail_decodes_embedded_task_and_trajectory():
+    """Selecting a bundle item should decode embedded JSON strings in the detail pane."""
+    widgets = render_file(DATA_DIR / "trajectories.json")
+    inspector = widgets[0]
+    assert isinstance(inspector, JsonInspector)
+
+    app = SkimApp(path=".")
+    async with app.run_test() as pilot:
+        pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
+        await pane.mount(inspector)
+        item_node = inspector._tree.root.children[1]
+        inspector.on_tree_node_selected(Tree.NodeSelected(item_node))
+        await pilot.pause()
+
+        detail = _detail_text(inspector)
+        assert "Task" in detail
+        assert "Trajectory" in detail
+        assert "claude-opus-4-6" in detail
+        assert "Final Output" in detail
+
+
+def test_hermes_json_uses_json_inspector_with_transcript_labels():
+    """Hermes transcripts should use the inspector with smart conversation labels."""
+    widgets = render_file(DATA_DIR / "hermes_trajectory.json")
+
+    assert len(widgets) == 1
+    inspector = widgets[0]
+    assert isinstance(inspector, JsonInspector)
+    labels = _tree_labels(inspector._tree)
+    assert labels[0] == "Transcript Summary"
+    assert "Conversations [5]" in labels
+    conversation_labels = [child.label.plain for child in inspector._tree.root.children[1].children]
+    assert conversation_labels[0].startswith("[0] System")
+    assert conversation_labels[1].startswith("[1] Human")
+
+
+async def test_output_json_exposes_raw_path_on_selectable_nodes():
+    """Each selectable JSON-inspector node should carry a stable raw path."""
+    widgets = render_file(DATA_DIR / "output.json")
+    inspector = widgets[0]
+    assert isinstance(inspector, JsonInspector)
+
+    metadata_node = inspector._tree.root.children[0]
+    trajectory_node = inspector._tree.root.children[6]
+    assert metadata_node.data.raw_path == ("trajectory", "metadata")
+    assert trajectory_node.data.raw_path == ("trajectory",)
 
 
 @pytest.mark.parametrize(
@@ -237,24 +322,24 @@ async def test_split_panes_keep_specialized_preview(tmp_path):
         pane.show_file(test_file)
 
         assert app._total_panes() == 2
-        assert isinstance(pane.query_one(TrajectoryViewer), TrajectoryViewer)
+        assert isinstance(pane.query_one(JsonInspector), JsonInspector)
 
 
 async def test_non_trajectory_previews_do_not_mount_local_footer(tmp_path):
-    """Only trajectory previews should render a local footer."""
-    generic = tmp_path / "data.json"
-    generic.write_text('{"alpha": 1}')
-    submission = tmp_path / "submission.json"
-    submission.write_text('{"task_name": "Task", "submission_type": "worker", "prompt": "Prompt"}')
+    """Only JSON tree/detail previews should render the local footer."""
+    markdown = tmp_path / "note.md"
+    markdown.write_text("# Note\n")
+    csv_file = tmp_path / "data.csv"
+    csv_file.write_text("a,b\n1,2\n")
     app = SkimApp(path=str(tmp_path))
 
     async with app.run_test() as pilot:
         pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
 
-        pane.show_file(generic)
+        pane.show_file(markdown)
         await pilot.pause()
         assert not pane.query(".trajectory-footer")
 
-        pane.show_file(submission)
+        pane.show_file(csv_file)
         await pilot.pause()
         assert not pane.query(".trajectory-footer")


### PR DESCRIPTION
## Summary
- unify JSON file handling under one structural `JsonInspector`
- add schema-aware overlays for trajectories, submissions, bundle JSON, and Hermes transcripts
- preserve stable raw JSON paths on selectable nodes for future annotation work

## Validation
- `uv run pytest`
- `uv run ruff check .`
- `uv run ruff format --check .`