### PR TITLE
[codex] add JSON annotation review flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ CLAUDE.md
 docs/v1/
 data/
 .ruff_cache/
+.skim/

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Zheng Shi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # skim
 
-A terminal UI for browsing folders and previewing files. Built with [Textual](https://textual.textualize.io/).
+A terminal UI for browsing folders and reviewing local artifacts. Built with
+[Textual](https://textual.textualize.io/).
 
-Point it at any directory to get a file tree on the left and a content preview on the right, with syntax highlighting, markdown rendering, and a flexible split pane system.
+Point it at any directory to get a file tree on the left and a content preview on the
+right, with syntax highlighting, markdown rendering, split panes, and a JSON inspector
+that now supports local node annotations.
 
 ## Install
 
@@ -19,6 +22,7 @@ Requires Python 3.12 or newer.
 ```bash
 uv run skim              # open current directory
 uv run skim ~/my/folder  # open a specific folder
+uv run skim-dev          # launch Textual dev mode
 ```
 
 ## Keybindings
@@ -30,27 +34,72 @@ uv run skim ~/my/folder  # open a specific folder
 | `Enter` | Open the selected file from the tree |
 | `Esc` | Leave file-tree mode or return from trajectory detail to the trajectory tree |
 | `Up/Down` or `j/k` | Scroll the active preview pane |
+| `PageUp/PageDown` | Page-scroll the active preview pane or JSON detail panel |
 | `s` then arrow or `h/j/k/l` | Split in a direction |
 | `d` | Close the active pane |
 | `w` | Cycle to the next pane |
 | `q` | Quit |
 
-Trajectory previews have their own local controls shown in the viewer footer:
+Specialized previews also show local command footers.
+
+Trajectory previews use a tree/detail model:
 
 | Key | Action |
 |---|---|
-| `Up/Down` | Move through the trajectory tree while in JSON mode |
+| `Up/Down` | Move through the trajectory tree while in tree mode |
 | `Left/Right` | Collapse, expand, or move across trajectory tree branches |
 | `Enter` | Open the selected trajectory node in the detail pane |
 | `Esc` | Return from the detail pane to the trajectory tree |
+
+JSON previews use a live inspector model:
+
+| Key | Action |
+|---|---|
+| `Up/Down` | Move the JSON tree cursor |
+| `Left/Right` | Collapse, expand, or move across JSON tree branches |
+| `PageUp/PageDown` | Scroll the right-hand detail panel |
+| `a` | Open the annotation editor for the selected annotatable node |
+
+Inside the annotation modal:
+
+| Key | Action |
+|---|---|
+| `Esc` | Close the modal |
+| `Tab` | Move to the next editor control |
+| `Enter` in tags | Jump directly to the note field |
+| `PageUp/PageDown` | Scroll the right-hand node preview |
 
 ## Split panes
 
 You can have up to 6 panes arranged in a 2 row by 3 column grid. Press `s` followed by a direction key to split. The active pane is highlighted with a border. Click a pane or press `w` to switch which pane is active. New files always open in the active pane.
 
-## Supported file types
+## JSON review workflow
 
-Syntax highlighting works for Python, JSON, JavaScript, TypeScript, HTML, CSS, YAML, TOML, Bash, Rust, Go, SQL, and XML. Markdown files are rendered with formatting. JSON files are pretty printed automatically. CSV files render as a compact table preview with the raw CSV available below it. Files over 1MB are skipped to keep things responsive.
+JSON files open in a structural inspector rather than a plain text dump. The inspector:
+
+- shows a tree on the left and detail panels on the right
+- adds schema-aware overlays for supported artifacts such as raw trajectories, bundles,
+  submissions, and Hermes-style transcripts
+- keeps annotations local in `<browse-root>/.skim/review.json`
+- marks annotated nodes in the tree and shows annotation state in a separate status panel
+- opens a split annotation modal with tags and note editing on the left and a read-only
+  preview of the selected node on the right
+
+Annotations bind to the underlying raw JSON location, using `annotation_path` when an
+overlay node maps to a raw node and falling back to `raw_path` otherwise.
+
+## Supported file types and limits
+
+Syntax highlighting works for Python, JSON, JavaScript, TypeScript, HTML, CSS, YAML,
+TOML, Bash, Rust, Go, SQL, and XML. Markdown files are rendered with formatting.
+
+JSON files are parsed into the inspector described above. CSV files render as a compact
+table preview with the raw CSV available below it, capped for readability. Non-JSON,
+non-Markdown text formats fall back to syntax-highlighted source when a lexer is
+available.
+
+Files over `1MB` are skipped to keep text previews responsive. JSON files get a higher
+limit of `10MB`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ A terminal UI for browsing folders and reviewing local artifacts. Built with
 [Textual](https://textual.textualize.io/).
 
 Point it at any directory to get a file tree on the left and a content preview on the
-right, with syntax highlighting, markdown rendering, split panes, and a JSON inspector
-that now supports local node annotations.
+right, with syntax highlighting, markdown rendering, split panes, and a **JSON inspector**
+that now supports `local node annotations`.
 
 ## Install
 

--- a/src/skim/app.py
+++ b/src/skim/app.py
@@ -111,9 +111,6 @@ class SkimApp(App):
         padding: 0 1;
         border: round $panel-lighten-1;
     }
-    .annotation-modal-panel-active {
-        border: round $accent;
-    }
     #annotation-editor-panel {
         width: 2fr;
         margin: 0 1 0 0;
@@ -283,6 +280,12 @@ class SkimApp(App):
         """Return whether a modal screen currently owns keyboard interaction."""
         return isinstance(self.screen, ModalScreen)
 
+    def check_action(self, action: str, parameters: tuple[object, ...]) -> bool | None:
+        """Disable app-level arrow scrolling while a modal owns focus."""
+        if self._modal_is_active() and action in {"scroll_up", "scroll_down"}:
+            return False
+        return super().check_action(action, parameters)
+
     def action_quit(self) -> None:
         """Quit the app unless a modal screen is active."""
         if self._modal_is_active():
@@ -313,10 +316,6 @@ class SkimApp(App):
     def action_scroll_down(self) -> None:
         """Scroll down in the active pane or confirm a downward split."""
         if self._modal_is_active():
-            screen = self.screen
-            action = getattr(screen, "action_move_editor_down", None)
-            if callable(action):
-                action()
             return
         if self.split_mode:
             self.split_mode = False
@@ -334,10 +333,6 @@ class SkimApp(App):
     def action_scroll_up(self) -> None:
         """Scroll up in the active pane or confirm an upward split."""
         if self._modal_is_active():
-            screen = self.screen
-            action = getattr(screen, "action_move_editor_up", None)
-            if callable(action):
-                action()
             return
         if self.split_mode:
             self.split_mode = False

--- a/src/skim/app.py
+++ b/src/skim/app.py
@@ -25,6 +25,7 @@ from .trajectory import JsonInspector, TrajectoryViewer
 MAX_ROWS = 2
 MAX_COLS = 3
 SCROLL_STEP = 3
+PAGE_SCROLL_STEP = 20
 
 
 class SkimApp(App):
@@ -145,6 +146,8 @@ class SkimApp(App):
         Binding("down", "scroll_down", show=False, priority=True),
         Binding("j", "scroll_down", show=False, priority=True),
         Binding("k", "scroll_up", show=False, priority=True),
+        Binding("pageup", "page_up", show=False, priority=True),
+        Binding("pagedown", "page_down", show=False, priority=True),
         Binding("f", "focus_file_tree", show=False),
         Binding("s", "enter_split", show=False),
         Binding("d", "close_pane", show=False),
@@ -338,6 +341,34 @@ class SkimApp(App):
         if self._modal_is_active():
             return
         self.query_one(DirectoryTree).action_select_cursor()
+
+    def action_page_down(self) -> None:
+        """Scroll the active content by a page-sized amount."""
+        if self._modal_is_active():
+            return
+        try:
+            pane = self.query_one(f"#{self.active_pane_id}", PreviewPane)
+            viewer = pane.active_json_navigator()
+            if isinstance(viewer, JsonInspector):
+                viewer.scroll_detail(PAGE_SCROLL_STEP)
+                return
+            pane.scroll_relative(y=PAGE_SCROLL_STEP, animate=False)
+        except Exception:
+            pass
+
+    def action_page_up(self) -> None:
+        """Scroll the active content up by a page-sized amount."""
+        if self._modal_is_active():
+            return
+        try:
+            pane = self.query_one(f"#{self.active_pane_id}", PreviewPane)
+            viewer = pane.active_json_navigator()
+            if isinstance(viewer, JsonInspector):
+                viewer.scroll_detail(-PAGE_SCROLL_STEP)
+                return
+            pane.scroll_relative(y=-PAGE_SCROLL_STEP, animate=False)
+        except Exception:
+            pass
 
     def on_key(self, event: Key) -> None:
         """Handle split-mode keys and tree navigation shortcuts."""

--- a/src/skim/app.py
+++ b/src/skim/app.py
@@ -83,6 +83,26 @@ class SkimApp(App):
         padding: 0 1;
         margin: 1 0 0 0;
     }
+    #annotation-modal {
+        width: 80;
+        max-width: 90%;
+        height: auto;
+        max-height: 85%;
+        padding: 1 2;
+        border: round $accent;
+        background: $surface;
+    }
+    .annotation-modal-actions {
+        height: auto;
+        margin: 1 0 0 0;
+    }
+    #annotation-tags {
+        margin: 1 0 0 0;
+    }
+    #annotation-note {
+        height: 8;
+        margin: 1 0 0 0;
+    }
     Collapsible.trajectory-section {
         margin: 0 0 1 0;
     }
@@ -348,6 +368,12 @@ class SkimApp(App):
 
         if viewer is not None and event.key == "enter":
             if viewer.handle_enter_key():
+                event.prevent_default()
+                event.stop()
+                return
+
+        if isinstance(viewer, JsonInspector) and event.key == "a":
+            if viewer.handle_annotation_key():
                 event.prevent_default()
                 event.stop()
                 return

--- a/src/skim/app.py
+++ b/src/skim/app.py
@@ -98,13 +98,32 @@ class SkimApp(App):
         margin: 1 0 0 0;
     }
     #annotation-modal {
-        width: 80;
-        max-width: 90%;
-        height: auto;
-        max-height: 85%;
-        padding: 1 2;
+        width: 140;
+        max-width: 96%;
+        height: 80%;
+        max-height: 90%;
+        padding: 1;
         border: round $accent;
         background: $surface;
+    }
+    .annotation-modal-panel {
+        height: 1fr;
+        padding: 0 1;
+        border: round $panel-lighten-1;
+    }
+    .annotation-modal-panel-active {
+        border: round $accent;
+    }
+    #annotation-editor-panel {
+        width: 2fr;
+        margin: 0 1 0 0;
+    }
+    #annotation-preview-panel {
+        width: 3fr;
+    }
+    .annotation-modal-preview {
+        height: 1fr;
+        margin: 1 0 0 0;
     }
     .annotation-modal-actions {
         height: auto;
@@ -114,7 +133,8 @@ class SkimApp(App):
         margin: 1 0 0 0;
     }
     #annotation-note {
-        height: 8;
+        height: 1fr;
+        min-height: 8;
         margin: 1 0 0 0;
     }
     Collapsible.trajectory-section {
@@ -293,6 +313,10 @@ class SkimApp(App):
     def action_scroll_down(self) -> None:
         """Scroll down in the active pane or confirm a downward split."""
         if self._modal_is_active():
+            screen = self.screen
+            action = getattr(screen, "action_move_editor_down", None)
+            if callable(action):
+                action()
             return
         if self.split_mode:
             self.split_mode = False
@@ -310,6 +334,10 @@ class SkimApp(App):
     def action_scroll_up(self) -> None:
         """Scroll up in the active pane or confirm an upward split."""
         if self._modal_is_active():
+            screen = self.screen
+            action = getattr(screen, "action_move_editor_up", None)
+            if callable(action):
+                action()
             return
         if self.split_mode:
             self.split_mode = False
@@ -345,6 +373,10 @@ class SkimApp(App):
     def action_page_down(self) -> None:
         """Scroll the active content by a page-sized amount."""
         if self._modal_is_active():
+            screen = self.screen
+            action = getattr(screen, "action_scroll_preview_down", None)
+            if callable(action):
+                action()
             return
         try:
             pane = self.query_one(f"#{self.active_pane_id}", PreviewPane)
@@ -359,6 +391,10 @@ class SkimApp(App):
     def action_page_up(self) -> None:
         """Scroll the active content up by a page-sized amount."""
         if self._modal_is_active():
+            screen = self.screen
+            action = getattr(screen, "action_scroll_preview_up", None)
+            if callable(action):
+                action()
             return
         try:
             pane = self.query_one(f"#{self.active_pane_id}", PreviewPane)

--- a/src/skim/app.py
+++ b/src/skim/app.py
@@ -15,6 +15,7 @@ from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical
 from textual.events import Key
+from textual.screen import ModalScreen
 from textual.widgets import Header, Static
 
 from .preview import PreviewPane
@@ -68,8 +69,20 @@ class SkimApp(App):
         min-width: 28;
         height: 1fr;
     }
-    .trajectory-detail-wrap {
+    .trajectory-detail-column {
         width: 2fr;
+        height: 1fr;
+    }
+    .annotation-status-panel {
+        height: 8;
+        min-height: 8;
+        border: round $panel-lighten-1;
+        background: $surface-lighten-1;
+        padding: 0 1;
+        margin: 0 0 1 0;
+    }
+    .trajectory-detail-wrap {
+        width: 1fr;
         height: 1fr;
         padding: 0 1;
     }
@@ -243,8 +256,20 @@ class SkimApp(App):
         """Refresh the global status bar text."""
         self.query_one("#status-bar", Static).update(self._status_text())
 
+    def _modal_is_active(self) -> bool:
+        """Return whether a modal screen currently owns keyboard interaction."""
+        return isinstance(self.screen, ModalScreen)
+
+    def action_quit(self) -> None:
+        """Quit the app unless a modal screen is active."""
+        if self._modal_is_active():
+            return
+        self.exit()
+
     def action_focus_file_tree(self) -> None:
         """Toggle focus between the file tree and the active preview pane."""
+        if self._modal_is_active():
+            return
         if self.file_tree_mode:
             self.exit_file_tree_mode()
             return
@@ -264,6 +289,8 @@ class SkimApp(App):
 
     def action_scroll_down(self) -> None:
         """Scroll down in the active pane or confirm a downward split."""
+        if self._modal_is_active():
+            return
         if self.split_mode:
             self.split_mode = False
             self._split("down")
@@ -279,6 +306,8 @@ class SkimApp(App):
 
     def action_scroll_up(self) -> None:
         """Scroll up in the active pane or confirm an upward split."""
+        if self._modal_is_active():
+            return
         if self.split_mode:
             self.split_mode = False
             self._split("up")
@@ -294,18 +323,27 @@ class SkimApp(App):
 
     def action_tree_up(self) -> None:
         """Move the directory tree cursor up."""
+        if self._modal_is_active():
+            return
         self.query_one(DirectoryTree).action_cursor_up()
 
     def action_tree_down(self) -> None:
         """Move the directory tree cursor down."""
+        if self._modal_is_active():
+            return
         self.query_one(DirectoryTree).action_cursor_down()
 
     def action_tree_select(self) -> None:
         """Open the currently selected tree item."""
+        if self._modal_is_active():
+            return
         self.query_one(DirectoryTree).action_select_cursor()
 
     def on_key(self, event: Key) -> None:
         """Handle split-mode keys and tree navigation shortcuts."""
+        if self._modal_is_active():
+            return
+
         if self.split_mode:
             direction_map = {
                 "left": "left",
@@ -402,6 +440,8 @@ class SkimApp(App):
 
     def action_enter_split(self) -> None:
         """Enter split mode for the next direction key."""
+        if self._modal_is_active():
+            return
         if self._total_panes() >= MAX_ROWS * MAX_COLS:
             self.notify("Maximum 6 panes reached", severity="warning")
             return
@@ -450,6 +490,8 @@ class SkimApp(App):
 
     def action_close_pane(self) -> None:
         """Close the active pane unless it is the last one."""
+        if self._modal_is_active():
+            return
         if self._total_panes() <= 1:
             self.notify("Cannot close last pane", severity="warning")
             return
@@ -474,6 +516,8 @@ class SkimApp(App):
 
     def action_cycle_pane(self) -> None:
         """Cycle the active pane through the current grid order."""
+        if self._modal_is_active():
+            return
         panes = [pane_id for row in self.grid for pane_id in row]
         if len(panes) <= 1:
             return

--- a/src/skim/app.py
+++ b/src/skim/app.py
@@ -106,6 +106,9 @@ class SkimApp(App):
         border: round $accent;
         background: $surface;
     }
+    .annotation-modal-body {
+        height: 1fr;
+    }
     .annotation-modal-panel {
         height: 1fr;
         padding: 0 1;

--- a/src/skim/preview.py
+++ b/src/skim/preview.py
@@ -87,7 +87,8 @@ class PreviewPane(DragScrollMixin, VerticalScroll, can_focus=True):
         """Render a file into the pane."""
         self.current_path = path
         self.remove_children()
-        widgets = render_file(path)
+        browse_root = getattr(self.app, "browse_path", path.parent)
+        widgets = render_file(path, browse_root=browse_root)
         for widget in widgets:
             self.mount(widget)
         self.scroll_home(animate=False)
@@ -124,7 +125,7 @@ class PreviewPane(DragScrollMixin, VerticalScroll, can_focus=True):
         return viewer if isinstance(viewer, JsonInspector) else None
 
 
-def render_file(path: Path) -> list[Widget]:
+def render_file(path: Path, *, browse_root: Path | None = None) -> list[Widget]:
     """Return a list of widgets for the given file."""
     if not path.is_file():
         return [Static(Text(f"Not a file: {path.name}", style="red"))]
@@ -146,7 +147,13 @@ def render_file(path: Path) -> list[Widget]:
     if suffix == ".json":
         try:
             parsed = json.loads(content)
-            return [JsonInspector(parsed)]
+            return [
+                JsonInspector(
+                    parsed,
+                    source_path=path,
+                    review_root=browse_root or path.parent,
+                )
+            ]
         except json.JSONDecodeError:
             pass
 

--- a/src/skim/trajectory.py
+++ b/src/skim/trajectory.py
@@ -1335,7 +1335,6 @@ class JsonInspector(Vertical):
         self.review_root = resolved_root.resolve()
         self._annotation_store = annotation_store or AnnotationStore(self.review_root)
         self._current_item: JsonInspectorItem | None = None
-        self._input_mode = "tree"
         self._tree: DragTree = DragTree("JSON", classes="trajectory-tree")
         self._build_tree()
         first_item = self._tree.root.children[0].data if self._tree.root.children else None
@@ -1374,6 +1373,16 @@ class JsonInspector(Vertical):
             self._show_detail(item)
         event.stop()
 
+    def on_tree_node_highlighted(
+        self,
+        event: TextualTree.NodeHighlighted[JsonInspectorItem],
+    ) -> None:
+        """Update detail when the highlighted JSON tree node changes."""
+        item = event.node.data
+        if isinstance(item, JsonInspectorItem):
+            self._show_detail(item)
+        event.stop()
+
     def _show_detail(self, item: JsonInspectorItem) -> None:
         """Replace the detail pane with widgets for the selected tree item."""
         self._current_item = item
@@ -1389,38 +1398,29 @@ class JsonInspector(Vertical):
 
     def is_tree_mode(self) -> bool:
         """Return whether keyboard navigation is driving the left tree."""
-        return self._input_mode == "tree"
+        return True
 
     def focus_tree_mode(self) -> None:
-        """Route navigation input to the tree."""
-        self._input_mode = "tree"
-        self._update_footer()
+        """Route keyboard focus to the JSON tree."""
         self._ensure_tree_cursor()
         if self.is_attached:
             self._tree.focus(scroll_visible=False)
 
     def focus_detail_mode(self) -> None:
-        """Route navigation input to the rendered detail pane."""
-        self._input_mode = "detail"
-        self._update_footer()
-        if self.is_attached:
-            self._detail_wrap.focus(scroll_visible=False)
+        """Keep compatibility with callers that expect a detail-focus method."""
+        self.focus_tree_mode()
 
     def handle_vertical_key(self, delta: int) -> bool:
-        """Handle up/down keys for the active JSON sub-view."""
-        if self.is_tree_mode():
-            if delta < 0:
-                self._tree.action_cursor_up()
-            else:
-                self._tree.action_cursor_down()
-            return True
-        self.scroll_detail(delta)
+        """Handle up/down keys by moving the JSON tree cursor."""
+        self._ensure_tree_cursor()
+        if delta < 0:
+            self._tree.action_cursor_up()
+        else:
+            self._tree.action_cursor_down()
         return True
 
     def handle_horizontal_key(self, key: str) -> bool:
         """Handle left/right tree navigation."""
-        if not self.is_tree_mode():
-            return False
         node = self._tree.cursor_node
         if node is None:
             return False
@@ -1439,19 +1439,12 @@ class JsonInspector(Vertical):
         return False
 
     def handle_enter_key(self) -> bool:
-        """Select the current tree item and move focus to the detail pane."""
-        if not self.is_tree_mode():
-            return False
+        """Consume Enter without switching JSON focus modes."""
         self._ensure_tree_cursor()
-        self._tree.action_select_cursor()
-        self.focus_detail_mode()
         return True
 
     def handle_escape_key(self) -> bool:
-        """Return keyboard control from detail back to the tree."""
-        if self.is_tree_mode():
-            return False
-        self.focus_tree_mode()
+        """Consume Escape without switching JSON focus modes."""
         return True
 
     def handle_annotation_key(self) -> bool:
@@ -1479,32 +1472,22 @@ class JsonInspector(Vertical):
             self._tree.move_cursor(self._tree.root.children[0], animate=False)
 
     def _footer_text(self) -> Text:
-        """Build the mode-aware local footer text."""
+        """Build the JSON-inspector footer text."""
         text = Text()
-        if self.is_tree_mode():
-            text.append(" JSON ", style="reverse")
-            text.append(" ")
-            text.append("↑↓", style="bold")
-            text.append(" Move  ")
-            text.append("←→", style="bold")
-            text.append(" Branch  ")
-            text.append("a", style="bold")
-            text.append(" Annotate  ")
-            text.append("Enter", style="bold")
-            text.append(" Detail")
-        else:
-            text.append(" Detail ", style="reverse")
-            text.append(" ")
-            text.append("↑↓", style="bold")
-            text.append(" Scroll  ")
-            text.append("a", style="bold")
-            text.append(" Annotate  ")
-            text.append("Esc", style="bold")
-            text.append(" Back to JSON")
+        text.append(" JSON ", style="reverse")
+        text.append(" ")
+        text.append("↑↓", style="bold")
+        text.append(" Move  ")
+        text.append("←→", style="bold")
+        text.append(" Branch  ")
+        text.append("PgUp/Dn", style="bold")
+        text.append(" Scroll  ")
+        text.append("a", style="bold")
+        text.append(" Annotate")
         return text
 
     def _update_footer(self) -> None:
-        """Refresh the local footer after mode changes."""
+        """Refresh the local footer."""
         self._footer.update(self._footer_text())
 
     def _build_tree(self) -> None:

--- a/src/skim/trajectory.py
+++ b/src/skim/trajectory.py
@@ -1968,9 +1968,7 @@ def _annotation_panel_widgets(
 
     if annotation is None:
         widgets.extend(_metadata_fields([("Status", "No annotation"), ("Tags", "(none)")]))
-        widgets.append(
-            Static(Text("No annotation yet"), classes="annotation-status-body")
-        )
+        widgets.append(Static(Text("No annotation yet"), classes="annotation-status-body"))
         widgets.append(
             Static(Text("Press a to annotate", style="dim"), classes="annotation-status-hint")
         )

--- a/src/skim/trajectory.py
+++ b/src/skim/trajectory.py
@@ -121,25 +121,16 @@ class AnnotationStore:
         self.review_root = review_root.resolve()
         self.path = self.review_root / ".skim" / "review.json"
         self._payload = self._load()
+        self._file_annotations: dict[str, dict[str, AnnotationRecord]] = {}
 
     def annotations_for_file(self, source_path: Path) -> dict[str, AnnotationRecord]:
         """Return stored annotations for one source file."""
         relative_path = self.relative_file_path(source_path)
-        files = self._payload.get("files", {})
-        file_entry = files.get(relative_path, {})
-        annotations = file_entry.get("annotations", {})
-        result: dict[str, AnnotationRecord] = {}
-        for path, payload in annotations.items():
-            if not isinstance(path, str) or not isinstance(payload, dict):
-                continue
-            tags = payload.get("tags", [])
-            note = payload.get("note", "")
-            if isinstance(tags, list) and isinstance(note, str):
-                result[path] = AnnotationRecord(
-                    tags=tuple(str(tag) for tag in tags if str(tag).strip()),
-                    note=note,
-                )
-        return result
+        cached = self._file_annotations.get(relative_path)
+        if cached is None:
+            cached = self._build_annotations_for_relative_path(relative_path)
+            self._file_annotations[relative_path] = cached
+        return cached
 
     def get_annotation(self, source_path: Path, path: str) -> AnnotationRecord | None:
         """Return one annotation by file-relative JSON path."""
@@ -159,6 +150,7 @@ class AnnotationStore:
         file_entry = files.setdefault(relative_path, {"annotations": {}})
         annotations = file_entry.setdefault("annotations", {})
         annotations[path] = {"tags": list(tags), "note": note}
+        self.annotations_for_file(source_path)[path] = AnnotationRecord(tags=tags, note=note)
         self._save()
 
     def delete_annotation(self, source_path: Path, path: str) -> None:
@@ -168,6 +160,7 @@ class AnnotationStore:
         file_entry = files.setdefault(relative_path, {"annotations": {}})
         annotations = file_entry.setdefault("annotations", {})
         annotations.pop(path, None)
+        self.annotations_for_file(source_path).pop(path, None)
         self._save()
 
     def relative_file_path(self, source_path: Path) -> str:
@@ -191,6 +184,27 @@ class AnnotationStore:
         payload.setdefault("version", 1)
         payload.setdefault("files", {})
         return payload
+
+    def _build_annotations_for_relative_path(
+        self,
+        relative_path: str,
+    ) -> dict[str, AnnotationRecord]:
+        """Normalize stored annotations for one file path."""
+        files = self._payload.get("files", {})
+        file_entry = files.get(relative_path, {})
+        annotations = file_entry.get("annotations", {})
+        result: dict[str, AnnotationRecord] = {}
+        for path, payload in annotations.items():
+            if not isinstance(path, str) or not isinstance(payload, dict):
+                continue
+            tags = payload.get("tags", [])
+            note = payload.get("note", "")
+            if isinstance(tags, list) and isinstance(note, str):
+                result[path] = AnnotationRecord(
+                    tags=tuple(str(tag) for tag in tags if str(tag).strip()),
+                    note=note,
+                )
+        return result
 
     def _save(self) -> None:
         """Write the annotation payload to disk."""
@@ -418,11 +432,26 @@ def normalize_step_events(trajectory: dict[str, Any]) -> list[list[TrajectoryEve
 
 def normalize_step_timeline(trajectory: dict[str, Any]) -> list[list[StepTimelineItem]]:
     """Return per-step display rows, pairing tool calls with matching results."""
+    return _normalize_step_timeline_from_events(normalize_step_events(trajectory))
+
+
+def normalize_step_overlay(
+    trajectory: dict[str, Any],
+) -> tuple[list[list[TrajectoryEvent]], list[list[StepTimelineItem]]]:
+    """Return grouped trajectory events plus their paired timeline rows."""
+    step_events = normalize_step_events(trajectory)
+    return step_events, _normalize_step_timeline_from_events(step_events)
+
+
+def _normalize_step_timeline_from_events(
+    step_events: list[list[TrajectoryEvent]],
+) -> list[list[StepTimelineItem]]:
+    """Return per-step display rows from pre-normalized events."""
     timeline_groups: list[list[StepTimelineItem]] = []
-    for step_events in normalize_step_events(trajectory):
+    for events in step_events:
         group: list[StepTimelineItem] = []
         pending_calls: dict[str, int] = {}
-        for event in step_events:
+        for event in events:
             if event.kind == "function_call":
                 interaction = ToolInteraction(
                     index=event.index,
@@ -1160,8 +1189,7 @@ class TrajectoryViewer(Vertical):
         """Initialize the trajectory viewer."""
         super().__init__(classes="trajectory-viewer")
         self.trajectory = trajectory
-        self.step_events = normalize_step_events(trajectory)
-        self.step_items = normalize_step_timeline(trajectory)
+        self.step_events, self.step_items = normalize_step_overlay(trajectory)
         self.events = normalize_events(trajectory)
         self._input_mode = "tree"
         self._summary = Static(Text(_metadata_header(trajectory)), classes="trajectory-summary")
@@ -1394,6 +1422,11 @@ class JsonInspector(Vertical):
         resolved_root = review_root or (self.source_path.parent if self.source_path else Path.cwd())
         self.review_root = resolved_root.resolve()
         self._annotation_store = annotation_store or AnnotationStore(self.review_root)
+        self._file_annotations = (
+            self._annotation_store.annotations_for_file(self.source_path)
+            if self.source_path is not None
+            else {}
+        )
         self._current_item: JsonInspectorItem | None = None
         self._tree: DragTree = DragTree("JSON", classes="trajectory-tree")
         self._build_tree()
@@ -1653,12 +1686,12 @@ class JsonInspector(Vertical):
             data=final_output_item,
         )
 
-        step_items = normalize_step_timeline(trajectory)
-        step_events = normalize_step_events(trajectory)
+        step_events, step_items = normalize_step_overlay(trajectory)
         steps = trajectory.get("steps", []) if isinstance(trajectory.get("steps"), list) else []
         for step_index, (items, events) in enumerate(zip(step_items, step_events, strict=False)):
             step_path = base_path + ("steps", step_index)
             step_raw_value = steps[step_index] if step_index < len(steps) else None
+            event_paths = _trajectory_event_paths(base_path, step_index, events)
             step_item = JsonInspectorItem(
                 kind="trajectory_step",
                 title=f"Step {step_index + 1}",
@@ -1680,10 +1713,8 @@ class JsonInspector(Vertical):
                 if item.interaction is not None:
                     call_event = item.interaction.call_event
                     result_event = item.interaction.result_event
-                    call_path = _trajectory_event_path(base_path, step_index, events, call_event)
-                    result_path = _trajectory_event_path(
-                        base_path, step_index, events, result_event
-                    )
+                    call_path = event_paths.get(id(call_event.raw)) if call_event else None
+                    result_path = event_paths.get(id(result_event.raw)) if result_event else None
                     parent_path = call_path or result_path or step_path
                     tool_item = JsonInspectorItem(
                         kind="trajectory_tool",
@@ -1743,7 +1774,7 @@ class JsonInspector(Vertical):
                     continue
 
                 if item.event is not None:
-                    event_path = _trajectory_event_path(base_path, step_index, events, item.event)
+                    event_path = event_paths.get(id(item.event.raw))
                     event_item = JsonInspectorItem(
                         kind="trajectory_event",
                         title=item.title.plain,
@@ -1838,12 +1869,10 @@ class JsonInspector(Vertical):
 
     def _annotation_for_item(self, item: JsonInspectorItem) -> AnnotationRecord | None:
         """Return the stored annotation for one item, if any."""
-        if self.source_path is None:
-            return None
         path = self._annotation_key(item)
         if path is None:
             return None
-        return self._annotation_store.get_annotation(self.source_path, path)
+        return self._file_annotations.get(path)
 
     def _tree_label_for_item(self, item: JsonInspectorItem) -> Text:
         """Return the rendered tree label for one item, including annotation state."""
@@ -2248,19 +2277,16 @@ def _hermes_summary(value: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _trajectory_event_path(
+def _trajectory_event_paths(
     base_path: tuple[str | int, ...],
     step_index: int,
     events: list[TrajectoryEvent],
-    event: TrajectoryEvent | None,
-) -> tuple[str | int, ...] | None:
-    """Return the raw path for one normalized trajectory event."""
-    if event is None:
-        return None
-    for output_index, candidate in enumerate(events):
-        if candidate.raw is event.raw:
-            return base_path + ("steps", step_index, "output", output_index)
-    return None
+) -> dict[int, tuple[str | int, ...]]:
+    """Return the raw-path lookup for one step's normalized events."""
+    return {
+        id(event.raw): base_path + ("steps", step_index, "output", output_index)
+        for output_index, event in enumerate(events)
+    }
 
 
 def _interaction_payload(interaction: ToolInteraction) -> dict[str, Any]:

--- a/src/skim/trajectory.py
+++ b/src/skim/trajectory.py
@@ -8,15 +8,19 @@ shell; those stay in the preview router and app modules.
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
 from rich.syntax import Syntax
 from rich.text import Text
 from textual.app import ComposeResult
+from textual.binding import Binding
 from textual.containers import Horizontal, Vertical
+from textual.screen import ModalScreen
 from textual.widget import Widget
-from textual.widgets import Collapsible, Markdown, Static
+from textual.widgets import Button, Collapsible, Input, Markdown, Static, TextArea
 from textual.widgets import Tree as TextualTree
 
 from .scrolling import DragTree, FocusableDetailWrap
@@ -90,6 +94,184 @@ class TrajectoryTreeItem:
     event: TrajectoryEvent | None = None
     interaction: ToolInteraction | None = None
     focus: str = "full"
+
+
+@dataclass(frozen=True)
+class AnnotationRecord:
+    """Persisted annotation for one JSON node."""
+
+    tags: tuple[str, ...]
+    note: str
+
+
+@dataclass(frozen=True)
+class AnnotationEditorResult:
+    """Dismiss payload from the annotation editor modal."""
+
+    action: str
+    tags: tuple[str, ...] = ()
+    note: str = ""
+
+
+class AnnotationStore:
+    """Local JSON-backed annotation storage rooted at the current browse path."""
+
+    def __init__(self, review_root: Path) -> None:
+        """Initialize the annotation store for one browse root."""
+        self.review_root = review_root.resolve()
+        self.path = self.review_root / ".skim" / "review.json"
+        self._payload = self._load()
+
+    def annotations_for_file(self, source_path: Path) -> dict[str, AnnotationRecord]:
+        """Return stored annotations for one source file."""
+        relative_path = self.relative_file_path(source_path)
+        files = self._payload.get("files", {})
+        file_entry = files.get(relative_path, {})
+        annotations = file_entry.get("annotations", {})
+        result: dict[str, AnnotationRecord] = {}
+        for path, payload in annotations.items():
+            if not isinstance(path, str) or not isinstance(payload, dict):
+                continue
+            tags = payload.get("tags", [])
+            note = payload.get("note", "")
+            if isinstance(tags, list) and isinstance(note, str):
+                result[path] = AnnotationRecord(
+                    tags=tuple(str(tag) for tag in tags if str(tag).strip()),
+                    note=note,
+                )
+        return result
+
+    def get_annotation(self, source_path: Path, path: str) -> AnnotationRecord | None:
+        """Return one annotation by file-relative JSON path."""
+        return self.annotations_for_file(source_path).get(path)
+
+    def set_annotation(
+        self,
+        source_path: Path,
+        path: str,
+        *,
+        tags: tuple[str, ...],
+        note: str,
+    ) -> None:
+        """Store or replace one annotation."""
+        relative_path = self.relative_file_path(source_path)
+        files = self._payload.setdefault("files", {})
+        file_entry = files.setdefault(relative_path, {"annotations": {}})
+        annotations = file_entry.setdefault("annotations", {})
+        annotations[path] = {"tags": list(tags), "note": note}
+        self._save()
+
+    def delete_annotation(self, source_path: Path, path: str) -> None:
+        """Delete one annotation if present."""
+        relative_path = self.relative_file_path(source_path)
+        files = self._payload.setdefault("files", {})
+        file_entry = files.setdefault(relative_path, {"annotations": {}})
+        annotations = file_entry.setdefault("annotations", {})
+        annotations.pop(path, None)
+        self._save()
+
+    def relative_file_path(self, source_path: Path) -> str:
+        """Return the normalized file key used in persisted review data."""
+        resolved = source_path.resolve()
+        try:
+            return resolved.relative_to(self.review_root).as_posix()
+        except ValueError:
+            return resolved.name
+
+    def _load(self) -> dict[str, Any]:
+        """Load the persisted annotation payload with safe fallbacks."""
+        if not self.path.is_file():
+            return {"version": 1, "files": {}}
+        try:
+            payload = json.loads(self.path.read_text())
+        except (OSError, json.JSONDecodeError):
+            return {"version": 1, "files": {}}
+        if not isinstance(payload, dict):
+            return {"version": 1, "files": {}}
+        payload.setdefault("version", 1)
+        payload.setdefault("files", {})
+        return payload
+
+    def _save(self) -> None:
+        """Write the annotation payload to disk."""
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.path.write_text(json.dumps(self._payload, indent=2, sort_keys=True))
+
+
+class AnnotationEditor(ModalScreen[AnnotationEditorResult | None]):
+    """Small modal form for editing one annotation."""
+
+    BINDINGS = [Binding("escape", "cancel", show=False)]
+
+    def __init__(
+        self,
+        path: str,
+        annotation: AnnotationRecord | None,
+        on_submit: Callable[[AnnotationEditorResult], None] | None = None,
+    ) -> None:
+        """Initialize the modal for one selected annotation target."""
+        super().__init__()
+        self.path = path
+        self.annotation = annotation
+        self._on_submit = on_submit
+
+    def compose(self) -> ComposeResult:
+        """Compose the modal editor widgets."""
+        tags = ", ".join(self.annotation.tags) if self.annotation is not None else ""
+        note = self.annotation.note if self.annotation is not None else ""
+        yield Vertical(
+            Static(Text("Edit Annotation", style="bold"), classes="annotation-modal-title"),
+            Static(Text(f"Path: {self.path}", style="dim"), classes="annotation-modal-path"),
+            Input(value=tags, placeholder="tags, comma, separated", id="annotation-tags"),
+            TextArea(note, id="annotation-note"),
+            Horizontal(
+                Button("Save", id="annotation-save", variant="primary"),
+                Button(
+                    "Delete",
+                    id="annotation-delete",
+                    variant="error",
+                    disabled=self.annotation is None,
+                ),
+                Button("Cancel", id="annotation-cancel"),
+                classes="annotation-modal-actions",
+            ),
+            id="annotation-modal",
+        )
+
+    def action_cancel(self) -> None:
+        """Dismiss the modal without changes."""
+        self.dismiss(None)
+
+    def action_save(self) -> None:
+        """Dismiss with a save payload."""
+        self._submit(
+            AnnotationEditorResult(
+                action="save",
+                tags=_parse_annotation_tags(self.query_one("#annotation-tags", Input).value),
+                note=self.query_one("#annotation-note", TextArea).text.rstrip(),
+            )
+        )
+
+    def action_delete(self) -> None:
+        """Dismiss with a delete payload."""
+        self._submit(AnnotationEditorResult(action="delete"))
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        """Handle modal button clicks."""
+        button_id = event.button.id
+        if button_id == "annotation-save":
+            self.action_save()
+        elif button_id == "annotation-delete":
+            self.action_delete()
+        else:
+            self.action_cancel()
+        event.stop()
+
+    def _submit(self, result: AnnotationEditorResult) -> None:
+        """Invoke the save/delete callback before dismissing the modal."""
+        if self._on_submit is not None:
+            self._on_submit(result)
+        self.dismiss(result)
 
 
 def extract_trajectory(data: Any) -> dict[str, Any] | None:
@@ -1126,17 +1308,30 @@ class JsonInspectorItem:
 class JsonInspector(Vertical):
     """Unified structural inspector for JSON files with semantic overlays."""
 
-    def __init__(self, data: Any) -> None:
+    def __init__(
+        self,
+        data: Any,
+        *,
+        source_path: Path | None = None,
+        review_root: Path | None = None,
+        annotation_store: AnnotationStore | None = None,
+    ) -> None:
         """Initialize the JSON inspector for parsed JSON content."""
         super().__init__(classes="trajectory-viewer")
         self.data = data
+        self.source_path = source_path.resolve() if source_path is not None else None
+        resolved_root = review_root or (self.source_path.parent if self.source_path else Path.cwd())
+        self.review_root = resolved_root.resolve()
+        self._annotation_store = annotation_store or AnnotationStore(self.review_root)
+        self._current_item: JsonInspectorItem | None = None
         self._input_mode = "tree"
         self._tree: DragTree = DragTree("JSON", classes="trajectory-tree")
         self._build_tree()
         first_item = self._tree.root.children[0].data if self._tree.root.children else None
         initial_widgets: list[Widget] = []
         if isinstance(first_item, JsonInspectorItem):
-            initial_widgets = _json_detail_widgets(first_item)
+            self._current_item = first_item
+            initial_widgets = self._detail_widgets_for_item(first_item)
         self._detail_wrap = FocusableDetailWrap(*initial_widgets, classes="trajectory-detail-wrap")
         self._footer = Static(self._footer_text(), classes="trajectory-footer")
 
@@ -1156,8 +1351,9 @@ class JsonInspector(Vertical):
 
     def _show_detail(self, item: JsonInspectorItem) -> None:
         """Replace the detail pane with widgets for the selected tree item."""
+        self._current_item = item
         self._detail_wrap.remove_children()
-        self._detail_wrap.mount(*_json_detail_widgets(item))
+        self._detail_wrap.mount(*self._detail_widgets_for_item(item))
         self._detail_wrap.scroll_home(animate=False)
 
     def scroll_detail(self, delta: int) -> None:
@@ -1231,6 +1427,24 @@ class JsonInspector(Vertical):
         self.focus_tree_mode()
         return True
 
+    def handle_annotation_key(self) -> bool:
+        """Open the annotation editor for the active JSON node."""
+        item = self._annotation_item()
+        if item is None:
+            return False
+        path = self._annotation_key(item)
+        if path is None:
+            self.app.notify("Annotations unavailable for this node", severity="warning")
+            return True
+        self.app.push_screen(
+            AnnotationEditor(
+                path,
+                self._annotation_for_item(item),
+                on_submit=self._handle_annotation_result,
+            )
+        )
+        return True
+
     def _ensure_tree_cursor(self) -> None:
         """Keep the tree cursor on the first visible child instead of the root."""
         cursor = self._tree.cursor_node
@@ -1247,6 +1461,8 @@ class JsonInspector(Vertical):
             text.append(" Move  ")
             text.append("←→", style="bold")
             text.append(" Branch  ")
+            text.append("a", style="bold")
+            text.append(" Annotate  ")
             text.append("Enter", style="bold")
             text.append(" Detail")
         else:
@@ -1254,6 +1470,8 @@ class JsonInspector(Vertical):
             text.append(" ")
             text.append("↑↓", style="bold")
             text.append(" Scroll  ")
+            text.append("a", style="bold")
+            text.append(" Annotate  ")
             text.append("Esc", style="bold")
             text.append(" Back to JSON")
         return text
@@ -1276,44 +1494,47 @@ class JsonInspector(Vertical):
     ) -> None:
         """Add synthetic schema-aware nodes before the raw children."""
         if raw_path == () and _looks_like_bundle(value):
+            item = JsonInspectorItem(
+                kind="bundle_summary",
+                title="Bundle Summary",
+                raw_path=raw_path,
+                raw_value=value,
+                detail=_bundle_summary(value),
+                synthetic=True,
+            )
             parent.add_leaf(
-                Text("Bundle Summary", style="bold cyan"),
-                data=JsonInspectorItem(
-                    kind="bundle_summary",
-                    title="Bundle Summary",
-                    raw_path=raw_path,
-                    raw_value=value,
-                    detail=_bundle_summary(value),
-                    synthetic=True,
-                ),
+                self._tree_label_for_item(item),
+                data=item,
             )
             return
 
         if raw_path == () and _looks_like_submission(value):
+            item = JsonInspectorItem(
+                kind="submission_summary",
+                title="Submission Summary",
+                raw_path=raw_path,
+                raw_value=value,
+                detail=_submission_summary_payload(value),
+                synthetic=True,
+            )
             parent.add_leaf(
-                Text("Submission Summary", style="bold cyan"),
-                data=JsonInspectorItem(
-                    kind="submission_summary",
-                    title="Submission Summary",
-                    raw_path=raw_path,
-                    raw_value=value,
-                    detail=_submission_summary_payload(value),
-                    synthetic=True,
-                ),
+                self._tree_label_for_item(item),
+                data=item,
             )
             return
 
         if raw_path == () and _looks_like_hermes(value):
+            item = JsonInspectorItem(
+                kind="transcript_summary",
+                title="Transcript Summary",
+                raw_path=raw_path,
+                raw_value=value,
+                detail=_hermes_summary(value),
+                synthetic=True,
+            )
             parent.add_leaf(
-                Text("Transcript Summary", style="bold cyan"),
-                data=JsonInspectorItem(
-                    kind="transcript_summary",
-                    title="Transcript Summary",
-                    raw_path=raw_path,
-                    raw_value=value,
-                    detail=_hermes_summary(value),
-                    synthetic=True,
-                ),
+                self._tree_label_for_item(item),
+                data=item,
             )
             return
 
@@ -1328,35 +1549,37 @@ class JsonInspector(Vertical):
         base_path: tuple[str | int, ...],
     ) -> None:
         """Add summary and step nodes for a trajectory object."""
-        parent.add_leaf(
-            Text("Metadata", style="bold cyan"),
-            data=JsonInspectorItem(
-                kind="trajectory_metadata",
-                title="Metadata",
-                raw_path=base_path + ("metadata",),
-                raw_value=trajectory.get("metadata"),
-                trajectory_item=TrajectoryTreeItem(
-                    "metadata",
-                    "Metadata",
-                    _metadata_detail(trajectory),
-                ),
-                synthetic=True,
+        metadata_item = JsonInspectorItem(
+            kind="trajectory_metadata",
+            title="Metadata",
+            raw_path=base_path + ("metadata",),
+            raw_value=trajectory.get("metadata"),
+            trajectory_item=TrajectoryTreeItem(
+                "metadata",
+                "Metadata",
+                _metadata_detail(trajectory),
             ),
+            synthetic=True,
         )
         parent.add_leaf(
-            Text("Final Output", style="bold cyan"),
-            data=JsonInspectorItem(
-                kind="trajectory_final_output",
-                title="Final Output",
-                raw_path=base_path + ("final_output",),
-                raw_value=trajectory.get("final_output"),
-                trajectory_item=TrajectoryTreeItem(
-                    "final_output",
-                    "Final Output",
-                    _final_output_detail(trajectory),
-                ),
-                synthetic=True,
+            self._tree_label_for_item(metadata_item),
+            data=metadata_item,
+        )
+        final_output_item = JsonInspectorItem(
+            kind="trajectory_final_output",
+            title="Final Output",
+            raw_path=base_path + ("final_output",),
+            raw_value=trajectory.get("final_output"),
+            trajectory_item=TrajectoryTreeItem(
+                "final_output",
+                "Final Output",
+                _final_output_detail(trajectory),
             ),
+            synthetic=True,
+        )
+        parent.add_leaf(
+            self._tree_label_for_item(final_output_item),
+            data=final_output_item,
         )
 
         step_items = normalize_step_timeline(trajectory)
@@ -1365,20 +1588,21 @@ class JsonInspector(Vertical):
         for step_index, (items, events) in enumerate(zip(step_items, step_events, strict=False)):
             step_path = base_path + ("steps", step_index)
             step_raw_value = steps[step_index] if step_index < len(steps) else None
-            step = parent.add(
-                Text(f"Step {step_index + 1}", style="bold yellow"),
-                data=JsonInspectorItem(
-                    kind="trajectory_step",
-                    title=f"Step {step_index + 1}",
-                    raw_path=step_path,
-                    raw_value=step_raw_value,
-                    trajectory_item=TrajectoryTreeItem(
-                        "step",
-                        f"Step {step_index + 1}",
-                        Text(f"Step {step_index + 1}\n\n{len(items)} items"),
-                    ),
-                    synthetic=True,
+            step_item = JsonInspectorItem(
+                kind="trajectory_step",
+                title=f"Step {step_index + 1}",
+                raw_path=step_path,
+                raw_value=step_raw_value,
+                trajectory_item=TrajectoryTreeItem(
+                    "step",
+                    f"Step {step_index + 1}",
+                    Text(f"Step {step_index + 1}\n\n{len(items)} items"),
                 ),
+                synthetic=True,
+            )
+            step = parent.add(
+                self._tree_label_for_item(step_item),
+                data=step_item,
                 expand=True,
             )
             for item in items:
@@ -1390,77 +1614,81 @@ class JsonInspector(Vertical):
                         base_path, step_index, events, result_event
                     )
                     parent_path = call_path or result_path or step_path
-                    tool = step.add(
-                        item.title,
-                        data=JsonInspectorItem(
-                            kind="trajectory_tool",
-                            title=item.title.plain,
-                            raw_path=parent_path,
-                            raw_value=_interaction_payload(item.interaction),
-                            trajectory_item=TrajectoryTreeItem(
-                                "tool",
-                                item.title.plain,
-                                interaction=item.interaction,
-                                focus="full",
-                            ),
-                            synthetic=True,
-                            annotation_path=parent_path,
+                    tool_item = JsonInspectorItem(
+                        kind="trajectory_tool",
+                        title=item.title.plain,
+                        raw_path=parent_path,
+                        raw_value=_interaction_payload(item.interaction),
+                        trajectory_item=TrajectoryTreeItem(
+                            "tool",
+                            item.title.plain,
+                            interaction=item.interaction,
+                            focus="full",
                         ),
+                        synthetic=True,
+                        annotation_path=parent_path,
+                    )
+                    tool = step.add(
+                        self._tree_label_for_item(tool_item),
+                        data=tool_item,
                         expand=True,
                     )
-                    tool.add_leaf(
-                        Text("Input", style="bold yellow"),
-                        data=JsonInspectorItem(
-                            kind="trajectory_tool_input",
-                            title="Input",
-                            raw_path=call_path or parent_path,
-                            raw_value=call_event.raw if call_event else None,
-                            trajectory_item=TrajectoryTreeItem(
-                                "tool_input",
-                                "Input",
-                                interaction=item.interaction,
-                                focus="input",
-                            ),
-                            synthetic=True,
-                            annotation_path=call_path or parent_path,
+                    input_item = JsonInspectorItem(
+                        kind="trajectory_tool_input",
+                        title="Input",
+                        raw_path=call_path or parent_path,
+                        raw_value=call_event.raw if call_event else None,
+                        trajectory_item=TrajectoryTreeItem(
+                            "tool_input",
+                            "Input",
+                            interaction=item.interaction,
+                            focus="input",
                         ),
+                        synthetic=True,
+                        annotation_path=call_path or parent_path,
                     )
                     tool.add_leaf(
-                        Text("Output", style="bold yellow"),
-                        data=JsonInspectorItem(
-                            kind="trajectory_tool_output",
-                            title="Output",
-                            raw_path=result_path or parent_path,
-                            raw_value=result_event.raw if result_event else None,
-                            trajectory_item=TrajectoryTreeItem(
-                                "tool_output",
-                                "Output",
-                                interaction=item.interaction,
-                                focus="output",
-                            ),
-                            synthetic=True,
-                            annotation_path=result_path or parent_path,
+                        self._tree_label_for_item(input_item),
+                        data=input_item,
+                    )
+                    output_item = JsonInspectorItem(
+                        kind="trajectory_tool_output",
+                        title="Output",
+                        raw_path=result_path or parent_path,
+                        raw_value=result_event.raw if result_event else None,
+                        trajectory_item=TrajectoryTreeItem(
+                            "tool_output",
+                            "Output",
+                            interaction=item.interaction,
+                            focus="output",
                         ),
+                        synthetic=True,
+                        annotation_path=result_path or parent_path,
+                    )
+                    tool.add_leaf(
+                        self._tree_label_for_item(output_item),
+                        data=output_item,
                     )
                     continue
 
                 if item.event is not None:
                     event_path = _trajectory_event_path(base_path, step_index, events, item.event)
-                    step.add_leaf(
-                        item.title,
-                        data=JsonInspectorItem(
-                            kind="trajectory_event",
-                            title=item.title.plain,
-                            raw_path=event_path or step_path,
-                            raw_value=item.event.raw,
-                            trajectory_item=TrajectoryTreeItem(
-                                "event",
-                                item.title.plain,
-                                event=item.event,
-                            ),
-                            synthetic=True,
-                            annotation_path=event_path or step_path,
+                    event_item = JsonInspectorItem(
+                        kind="trajectory_event",
+                        title=item.title.plain,
+                        raw_path=event_path or step_path,
+                        raw_value=item.event.raw,
+                        trajectory_item=TrajectoryTreeItem(
+                            "event",
+                            item.title.plain,
+                            event=item.event,
                         ),
+                        synthetic=True,
+                        annotation_path=event_path or step_path,
+                    )
+                    step.add_leaf(
+                        self._tree_label_for_item(event_item),
+                        data=event_item,
                     )
 
     def _add_raw_children(
@@ -1480,7 +1708,7 @@ class JsonInspector(Vertical):
                     raw_value=child,
                     key=key,
                 )
-                label = _dict_tree_label(key, child)
+                label = self._tree_label_for_item(item)
                 if isinstance(child, dict | list):
                     node = parent.add(label, data=item)
                     self._add_overlay_children(node, child, child_path)
@@ -1499,7 +1727,7 @@ class JsonInspector(Vertical):
                     raw_value=child,
                     key=str(index),
                 )
-                label = _list_tree_label(self.data, raw_path, index, child)
+                label = self._tree_label_for_item(item)
                 if isinstance(child, dict | list):
                     node = parent.add(label, data=item)
                     self._add_overlay_children(node, child, child_path)
@@ -1507,23 +1735,104 @@ class JsonInspector(Vertical):
                 else:
                     parent.add_leaf(label, data=item)
 
+    def _detail_widgets_for_item(self, item: JsonInspectorItem) -> list[Widget]:
+        """Return detail widgets for one selected JSON node."""
+        return _json_detail_widgets(
+            item,
+            annotation=self._annotation_for_item(item),
+            annotatable=self._is_annotatable(item),
+        )
 
-def _json_detail_widgets(item: JsonInspectorItem) -> list[Widget]:
+    def _annotation_item(self) -> JsonInspectorItem | None:
+        """Return the active item for the annotation action."""
+        if self.is_tree_mode():
+            self._ensure_tree_cursor()
+            node = self._tree.cursor_node
+            if node is not None and isinstance(node.data, JsonInspectorItem):
+                return node.data
+        return self._current_item
+
+    def _is_annotatable(self, item: JsonInspectorItem) -> bool:
+        """Return whether the item can be annotated in the MVP."""
+        return item.annotation_path is not None or not item.synthetic
+
+    def _annotation_key(self, item: JsonInspectorItem) -> str | None:
+        """Return the persisted annotation key for one item."""
+        if not self._is_annotatable(item):
+            return None
+        return _format_raw_path(item.annotation_path or item.raw_path)
+
+    def _annotation_for_item(self, item: JsonInspectorItem) -> AnnotationRecord | None:
+        """Return the stored annotation for one item, if any."""
+        if self.source_path is None:
+            return None
+        path = self._annotation_key(item)
+        if path is None:
+            return None
+        return self._annotation_store.get_annotation(self.source_path, path)
+
+    def _tree_label_for_item(self, item: JsonInspectorItem) -> Text:
+        """Return the rendered tree label for one item, including annotation state."""
+        label = _json_tree_label(self.data, item)
+        if self._annotation_for_item(item) is None:
+            return label
+        marked = Text("* ", style="bold green")
+        marked.append_text(label)
+        return marked
+
+    def _handle_annotation_result(self, result: AnnotationEditorResult | None) -> None:
+        """Apply a modal annotation result to the current selection."""
+        item = self._annotation_item()
+        if item is None or result is None or self.source_path is None:
+            return
+        path = self._annotation_key(item)
+        if path is None:
+            return
+        if result.action == "delete":
+            self._annotation_store.delete_annotation(self.source_path, path)
+        elif result.action == "save":
+            self._annotation_store.set_annotation(
+                self.source_path,
+                path,
+                tags=result.tags,
+                note=result.note,
+            )
+        else:
+            return
+        self._refresh_annotation_labels(path)
+        self._show_detail(item)
+
+    def _refresh_annotation_labels(self, path: str | None = None) -> None:
+        """Refresh annotation markers for all tree nodes or one target path."""
+        for node in _walk_tree_nodes(self._tree.root):
+            item = node.data
+            if not isinstance(item, JsonInspectorItem):
+                continue
+            item_path = self._annotation_key(item)
+            if path is not None and item_path != path:
+                continue
+            node.set_label(self._tree_label_for_item(item))
+
+
+def _json_detail_widgets(
+    item: JsonInspectorItem,
+    *,
+    annotation: AnnotationRecord | None,
+    annotatable: bool,
+) -> list[Widget]:
     """Return detail widgets for a selected JSON-inspector node."""
     path = _format_raw_path(item.annotation_path or item.raw_path)
-    if item.trajectory_item is not None:
-        return _metadata_fields([("Path", path)]) + _detail_widgets_for_item(item.trajectory_item)
-
     title = Text(item.title or "JSON", style="bold")
     widgets: list[Widget] = [Static(title, classes="trajectory-detail-heading")]
-    widgets.extend(
-        _metadata_fields(
-            [
-                ("Path", path),
-                ("Type", _json_type_name(item.raw_value)),
-            ]
-        )
-    )
+    metadata = [("Path", path)]
+    if item.trajectory_item is None:
+        metadata.append(("Type", _json_type_name(item.raw_value)))
+    widgets.extend(_metadata_fields(metadata))
+    widgets.extend(_annotation_detail_widgets(annotation, annotatable))
+
+    if item.trajectory_item is not None:
+        widgets.extend(_detail_widgets_for_item(item.trajectory_item))
+        return widgets
 
     value = item.detail if item.synthetic and item.detail is not None else item.raw_value
     if item.synthetic and isinstance(value, dict | list):
@@ -1534,6 +1843,66 @@ def _json_detail_widgets(item: JsonInspectorItem) -> list[Widget]:
     else:
         widgets.extend(_render_payload_detail(value))
     return widgets
+
+
+def _annotation_detail_widgets(
+    annotation: AnnotationRecord | None,
+    annotatable: bool,
+) -> list[Widget]:
+    """Return the annotation block for one selected JSON node."""
+    if not annotatable:
+        return []
+
+    widgets: list[Widget] = [Static(Text("Annotation", style="bold"), classes="trajectory-detail")]
+    if annotation is None:
+        widgets.append(Static(Text("No annotation yet"), classes="trajectory-detail"))
+        widgets.append(
+            Static(Text("Press a to annotate", style="dim"), classes="trajectory-detail")
+        )
+        return widgets
+
+    widgets.extend(_metadata_fields([("Tags", ", ".join(annotation.tags))]))
+    note = Text()
+    note.append("Note: ", style="bold cyan")
+    note.append(annotation.note or "(empty)")
+    widgets.append(Static(note, classes="trajectory-detail"))
+    return widgets
+
+
+def _json_tree_label(root_data: Any, item: JsonInspectorItem) -> Text:
+    """Return the base tree label for one JSON-inspector node."""
+    if item.kind == "raw_dict_key":
+        return _dict_tree_label(item.key, item.raw_value)
+    if item.kind == "raw_list_item":
+        index = item.raw_path[-1] if item.raw_path else 0
+        if isinstance(index, int):
+            return _list_tree_label(root_data, item.raw_path[:-1], index, item.raw_value)
+    if item.kind in {
+        "bundle_summary",
+        "submission_summary",
+        "transcript_summary",
+        "trajectory_metadata",
+        "trajectory_final_output",
+    }:
+        return Text(item.title, style="bold cyan")
+    if item.kind in {"trajectory_step", "trajectory_tool_input", "trajectory_tool_output"}:
+        return Text(item.title, style="bold yellow")
+    return Text(item.title)
+
+
+def _walk_tree_nodes(
+    node: TextualTree.Node[JsonInspectorItem],
+) -> list[TextualTree.Node[JsonInspectorItem]]:
+    """Return the supplied node and all descendants."""
+    nodes = [node]
+    for child in node.children:
+        nodes.extend(_walk_tree_nodes(child))
+    return nodes
+
+
+def _parse_annotation_tags(raw_tags: str) -> tuple[str, ...]:
+    """Parse the comma-separated tag field used by the modal editor."""
+    return tuple(tag.strip() for tag in raw_tags.split(",") if tag.strip())
 
 
 def _json_type_name(value: Any) -> str:

--- a/src/skim/trajectory.py
+++ b/src/skim/trajectory.py
@@ -238,6 +238,17 @@ class AnnotationEditor(ModalScreen[AnnotationEditorResult | None]):
             id="annotation-modal",
         )
 
+    def on_mount(self) -> None:
+        """Focus the tags field when the modal opens."""
+        self.query_one("#annotation-tags", Input).focus()
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        """Advance from tags input to note instead of submitting the modal."""
+        if event.input.id != "annotation-tags":
+            return
+        self.query_one("#annotation-note", TextArea).focus()
+        event.stop()
+
     def action_cancel(self) -> None:
         """Dismiss the modal without changes."""
         self.dismiss(None)
@@ -1328,18 +1339,32 @@ class JsonInspector(Vertical):
         self._tree: DragTree = DragTree("JSON", classes="trajectory-tree")
         self._build_tree()
         first_item = self._tree.root.children[0].data if self._tree.root.children else None
-        initial_widgets: list[Widget] = []
+        initial_detail_widgets: list[Widget] = []
+        initial_annotation_widgets: list[Widget] = _annotation_panel_widgets(None, False)
         if isinstance(first_item, JsonInspectorItem):
             self._current_item = first_item
-            initial_widgets = self._detail_widgets_for_item(first_item)
-        self._detail_wrap = FocusableDetailWrap(*initial_widgets, classes="trajectory-detail-wrap")
+            initial_detail_widgets = self._detail_widgets_for_item(first_item)
+            initial_annotation_widgets = self._annotation_widgets_for_item(first_item)
+        self._annotation_wrap = Vertical(
+            *initial_annotation_widgets,
+            classes="annotation-status-panel",
+        )
+        self._detail_wrap = FocusableDetailWrap(
+            *initial_detail_widgets,
+            classes="trajectory-detail-wrap",
+        )
+        self._detail_column = Vertical(
+            self._annotation_wrap,
+            self._detail_wrap,
+            classes="trajectory-detail-column",
+        )
         self._footer = Static(self._footer_text(), classes="trajectory-footer")
 
     def compose(self) -> ComposeResult:
         """Compose the JSON tree, detail panel, and local footer."""
         with Horizontal(classes="trajectory-body"):
             yield self._tree
-            yield self._detail_wrap
+            yield self._detail_column
         yield self._footer
 
     def on_tree_node_selected(self, event: TextualTree.NodeSelected[JsonInspectorItem]) -> None:
@@ -1352,6 +1377,8 @@ class JsonInspector(Vertical):
     def _show_detail(self, item: JsonInspectorItem) -> None:
         """Replace the detail pane with widgets for the selected tree item."""
         self._current_item = item
+        self._annotation_wrap.remove_children()
+        self._annotation_wrap.mount(*self._annotation_widgets_for_item(item))
         self._detail_wrap.remove_children()
         self._detail_wrap.mount(*self._detail_widgets_for_item(item))
         self._detail_wrap.scroll_home(animate=False)
@@ -1737,10 +1764,13 @@ class JsonInspector(Vertical):
 
     def _detail_widgets_for_item(self, item: JsonInspectorItem) -> list[Widget]:
         """Return detail widgets for one selected JSON node."""
-        return _json_detail_widgets(
-            item,
-            annotation=self._annotation_for_item(item),
-            annotatable=self._is_annotatable(item),
+        return _json_detail_widgets(item)
+
+    def _annotation_widgets_for_item(self, item: JsonInspectorItem) -> list[Widget]:
+        """Return annotation-panel widgets for one selected JSON node."""
+        return _annotation_panel_widgets(
+            self._annotation_for_item(item),
+            self._is_annotatable(item),
         )
 
     def _annotation_item(self) -> JsonInspectorItem | None:
@@ -1814,12 +1844,7 @@ class JsonInspector(Vertical):
             node.set_label(self._tree_label_for_item(item))
 
 
-def _json_detail_widgets(
-    item: JsonInspectorItem,
-    *,
-    annotation: AnnotationRecord | None,
-    annotatable: bool,
-) -> list[Widget]:
+def _json_detail_widgets(item: JsonInspectorItem) -> list[Widget]:
     """Return detail widgets for a selected JSON-inspector node."""
     path = _format_raw_path(item.annotation_path or item.raw_path)
     title = Text(item.title or "JSON", style="bold")
@@ -1828,7 +1853,6 @@ def _json_detail_widgets(
     if item.trajectory_item is None:
         metadata.append(("Type", _json_type_name(item.raw_value)))
     widgets.extend(_metadata_fields(metadata))
-    widgets.extend(_annotation_detail_widgets(annotation, annotatable))
 
     if item.trajectory_item is not None:
         widgets.extend(_detail_widgets_for_item(item.trajectory_item))
@@ -1845,27 +1869,53 @@ def _json_detail_widgets(
     return widgets
 
 
-def _annotation_detail_widgets(
+def _annotation_panel_widgets(
     annotation: AnnotationRecord | None,
     annotatable: bool,
 ) -> list[Widget]:
-    """Return the annotation block for one selected JSON node."""
+    """Return the separate annotation-status panel for one selected JSON node."""
+    widgets: list[Widget] = [
+        Static(Text("Annotation", style="bold"), classes="annotation-status-title")
+    ]
     if not annotatable:
-        return []
-
-    widgets: list[Widget] = [Static(Text("Annotation", style="bold"), classes="trajectory-detail")]
-    if annotation is None:
-        widgets.append(Static(Text("No annotation yet"), classes="trajectory-detail"))
-        widgets.append(
-            Static(Text("Press a to annotate", style="dim"), classes="trajectory-detail")
+        widgets.extend(
+            _metadata_fields([("Status", "Unavailable")])
+            + [
+                Static(
+                    Text("Summary nodes do not map to raw JSON targets."),
+                    classes="annotation-status-body",
+                ),
+                Static(
+                    Text("Select a raw or mapped overlay node to annotate.", style="dim"),
+                    classes="annotation-status-hint",
+                ),
+            ]
         )
         return widgets
 
-    widgets.extend(_metadata_fields([("Tags", ", ".join(annotation.tags))]))
+    if annotation is None:
+        widgets.extend(_metadata_fields([("Status", "No annotation"), ("Tags", "(none)")]))
+        widgets.append(
+            Static(Text("No annotation yet"), classes="annotation-status-body")
+        )
+        widgets.append(
+            Static(Text("Press a to annotate", style="dim"), classes="annotation-status-hint")
+        )
+        return widgets
+
+    widgets.extend(
+        _metadata_fields(
+            [
+                ("Status", "Annotated"),
+                ("Tags", ", ".join(annotation.tags) if annotation.tags else "(none)"),
+            ]
+        )
+    )
     note = Text()
     note.append("Note: ", style="bold cyan")
     note.append(annotation.note or "(empty)")
-    widgets.append(Static(note, classes="trajectory-detail"))
+    widgets.append(Static(note, classes="annotation-status-body"))
+    widgets.append(Static(Text("Press a to edit", style="dim"), classes="annotation-status-hint"))
     return widgets
 
 

--- a/src/skim/trajectory.py
+++ b/src/skim/trajectory.py
@@ -15,7 +15,6 @@ from typing import Any
 
 from rich.syntax import Syntax
 from rich.text import Text
-from textual import events as textual_events
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical
@@ -205,10 +204,6 @@ class AnnotationEditor(ModalScreen[AnnotationEditorResult | None]):
     PREVIEW_SCROLL_STEP = 20
     BINDINGS = [
         Binding("escape", "cancel", show=False),
-        Binding("left", "focus_editor_panel", show=False),
-        Binding("right", "focus_preview_panel", show=False),
-        Binding("up", "move_editor_up", show=False),
-        Binding("down", "move_editor_down", show=False),
         Binding("pageup", "scroll_preview_up", show=False),
         Binding("pagedown", "scroll_preview_down", show=False),
     ]
@@ -226,8 +221,6 @@ class AnnotationEditor(ModalScreen[AnnotationEditorResult | None]):
         self.annotation = annotation
         self.item = item
         self._on_submit = on_submit
-        self._active_panel = "editor"
-        self._editor_index = 0
 
     def compose(self) -> ComposeResult:
         """Compose the modal editor widgets."""
@@ -271,73 +264,24 @@ class AnnotationEditor(ModalScreen[AnnotationEditorResult | None]):
 
     def on_mount(self) -> None:
         """Focus the tags field when the modal opens."""
-        self._focus_editor_index(0)
+        self.query_one("#annotation-tags", Input).focus()
 
     def on_input_submitted(self, event: Input.Submitted) -> None:
         """Advance from tags input to note instead of submitting the modal."""
         if event.input.id != "annotation-tags":
             return
-        self._editor_index = min(1, len(self._editor_controls()) - 1)
-        self._focus_editor_index(self._editor_index)
+        self.query_one("#annotation-note", TextArea).focus()
         event.stop()
-
-    def on_key(self, event: textual_events.Key) -> None:
-        """Handle modal-local navigation before focused widgets consume it."""
-        if event.key == "left":
-            self.action_focus_editor_panel()
-        elif event.key == "right":
-            self.action_focus_preview_panel()
-        elif event.key == "up":
-            self.action_move_editor_up()
-        elif event.key == "down":
-            self.action_move_editor_down()
-        elif event.key == "pageup":
-            self.action_scroll_preview_up()
-        elif event.key == "pagedown":
-            self.action_scroll_preview_down()
-        else:
-            return
-        event.prevent_default()
-        event.stop()
-
-    def action_focus_editor_panel(self) -> None:
-        """Move modal focus back to the editor panel."""
-        self._active_panel = "editor"
-        self._focus_editor_index(self._editor_index)
-
-    def action_focus_preview_panel(self) -> None:
-        """Move modal focus to the read-only preview panel."""
-        self._active_panel = "preview"
-        self.query_one("#annotation-preview", FocusableDetailWrap).focus()
-        self._update_panel_classes()
-
-    def action_move_editor_up(self) -> None:
-        """Move focus to the previous editor control."""
-        if self._active_panel != "editor":
-            return
-        self._editor_index = max(0, self._editor_index - 1)
-        self._focus_editor_index(self._editor_index)
-
-    def action_move_editor_down(self) -> None:
-        """Move focus to the next editor control."""
-        if self._active_panel != "editor":
-            return
-        self._editor_index = min(len(self._editor_controls()) - 1, self._editor_index + 1)
-        self._focus_editor_index(self._editor_index)
 
     def action_scroll_preview_up(self) -> None:
-        """Scroll the right preview up when it is the active panel."""
-        if self._active_panel != "preview":
-            return
+        """Scroll the right preview up."""
         self.query_one("#annotation-preview", FocusableDetailWrap).scroll_relative(
             y=-self.PREVIEW_SCROLL_STEP,
             animate=False,
         )
 
     def action_scroll_preview_down(self) -> None:
-        """Scroll the right preview down when it is the active panel."""
-        if self._active_panel != "preview":
-            return
+        """Scroll the right preview down."""
         self.query_one("#annotation-preview", FocusableDetailWrap).scroll_relative(
             y=self.PREVIEW_SCROLL_STEP,
             animate=False,
@@ -377,38 +321,6 @@ class AnnotationEditor(ModalScreen[AnnotationEditorResult | None]):
         if self._on_submit is not None:
             self._on_submit(result)
         self.dismiss(result)
-
-    def _editor_controls(self) -> list[Widget]:
-        """Return the keyboard navigation order for editor controls."""
-        controls: list[Widget] = [
-            self.query_one("#annotation-tags", Input),
-            self.query_one("#annotation-note", TextArea),
-            self.query_one("#annotation-save", Button),
-        ]
-        delete = self.query_one("#annotation-delete", Button)
-        if not delete.disabled:
-            controls.append(delete)
-        controls.append(self.query_one("#annotation-cancel", Button))
-        return controls
-
-    def _focus_editor_index(self, index: int) -> None:
-        """Focus one editor control by navigation order index."""
-        controls = self._editor_controls()
-        self._editor_index = max(0, min(index, len(controls) - 1))
-        self._active_panel = "editor"
-        controls[self._editor_index].focus()
-        self._update_panel_classes()
-
-    def _update_panel_classes(self) -> None:
-        """Reflect which modal panel is currently active."""
-        editor = self.query_one("#annotation-editor-panel")
-        preview = self.query_one("#annotation-preview-panel")
-        editor.remove_class("annotation-modal-panel-active")
-        preview.remove_class("annotation-modal-panel-active")
-        if self._active_panel == "preview":
-            preview.add_class("annotation-modal-panel-active")
-        else:
-            editor.add_class("annotation-modal-panel-active")
 
 
 def extract_trajectory(data: Any) -> dict[str, Any] | None:

--- a/src/skim/trajectory.py
+++ b/src/skim/trajectory.py
@@ -226,39 +226,46 @@ class AnnotationEditor(ModalScreen[AnnotationEditorResult | None]):
         """Compose the modal editor widgets."""
         tags = ", ".join(self.annotation.tags) if self.annotation is not None else ""
         note = self.annotation.note if self.annotation is not None else ""
-        yield Horizontal(
-            Vertical(
-                Static(Text("Edit Annotation", style="bold"), classes="annotation-modal-title"),
-                Static(Text(f"Path: {self.path}", style="dim"), classes="annotation-modal-path"),
-                Input(value=tags, placeholder="tags, comma, separated", id="annotation-tags"),
-                TextArea(note, id="annotation-note"),
-                Horizontal(
-                    Button("Save", id="annotation-save", variant="primary"),
-                    Button(
-                        "Delete",
-                        id="annotation-delete",
-                        variant="error",
-                        disabled=self.annotation is None,
+        yield Vertical(
+            Horizontal(
+                Vertical(
+                    Static(Text("Edit Annotation", style="bold"), classes="annotation-modal-title"),
+                    Static(
+                        Text(f"Path: {self.path}", style="dim"),
+                        classes="annotation-modal-path",
                     ),
-                    Button("Cancel", id="annotation-cancel"),
-                    classes="annotation-modal-actions",
+                    Input(value=tags, placeholder="tags, comma, separated", id="annotation-tags"),
+                    TextArea(note, id="annotation-note"),
+                    Horizontal(
+                        Button("Save", id="annotation-save", variant="primary"),
+                        Button(
+                            "Delete",
+                            id="annotation-delete",
+                            variant="error",
+                            disabled=self.annotation is None,
+                        ),
+                        Button("Cancel", id="annotation-cancel"),
+                        classes="annotation-modal-actions",
+                    ),
+                    id="annotation-editor-panel",
+                    classes="annotation-modal-panel",
                 ),
-                id="annotation-editor-panel",
-                classes="annotation-modal-panel",
+                Vertical(
+                    Static(
+                        Text("Node Preview", style="bold"),
+                        classes="annotation-modal-preview-title",
+                    ),
+                    FocusableDetailWrap(
+                        *_json_detail_widgets(self.item),
+                        id="annotation-preview",
+                        classes="annotation-modal-preview",
+                    ),
+                    id="annotation-preview-panel",
+                    classes="annotation-modal-panel",
+                ),
+                classes="annotation-modal-body",
             ),
-            Vertical(
-                Static(
-                    Text("Node Preview", style="bold"),
-                    classes="annotation-modal-preview-title",
-                ),
-                FocusableDetailWrap(
-                    *_json_detail_widgets(self.item),
-                    id="annotation-preview",
-                    classes="annotation-modal-preview",
-                ),
-                id="annotation-preview-panel",
-                classes="annotation-modal-panel",
-            ),
+            Static(self._footer_text(), id="annotation-modal-footer", classes="trajectory-footer"),
             id="annotation-modal",
         )
 
@@ -321,6 +328,21 @@ class AnnotationEditor(ModalScreen[AnnotationEditorResult | None]):
         if self._on_submit is not None:
             self._on_submit(result)
         self.dismiss(result)
+
+    def _footer_text(self) -> Text:
+        """Build the modal-local footer text."""
+        text = Text()
+        text.append(" Annotation ", style="reverse")
+        text.append(" ")
+        text.append("Esc", style="bold")
+        text.append(" Close  ")
+        text.append("Tab", style="bold")
+        text.append(" Next field  ")
+        text.append("Enter", style="bold")
+        text.append(" Tags→Note  ")
+        text.append("PgUp/Dn", style="bold")
+        text.append(" Scroll preview")
+        return text
 
 
 def extract_trajectory(data: Any) -> dict[str, Any] | None:

--- a/src/skim/trajectory.py
+++ b/src/skim/trajectory.py
@@ -15,6 +15,7 @@ from typing import Any
 
 from rich.syntax import Syntax
 from rich.text import Text
+from textual import events as textual_events
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical
@@ -201,53 +202,146 @@ class AnnotationStore:
 class AnnotationEditor(ModalScreen[AnnotationEditorResult | None]):
     """Small modal form for editing one annotation."""
 
-    BINDINGS = [Binding("escape", "cancel", show=False)]
+    PREVIEW_SCROLL_STEP = 20
+    BINDINGS = [
+        Binding("escape", "cancel", show=False),
+        Binding("left", "focus_editor_panel", show=False),
+        Binding("right", "focus_preview_panel", show=False),
+        Binding("up", "move_editor_up", show=False),
+        Binding("down", "move_editor_down", show=False),
+        Binding("pageup", "scroll_preview_up", show=False),
+        Binding("pagedown", "scroll_preview_down", show=False),
+    ]
 
     def __init__(
         self,
         path: str,
         annotation: AnnotationRecord | None,
+        item: JsonInspectorItem,
         on_submit: Callable[[AnnotationEditorResult], None] | None = None,
     ) -> None:
         """Initialize the modal for one selected annotation target."""
         super().__init__()
         self.path = path
         self.annotation = annotation
+        self.item = item
         self._on_submit = on_submit
+        self._active_panel = "editor"
+        self._editor_index = 0
 
     def compose(self) -> ComposeResult:
         """Compose the modal editor widgets."""
         tags = ", ".join(self.annotation.tags) if self.annotation is not None else ""
         note = self.annotation.note if self.annotation is not None else ""
-        yield Vertical(
-            Static(Text("Edit Annotation", style="bold"), classes="annotation-modal-title"),
-            Static(Text(f"Path: {self.path}", style="dim"), classes="annotation-modal-path"),
-            Input(value=tags, placeholder="tags, comma, separated", id="annotation-tags"),
-            TextArea(note, id="annotation-note"),
-            Horizontal(
-                Button("Save", id="annotation-save", variant="primary"),
-                Button(
-                    "Delete",
-                    id="annotation-delete",
-                    variant="error",
-                    disabled=self.annotation is None,
+        yield Horizontal(
+            Vertical(
+                Static(Text("Edit Annotation", style="bold"), classes="annotation-modal-title"),
+                Static(Text(f"Path: {self.path}", style="dim"), classes="annotation-modal-path"),
+                Input(value=tags, placeholder="tags, comma, separated", id="annotation-tags"),
+                TextArea(note, id="annotation-note"),
+                Horizontal(
+                    Button("Save", id="annotation-save", variant="primary"),
+                    Button(
+                        "Delete",
+                        id="annotation-delete",
+                        variant="error",
+                        disabled=self.annotation is None,
+                    ),
+                    Button("Cancel", id="annotation-cancel"),
+                    classes="annotation-modal-actions",
                 ),
-                Button("Cancel", id="annotation-cancel"),
-                classes="annotation-modal-actions",
+                id="annotation-editor-panel",
+                classes="annotation-modal-panel",
+            ),
+            Vertical(
+                Static(
+                    Text("Node Preview", style="bold"),
+                    classes="annotation-modal-preview-title",
+                ),
+                FocusableDetailWrap(
+                    *_json_detail_widgets(self.item),
+                    id="annotation-preview",
+                    classes="annotation-modal-preview",
+                ),
+                id="annotation-preview-panel",
+                classes="annotation-modal-panel",
             ),
             id="annotation-modal",
         )
 
     def on_mount(self) -> None:
         """Focus the tags field when the modal opens."""
-        self.query_one("#annotation-tags", Input).focus()
+        self._focus_editor_index(0)
 
     def on_input_submitted(self, event: Input.Submitted) -> None:
         """Advance from tags input to note instead of submitting the modal."""
         if event.input.id != "annotation-tags":
             return
-        self.query_one("#annotation-note", TextArea).focus()
+        self._editor_index = min(1, len(self._editor_controls()) - 1)
+        self._focus_editor_index(self._editor_index)
         event.stop()
+
+    def on_key(self, event: textual_events.Key) -> None:
+        """Handle modal-local navigation before focused widgets consume it."""
+        if event.key == "left":
+            self.action_focus_editor_panel()
+        elif event.key == "right":
+            self.action_focus_preview_panel()
+        elif event.key == "up":
+            self.action_move_editor_up()
+        elif event.key == "down":
+            self.action_move_editor_down()
+        elif event.key == "pageup":
+            self.action_scroll_preview_up()
+        elif event.key == "pagedown":
+            self.action_scroll_preview_down()
+        else:
+            return
+        event.prevent_default()
+        event.stop()
+
+    def action_focus_editor_panel(self) -> None:
+        """Move modal focus back to the editor panel."""
+        self._active_panel = "editor"
+        self._focus_editor_index(self._editor_index)
+
+    def action_focus_preview_panel(self) -> None:
+        """Move modal focus to the read-only preview panel."""
+        self._active_panel = "preview"
+        self.query_one("#annotation-preview", FocusableDetailWrap).focus()
+        self._update_panel_classes()
+
+    def action_move_editor_up(self) -> None:
+        """Move focus to the previous editor control."""
+        if self._active_panel != "editor":
+            return
+        self._editor_index = max(0, self._editor_index - 1)
+        self._focus_editor_index(self._editor_index)
+
+    def action_move_editor_down(self) -> None:
+        """Move focus to the next editor control."""
+        if self._active_panel != "editor":
+            return
+        self._editor_index = min(len(self._editor_controls()) - 1, self._editor_index + 1)
+        self._focus_editor_index(self._editor_index)
+
+    def action_scroll_preview_up(self) -> None:
+        """Scroll the right preview up when it is the active panel."""
+        if self._active_panel != "preview":
+            return
+        self.query_one("#annotation-preview", FocusableDetailWrap).scroll_relative(
+            y=-self.PREVIEW_SCROLL_STEP,
+            animate=False,
+        )
+
+    def action_scroll_preview_down(self) -> None:
+        """Scroll the right preview down when it is the active panel."""
+        if self._active_panel != "preview":
+            return
+        self.query_one("#annotation-preview", FocusableDetailWrap).scroll_relative(
+            y=self.PREVIEW_SCROLL_STEP,
+            animate=False,
+        )
 
     def action_cancel(self) -> None:
         """Dismiss the modal without changes."""
@@ -283,6 +377,38 @@ class AnnotationEditor(ModalScreen[AnnotationEditorResult | None]):
         if self._on_submit is not None:
             self._on_submit(result)
         self.dismiss(result)
+
+    def _editor_controls(self) -> list[Widget]:
+        """Return the keyboard navigation order for editor controls."""
+        controls: list[Widget] = [
+            self.query_one("#annotation-tags", Input),
+            self.query_one("#annotation-note", TextArea),
+            self.query_one("#annotation-save", Button),
+        ]
+        delete = self.query_one("#annotation-delete", Button)
+        if not delete.disabled:
+            controls.append(delete)
+        controls.append(self.query_one("#annotation-cancel", Button))
+        return controls
+
+    def _focus_editor_index(self, index: int) -> None:
+        """Focus one editor control by navigation order index."""
+        controls = self._editor_controls()
+        self._editor_index = max(0, min(index, len(controls) - 1))
+        self._active_panel = "editor"
+        controls[self._editor_index].focus()
+        self._update_panel_classes()
+
+    def _update_panel_classes(self) -> None:
+        """Reflect which modal panel is currently active."""
+        editor = self.query_one("#annotation-editor-panel")
+        preview = self.query_one("#annotation-preview-panel")
+        editor.remove_class("annotation-modal-panel-active")
+        preview.remove_class("annotation-modal-panel-active")
+        if self._active_panel == "preview":
+            preview.add_class("annotation-modal-panel-active")
+        else:
+            editor.add_class("annotation-modal-panel-active")
 
 
 def extract_trajectory(data: Any) -> dict[str, Any] | None:
@@ -1460,6 +1586,7 @@ class JsonInspector(Vertical):
             AnnotationEditor(
                 path,
                 self._annotation_for_item(item),
+                item,
                 on_submit=self._handle_annotation_result,
             )
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -186,6 +186,21 @@ def _annotation_text(viewer: JsonInspector) -> str:
     return "\n".join(parts)
 
 
+def _modal_preview_text(screen) -> str:
+    """Collect textual content from the annotation modal preview panel."""
+    parts = []
+    preview = screen.query_one("#annotation-preview")
+    for widget in preview.query(Static):
+        content = _static_content(widget)
+        if isinstance(content, Text):
+            parts.append(content.plain)
+        elif isinstance(content, Syntax):
+            parts.append(content.code)
+        else:
+            parts.append(str(content))
+    return "\n".join(parts)
+
+
 def _detail_syntax_blocks(viewer: TrajectoryViewer | JsonInspector) -> list[Syntax]:
     """Return all Syntax renderables mounted inside the detail pane."""
     return [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -172,6 +172,20 @@ def _detail_text(viewer: TrajectoryViewer | JsonInspector) -> str:
     return "\n".join(parts)
 
 
+def _annotation_text(viewer: JsonInspector) -> str:
+    """Collect textual content from the JSON inspector annotation panel."""
+    parts = []
+    for widget in viewer._annotation_wrap.query(Static):
+        content = _static_content(widget)
+        if isinstance(content, Text):
+            parts.append(content.plain)
+        elif isinstance(content, Syntax):
+            parts.append(content.code)
+        else:
+            parts.append(str(content))
+    return "\n".join(parts)
+
+
 def _detail_syntax_blocks(viewer: TrajectoryViewer | JsonInspector) -> list[Syntax]:
     """Return all Syntax renderables mounted inside the detail pane."""
     return [

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -12,6 +12,7 @@ import pytest
 from conftest import (
     _annotation_text,
     _detail_text,
+    _modal_preview_text,
     _static_content,
     _tree_labels,
     sample_bundle,
@@ -25,6 +26,7 @@ from textual.widgets import Collapsible, Input, Markdown, Static, TextArea, Tree
 
 from skim import JsonInspector, PreviewPane, SkimApp, render_file
 from skim.preview import CsvPreview
+from skim.scrolling import FocusableDetailWrap
 
 
 def test_generic_json_uses_json_inspector(tmp_path):
@@ -455,6 +457,108 @@ async def test_annotation_modal_enter_moves_focus_to_note_without_saving(tmp_pat
         assert note.has_focus
         assert inspector._tree.cursor_node is first_node
         assert not (tmp_path / ".skim" / "review.json").exists()
+
+
+async def test_annotation_modal_shows_split_editor_and_node_preview(tmp_path):
+    """The annotation modal should show editor controls and selected-node preview."""
+    test_file = tmp_path / "plain.json"
+    test_file.write_text(json.dumps({"alpha": 1, "beta": 2}))
+    app = SkimApp(path=str(tmp_path))
+
+    async with app.run_test() as pilot:
+        pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
+        pane.show_file(test_file)
+        await pilot.pause()
+
+        await pilot.press("a")
+        await pilot.pause()
+
+        assert app.screen.query_one("#annotation-tags", Input).has_focus
+        preview_text = _modal_preview_text(app.screen)
+        assert "Path: $.alpha" in preview_text
+        assert "Type: int" in preview_text
+        assert "1" in preview_text
+
+
+async def test_annotation_modal_right_switches_to_preview_panel(tmp_path):
+    """Right should switch the active modal panel from editor to preview."""
+    test_file = tmp_path / "plain.json"
+    test_file.write_text(json.dumps({"alpha": 1}))
+    app = SkimApp(path=str(tmp_path))
+
+    async with app.run_test() as pilot:
+        pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
+        pane.show_file(test_file)
+        await pilot.pause()
+
+        await pilot.press("a")
+        await pilot.pause()
+        assert app.screen.query_one("#annotation-tags", Input).has_focus
+
+        await pilot.press("right")
+        await pilot.pause()
+
+        preview = app.screen.query_one("#annotation-preview", FocusableDetailWrap)
+        assert preview.has_focus
+
+
+async def test_annotation_modal_up_down_navigate_editor_controls(tmp_path):
+    """Up/down should navigate the left editor controls without using Tab."""
+    test_file = tmp_path / "plain.json"
+    test_file.write_text(json.dumps({"alpha": 1}))
+    app = SkimApp(path=str(tmp_path))
+
+    async with app.run_test() as pilot:
+        pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
+        pane.show_file(test_file)
+        await pilot.pause()
+
+        await pilot.press("a")
+        await pilot.pause()
+
+        tags = app.screen.query_one("#annotation-tags", Input)
+        note = app.screen.query_one("#annotation-note", TextArea)
+        save = app.screen.query_one("#annotation-save")
+
+        assert tags.has_focus
+
+        await pilot.press("down")
+        await pilot.pause()
+        assert note.has_focus
+
+        await pilot.press("down")
+        await pilot.pause()
+        assert save.has_focus
+
+        await pilot.press("up")
+        await pilot.pause()
+        assert note.has_focus
+
+
+async def test_annotation_modal_pagedown_scrolls_preview_panel(tmp_path):
+    """PageDown should scroll the right preview when that panel is active."""
+    test_file = tmp_path / "plain.json"
+    long_text = "\n".join(f"line {index}" for index in range(200))
+    test_file.write_text(json.dumps({"log": long_text}))
+    app = SkimApp(path=str(tmp_path))
+
+    async with app.run_test() as pilot:
+        pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
+        pane.show_file(test_file)
+        await pilot.pause()
+
+        await pilot.press("a")
+        await pilot.pause()
+        await pilot.press("right")
+        await pilot.pause()
+
+        preview = app.screen.query_one("#annotation-preview", FocusableDetailWrap)
+        before = preview.scroll_y
+
+        await pilot.press("pagedown")
+        await pilot.pause()
+
+        assert preview.scroll_y > before
 
 
 async def test_annotation_modal_blocks_tree_and_pane_shortcuts(tmp_path):

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -20,6 +20,7 @@ from conftest import (
     sample_trajectory,
 )
 from rich.syntax import Syntax
+from rich.text import Text
 from textual.widgets import Collapsible, Input, Markdown, Static, TextArea, Tree
 
 from skim import JsonInspector, PreviewPane, SkimApp, render_file
@@ -228,6 +229,56 @@ async def test_json_inspector_shows_empty_annotation_section_for_annotatable_nod
         assert "No annotation yet" in annotation
         assert "Press a to annotate" in annotation
         assert "No annotation yet" not in detail
+
+
+async def test_json_inspector_detail_follows_tree_cursor_without_enter(tmp_path):
+    """Moving the JSON tree cursor should update the right panel immediately."""
+    test_file = tmp_path / "plain.json"
+    test_file.write_text(json.dumps({"alpha": 1, "beta": 2}))
+    app = SkimApp(path=str(tmp_path))
+
+    async with app.run_test() as pilot:
+        pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
+        pane.show_file(test_file)
+        await pilot.pause()
+
+        inspector = pane.query_one(JsonInspector)
+        inspector.focus_tree_mode()
+        await pilot.pause()
+
+        assert inspector._tree.cursor_node is inspector._tree.root.children[0]
+        assert "Path: $.alpha" in _detail_text(inspector)
+
+        await pilot.press("down")
+        await pilot.pause()
+
+        assert inspector._tree.cursor_node is inspector._tree.root.children[1]
+        assert "Path: $.beta" in _detail_text(inspector)
+
+
+async def test_json_inspector_pagedown_scrolls_detail_without_leaving_tree(tmp_path):
+    """PageDown should scroll long JSON detail while arrows remain tree-only."""
+    test_file = tmp_path / "plain.json"
+    long_text = "\n".join(f"line {index}" for index in range(200))
+    test_file.write_text(json.dumps({"log": long_text, "other": "x"}))
+    app = SkimApp(path=str(tmp_path))
+
+    async with app.run_test() as pilot:
+        pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
+        pane.show_file(test_file)
+        await pilot.pause()
+
+        inspector = pane.query_one(JsonInspector)
+        inspector.focus_tree_mode()
+        await pilot.pause()
+
+        first_node = inspector._tree.root.children[0]
+        before_scroll = inspector._detail_wrap.scroll_y
+        await pilot.press("pagedown")
+        await pilot.pause()
+
+        assert inspector._detail_wrap.scroll_y > before_scroll
+        assert inspector._tree.cursor_node is first_node
 
 
 async def test_json_inspector_shows_unavailable_state_for_summary_nodes(tmp_path):
@@ -443,6 +494,29 @@ async def test_annotation_modal_blocks_tree_and_pane_shortcuts(tmp_path):
         assert inspector._tree.cursor_node is first_node
         assert inspector._tree.cursor_node is not second_node
         assert app.active_pane_id == active_before
+
+
+async def test_json_inspector_footer_shows_live_preview_controls(tmp_path):
+    """The JSON footer should describe the always-visible detail model."""
+    test_file = tmp_path / "plain.json"
+    test_file.write_text(json.dumps({"hello": "world"}))
+    app = SkimApp(path=str(tmp_path))
+
+    async with app.run_test() as pilot:
+        pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
+        pane.show_file(test_file)
+        await pilot.pause()
+
+        inspector = pane.query_one(JsonInspector)
+        footer = inspector.query_one(".trajectory-footer", Static)
+        content = _static_content(footer)
+
+        assert isinstance(content, Text)
+        assert "Move" in content.plain
+        assert "Branch" in content.plain
+        assert "PgUp/Dn" in content.plain
+        assert "Detail" not in content.plain
+        assert "Back to JSON" not in content.plain
 
 
 def test_bundle_json_uses_json_inspector_with_human_run_labels(tmp_path):

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -19,7 +19,7 @@ from conftest import (
     sample_trajectory,
 )
 from rich.syntax import Syntax
-from textual.widgets import Collapsible, Markdown, Static, Tree
+from textual.widgets import Collapsible, Input, Markdown, Static, TextArea, Tree
 
 from skim import JsonInspector, PreviewPane, SkimApp, render_file
 from skim.preview import CsvPreview
@@ -35,6 +35,19 @@ def test_generic_json_uses_json_inspector(tmp_path):
     assert len(widgets) == 1
     assert isinstance(widgets[0], JsonInspector)
     assert _tree_labels(widgets[0]._tree) == ["Hello world"]
+
+
+def test_render_file_passes_source_context_to_json_inspector(tmp_path):
+    """JSON inspectors should know the source file and review root."""
+    test_file = tmp_path / "plain.json"
+    test_file.write_text(json.dumps({"hello": "world"}))
+
+    widgets = render_file(test_file, browse_root=tmp_path)
+
+    inspector = widgets[0]
+    assert isinstance(inspector, JsonInspector)
+    assert inspector.source_path == test_file.resolve()
+    assert inspector.review_root == tmp_path.resolve()
 
 
 def test_csv_uses_specialized_preview(tmp_path):
@@ -192,6 +205,166 @@ async def test_submission_summary_node_renders_summary_detail(tmp_path):
         assert "Task Name:" in detail
         assert "Submission Type:" in detail
         assert "Grader Guidance" in detail
+
+
+async def test_json_inspector_shows_empty_annotation_section_for_annotatable_nodes(tmp_path):
+    """Annotatable JSON nodes should always show the annotation section."""
+    test_file = tmp_path / "plain.json"
+    test_file.write_text(json.dumps({"hello": "world"}))
+    widgets = render_file(test_file, browse_root=tmp_path)
+    inspector = widgets[0]
+    assert isinstance(inspector, JsonInspector)
+
+    app = SkimApp(path=str(tmp_path))
+    async with app.run_test() as pilot:
+        pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
+        await pane.mount(inspector)
+        await pilot.pause()
+
+        detail = _detail_text(inspector)
+        assert "Annotation" in detail
+        assert "No annotation yet" in detail
+        assert "Press a to annotate" in detail
+
+
+async def test_json_inspector_omits_annotation_section_for_summary_nodes(tmp_path):
+    """Synthetic summary nodes should stay read-only in the MVP."""
+    test_file = tmp_path / "submission.json"
+    test_file.write_text(json.dumps(sample_submission()))
+    widgets = render_file(test_file, browse_root=tmp_path)
+    inspector = widgets[0]
+    assert isinstance(inspector, JsonInspector)
+
+    app = SkimApp(path=str(tmp_path))
+    async with app.run_test() as pilot:
+        pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
+        await pane.mount(inspector)
+        summary_node = inspector._tree.root.children[0]
+        inspector.on_tree_node_selected(Tree.NodeSelected(summary_node))
+        await pilot.pause()
+
+        detail = _detail_text(inspector)
+        assert "Annotation" not in detail
+        assert "Press a to annotate" not in detail
+
+
+async def test_persisted_annotations_mark_tree_and_detail_on_reload(tmp_path):
+    """Stored annotations should reload into the tree marker and detail pane."""
+    test_file = tmp_path / "plain.json"
+    test_file.write_text(json.dumps({"hello": "world"}))
+    review_file = tmp_path / ".skim" / "review.json"
+    review_file.parent.mkdir()
+    review_file.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "files": {
+                    "plain.json": {
+                        "annotations": {
+                            "$.hello": {
+                                "tags": ["evidence", "bug"],
+                                "note": "First concrete failure appears here.",
+                            }
+                        }
+                    }
+                },
+            }
+        )
+    )
+
+    widgets = render_file(test_file, browse_root=tmp_path)
+    inspector = widgets[0]
+    assert isinstance(inspector, JsonInspector)
+    assert inspector._tree.root.children[0].label.plain.startswith("* ")
+
+    app = SkimApp(path=str(tmp_path))
+    async with app.run_test() as pilot:
+        pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
+        await pane.mount(inspector)
+        await pilot.pause()
+
+        detail = _detail_text(inspector)
+        assert "Annotation" in detail
+        assert "evidence, bug" in detail
+        assert "First concrete failure appears here." in detail
+
+
+async def test_annotation_modal_saves_selected_node_annotation(tmp_path):
+    """Pressing a should open the modal and persist the selected annotation."""
+    test_file = tmp_path / "plain.json"
+    test_file.write_text(json.dumps({"hello": "world"}))
+    app = SkimApp(path=str(tmp_path))
+
+    async with app.run_test() as pilot:
+        pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
+        pane.show_file(test_file)
+        await pilot.pause()
+
+        inspector = pane.query_one(JsonInspector)
+        await pilot.press("a")
+        await pilot.pause()
+
+        tags = app.screen.query_one("#annotation-tags", Input)
+        note = app.screen.query_one("#annotation-note", TextArea)
+        tags.value = "evidence, bug"
+        note.load_text("First concrete failure appears here.")
+        app.screen.action_save()
+        await pilot.pause()
+
+        review_file = tmp_path / ".skim" / "review.json"
+        payload = json.loads(review_file.read_text())
+        assert payload["files"]["plain.json"]["annotations"]["$.hello"] == {
+            "tags": ["evidence", "bug"],
+            "note": "First concrete failure appears here.",
+        }
+        assert inspector._tree.root.children[0].label.plain.startswith("* ")
+        detail = _detail_text(inspector)
+        assert "evidence, bug" in detail
+        assert "First concrete failure appears here." in detail
+
+
+async def test_annotation_modal_delete_removes_selected_node_annotation(tmp_path):
+    """Deleting from the annotation modal should clear persistence and UI state."""
+    test_file = tmp_path / "plain.json"
+    test_file.write_text(json.dumps({"hello": "world"}))
+    review_file = tmp_path / ".skim" / "review.json"
+    review_file.parent.mkdir()
+    review_file.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "files": {
+                    "plain.json": {
+                        "annotations": {
+                            "$.hello": {
+                                "tags": ["evidence"],
+                                "note": "First concrete failure appears here.",
+                            }
+                        }
+                    }
+                },
+            }
+        )
+    )
+    app = SkimApp(path=str(tmp_path))
+
+    async with app.run_test() as pilot:
+        pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
+        pane.show_file(test_file)
+        await pilot.pause()
+
+        inspector = pane.query_one(JsonInspector)
+        await pilot.press("a")
+        await pilot.pause()
+        app.screen.action_delete()
+        await pilot.pause()
+
+        payload = json.loads(review_file.read_text())
+        assert payload["files"]["plain.json"]["annotations"] == {}
+        assert not inspector._tree.root.children[0].label.plain.startswith("* ")
+        detail = _detail_text(inspector)
+        assert "No annotation yet" in detail
+        assert "Press a to annotate" in detail
 
 
 def test_bundle_json_uses_json_inspector_with_human_run_labels(tmp_path):

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -10,6 +10,7 @@ import json
 
 import pytest
 from conftest import (
+    _annotation_text,
     _detail_text,
     _static_content,
     _tree_labels,
@@ -208,7 +209,7 @@ async def test_submission_summary_node_renders_summary_detail(tmp_path):
 
 
 async def test_json_inspector_shows_empty_annotation_section_for_annotatable_nodes(tmp_path):
-    """Annotatable JSON nodes should always show the annotation section."""
+    """Annotatable JSON nodes should show a separate annotation panel."""
     test_file = tmp_path / "plain.json"
     test_file.write_text(json.dumps({"hello": "world"}))
     widgets = render_file(test_file, browse_root=tmp_path)
@@ -221,14 +222,16 @@ async def test_json_inspector_shows_empty_annotation_section_for_annotatable_nod
         await pane.mount(inspector)
         await pilot.pause()
 
+        annotation = _annotation_text(inspector)
         detail = _detail_text(inspector)
-        assert "Annotation" in detail
-        assert "No annotation yet" in detail
-        assert "Press a to annotate" in detail
+        assert "Annotation" in annotation
+        assert "No annotation yet" in annotation
+        assert "Press a to annotate" in annotation
+        assert "No annotation yet" not in detail
 
 
-async def test_json_inspector_omits_annotation_section_for_summary_nodes(tmp_path):
-    """Synthetic summary nodes should stay read-only in the MVP."""
+async def test_json_inspector_shows_unavailable_state_for_summary_nodes(tmp_path):
+    """Synthetic summary nodes should show an unavailable annotation state."""
     test_file = tmp_path / "submission.json"
     test_file.write_text(json.dumps(sample_submission()))
     widgets = render_file(test_file, browse_root=tmp_path)
@@ -243,13 +246,14 @@ async def test_json_inspector_omits_annotation_section_for_summary_nodes(tmp_pat
         inspector.on_tree_node_selected(Tree.NodeSelected(summary_node))
         await pilot.pause()
 
-        detail = _detail_text(inspector)
-        assert "Annotation" not in detail
-        assert "Press a to annotate" not in detail
+        annotation = _annotation_text(inspector)
+        assert "Annotation" in annotation
+        assert "Unavailable" in annotation
+        assert "summary nodes" in annotation.lower()
 
 
 async def test_persisted_annotations_mark_tree_and_detail_on_reload(tmp_path):
-    """Stored annotations should reload into the tree marker and detail pane."""
+    """Stored annotations should reload into the tree marker and annotation panel."""
     test_file = tmp_path / "plain.json"
     test_file.write_text(json.dumps({"hello": "world"}))
     review_file = tmp_path / ".skim" / "review.json"
@@ -283,10 +287,12 @@ async def test_persisted_annotations_mark_tree_and_detail_on_reload(tmp_path):
         await pane.mount(inspector)
         await pilot.pause()
 
+        annotation = _annotation_text(inspector)
         detail = _detail_text(inspector)
-        assert "Annotation" in detail
-        assert "evidence, bug" in detail
-        assert "First concrete failure appears here." in detail
+        assert "Annotation" in annotation
+        assert "evidence, bug" in annotation
+        assert "First concrete failure appears here." in annotation
+        assert "First concrete failure appears here." not in detail
 
 
 async def test_annotation_modal_saves_selected_node_annotation(tmp_path):
@@ -318,9 +324,11 @@ async def test_annotation_modal_saves_selected_node_annotation(tmp_path):
             "note": "First concrete failure appears here.",
         }
         assert inspector._tree.root.children[0].label.plain.startswith("* ")
+        annotation = _annotation_text(inspector)
         detail = _detail_text(inspector)
-        assert "evidence, bug" in detail
-        assert "First concrete failure appears here." in detail
+        assert "evidence, bug" in annotation
+        assert "First concrete failure appears here." in annotation
+        assert "First concrete failure appears here." not in detail
 
 
 async def test_annotation_modal_delete_removes_selected_node_annotation(tmp_path):
@@ -362,9 +370,79 @@ async def test_annotation_modal_delete_removes_selected_node_annotation(tmp_path
         payload = json.loads(review_file.read_text())
         assert payload["files"]["plain.json"]["annotations"] == {}
         assert not inspector._tree.root.children[0].label.plain.startswith("* ")
+        annotation = _annotation_text(inspector)
         detail = _detail_text(inspector)
-        assert "No annotation yet" in detail
-        assert "Press a to annotate" in detail
+        assert "No annotation yet" in annotation
+        assert "Press a to annotate" in annotation
+        assert "No annotation yet" not in detail
+
+
+async def test_annotation_modal_enter_moves_focus_to_note_without_saving(tmp_path):
+    """Enter in the tags field should stay inside the modal and move to the note."""
+    test_file = tmp_path / "plain.json"
+    test_file.write_text(json.dumps({"alpha": 1, "beta": 2}))
+    app = SkimApp(path=str(tmp_path))
+
+    async with app.run_test() as pilot:
+        pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
+        pane.show_file(test_file)
+        await pilot.pause()
+
+        inspector = pane.query_one(JsonInspector)
+        first_node = inspector._tree.root.children[0]
+        assert inspector._tree.cursor_node is first_node
+
+        await pilot.press("a")
+        await pilot.pause()
+
+        note = app.screen.query_one("#annotation-note", TextArea)
+        assert not note.has_focus
+
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert note.has_focus
+        assert inspector._tree.cursor_node is first_node
+        assert not (tmp_path / ".skim" / "review.json").exists()
+
+
+async def test_annotation_modal_blocks_tree_and_pane_shortcuts(tmp_path):
+    """While the annotation modal is open, app-level shortcuts should not fire."""
+    first_file = tmp_path / "plain.json"
+    first_file.write_text(json.dumps({"alpha": 1, "beta": 2}))
+    second_file = tmp_path / "other.json"
+    second_file.write_text(json.dumps({"hello": "world"}))
+    app = SkimApp(path=str(tmp_path))
+
+    async with app.run_test() as pilot:
+        await pilot.press("s")
+        await pilot.press("right")
+        await pilot.pause()
+
+        first_pane = app.query_one("#pane-0", PreviewPane)
+        first_pane.show_file(first_file)
+        app.set_active_pane("pane-0")
+        await pilot.pause()
+
+        inspector = first_pane.query_one(JsonInspector)
+        inspector.focus_tree_mode()
+        await pilot.pause()
+        first_node = inspector._tree.root.children[0]
+        second_node = inspector._tree.root.children[1]
+        assert inspector._tree.cursor_node is first_node
+
+        await pilot.press("a")
+        await pilot.pause()
+
+        active_before = app.active_pane_id
+        await pilot.press("down")
+        await pilot.pause()
+        await pilot.press("w")
+        await pilot.pause()
+
+        assert inspector._tree.cursor_node is first_node
+        assert inspector._tree.cursor_node is not second_node
+        assert app.active_pane_id == active_before
 
 
 def test_bundle_json_uses_json_inspector_with_human_run_labels(tmp_path):

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -574,6 +574,37 @@ async def test_annotation_modal_pagedown_scrolls_preview_panel_from_editor_focus
         assert preview.scroll_y > before
 
 
+async def test_annotation_modal_footer_shows_modal_commands(tmp_path):
+    """The annotation modal should show a local footer with its own key hints."""
+    test_file = tmp_path / "plain.json"
+    test_file.write_text(json.dumps({"alpha": 1}))
+    app = SkimApp(path=str(tmp_path))
+
+    async with app.run_test() as pilot:
+        pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
+        pane.show_file(test_file)
+        await pilot.pause()
+
+        await pilot.press("a")
+        await pilot.pause()
+
+        footer = app.screen.query_one("#annotation-modal-footer", Static)
+        content = _static_content(footer)
+
+        assert isinstance(content, Text)
+        assert "Annotation" in content.plain
+        assert "Esc" in content.plain
+        assert "Close" in content.plain
+        assert "Tab" in content.plain
+        assert "Next field" in content.plain
+        assert "Enter" in content.plain
+        assert "Tags→Note" in content.plain
+        assert "PgUp/Dn" in content.plain
+        assert "Scroll preview" in content.plain
+        assert "Move" not in content.plain
+        assert "Branch" not in content.plain
+
+
 async def test_annotation_modal_blocks_tree_and_pane_shortcuts(tmp_path):
     """While the annotation modal is open, app-level shortcuts should not fire."""
     first_file = tmp_path / "plain.json"

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -24,9 +24,11 @@ from rich.syntax import Syntax
 from rich.text import Text
 from textual.widgets import Collapsible, Input, Markdown, Static, TextArea, Tree
 
+import skim.trajectory as trajectory_module
 from skim import JsonInspector, PreviewPane, SkimApp, render_file
 from skim.preview import CsvPreview
 from skim.scrolling import FocusableDetailWrap
+from skim.trajectory import AnnotationStore
 
 
 def test_generic_json_uses_json_inspector(tmp_path):
@@ -346,6 +348,82 @@ async def test_persisted_annotations_mark_tree_and_detail_on_reload(tmp_path):
         assert "evidence, bug" in annotation
         assert "First concrete failure appears here." in annotation
         assert "First concrete failure appears here." not in detail
+
+
+def test_annotation_store_caches_one_file_lookup(tmp_path, monkeypatch):
+    """Repeated annotation reads for one file should reuse the normalized cache."""
+    source = tmp_path / "plain.json"
+    source.write_text(json.dumps({"hello": "world"}))
+    review_file = tmp_path / ".skim" / "review.json"
+    review_file.parent.mkdir()
+    review_file.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "files": {
+                    "plain.json": {
+                        "annotations": {
+                            "$.hello": {
+                                "tags": ["evidence"],
+                                "note": "cached",
+                            }
+                        }
+                    }
+                },
+            }
+        )
+    )
+
+    store = AnnotationStore(tmp_path)
+    calls = 0
+    original = store._build_annotations_for_relative_path
+
+    def wrapped(relative_path: str):
+        nonlocal calls
+        calls += 1
+        return original(relative_path)
+
+    monkeypatch.setattr(store, "_build_annotations_for_relative_path", wrapped)
+
+    first = store.get_annotation(source, "$.hello")
+    second = store.get_annotation(source, "$.hello")
+    records = store.annotations_for_file(source)
+
+    assert first is not None
+    assert second is not None
+    assert first.note == "cached"
+    assert second.note == "cached"
+    assert records["$.hello"].note == "cached"
+    assert calls == 1
+
+    store.set_annotation(source, "$.hello", tags=("updated",), note="changed")
+
+    updated = store.get_annotation(source, "$.hello")
+    assert updated is not None
+    assert updated.note == "changed"
+    assert calls == 1
+
+
+def test_trajectory_json_inspector_uses_one_overlay_normalization_pass(tmp_path, monkeypatch):
+    """Opening trajectory JSON should normalize overlay data through one shared pass."""
+    test_file = tmp_path / "trajectory.json"
+    test_file.write_text(json.dumps(sample_trajectory()))
+
+    calls = 0
+    original = trajectory_module.normalize_step_overlay
+
+    def wrapped(trajectory):
+        nonlocal calls
+        calls += 1
+        return original(trajectory)
+
+    monkeypatch.setattr(trajectory_module, "normalize_step_overlay", wrapped)
+
+    widgets = render_file(test_file, browse_root=tmp_path)
+
+    assert len(widgets) == 1
+    assert isinstance(widgets[0], JsonInspector)
+    assert calls == 1
 
 
 async def test_annotation_modal_saves_selected_node_annotation(tmp_path):

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -480,8 +480,8 @@ async def test_annotation_modal_shows_split_editor_and_node_preview(tmp_path):
         assert "1" in preview_text
 
 
-async def test_annotation_modal_right_switches_to_preview_panel(tmp_path):
-    """Right should switch the active modal panel from editor to preview."""
+async def test_annotation_modal_left_right_do_not_switch_focus(tmp_path):
+    """Left/right should stay local to the focused editor control."""
     test_file = tmp_path / "plain.json"
     test_file.write_text(json.dumps({"alpha": 1}))
     app = SkimApp(path=str(tmp_path))
@@ -493,17 +493,23 @@ async def test_annotation_modal_right_switches_to_preview_panel(tmp_path):
 
         await pilot.press("a")
         await pilot.pause()
-        assert app.screen.query_one("#annotation-tags", Input).has_focus
+        tags = app.screen.query_one("#annotation-tags", Input)
+        preview = app.screen.query_one("#annotation-preview", FocusableDetailWrap)
+        assert tags.has_focus
 
         await pilot.press("right")
         await pilot.pause()
+        assert tags.has_focus
+        assert not preview.has_focus
 
-        preview = app.screen.query_one("#annotation-preview", FocusableDetailWrap)
-        assert preview.has_focus
+        await pilot.press("left")
+        await pilot.pause()
+        assert tags.has_focus
+        assert not preview.has_focus
 
 
-async def test_annotation_modal_up_down_navigate_editor_controls(tmp_path):
-    """Up/down should navigate the left editor controls without using Tab."""
+async def test_annotation_modal_up_down_stay_local_to_note_editor(tmp_path):
+    """Up/down should not move focus out of the note editor."""
     test_file = tmp_path / "plain.json"
     test_file.write_text(json.dumps({"alpha": 1}))
     app = SkimApp(path=str(tmp_path))
@@ -516,27 +522,25 @@ async def test_annotation_modal_up_down_navigate_editor_controls(tmp_path):
         await pilot.press("a")
         await pilot.pause()
 
-        tags = app.screen.query_one("#annotation-tags", Input)
         note = app.screen.query_one("#annotation-note", TextArea)
         save = app.screen.query_one("#annotation-save")
 
-        assert tags.has_focus
-
-        await pilot.press("down")
+        await pilot.press("enter")
         await pilot.pause()
         assert note.has_focus
 
         await pilot.press("down")
         await pilot.pause()
-        assert save.has_focus
+        assert note.has_focus
+        assert not save.has_focus
 
         await pilot.press("up")
         await pilot.pause()
         assert note.has_focus
 
 
-async def test_annotation_modal_pagedown_scrolls_preview_panel(tmp_path):
-    """PageDown should scroll the right preview when that panel is active."""
+async def test_annotation_modal_pagedown_scrolls_preview_panel_from_editor_focus(tmp_path):
+    """PageDown should scroll the right preview even while editing on the left."""
     test_file = tmp_path / "plain.json"
     long_text = "\n".join(f"line {index}" for index in range(200))
     test_file.write_text(json.dumps({"log": long_text}))
@@ -549,12 +553,21 @@ async def test_annotation_modal_pagedown_scrolls_preview_panel(tmp_path):
 
         await pilot.press("a")
         await pilot.pause()
-        await pilot.press("right")
-        await pilot.pause()
 
         preview = app.screen.query_one("#annotation-preview", FocusableDetailWrap)
+        note = app.screen.query_one("#annotation-note", TextArea)
         before = preview.scroll_y
 
+        await pilot.press("pagedown")
+        await pilot.pause()
+
+        assert preview.scroll_y > before
+
+        await pilot.press("enter")
+        await pilot.pause()
+        assert note.has_focus
+
+        before = preview.scroll_y
         await pilot.press("pagedown")
         await pilot.pause()
 


### PR DESCRIPTION
## Summary
- add JSON-node annotations persisted in `.skim/review.json`
- show annotation state in the inspector tree/detail flow and edit annotations in a split modal with a local footer
- simplify JSON inspection/navigation and cache annotation lookups to avoid large `trajectory.json` open hiccups

## What changed
- route JSON previews into an annotation-aware `JsonInspector` with source/root context
- bind annotations to `annotation_path or raw_path`, mark annotated nodes in the tree, and show a dedicated annotation status panel
- add an annotation modal with tags/note editing, inline node preview, modal-local keyboard handling, and footer hints
- keep review artifacts local by ignoring `.skim`
- reduce open-time cost by caching per-file annotations and sharing trajectory overlay normalization work

## Why
This is the next step from a read-only JSON/trajectory browser into a local review tool. It gives reviewers a minimal annotation workflow without changing the outer skim shell, and it removes the biggest performance regression introduced by annotation-aware tree labeling.

## Validation
- `uv run pytest -v`
- `uv run ruff check src/ tests/`

## Impact
Reviewers can now annotate raw-backed JSON nodes, keep those notes locally under the browse root, and inspect/edit them in the existing JSON workflow without switching to a separate review screen.