### PR TITLE
[codex] Fix file-tree key routing and footer hints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,5 @@ CLAUDE.md
 docs/v1/
 data/
 .ruff_cache/
+.pytest_cache/
 .skim/

--- a/README.md
+++ b/README.md
@@ -105,8 +105,8 @@ overlay node maps to a raw node and falling back to `raw_path` otherwise.
 
 ## File size limits
 
-Files over `1MB` are skipped to keep text previews responsive. JSON files get a higher
-limit of `10MB`.
+Files over `1MB` are skipped to keep text previews responsive. JSON and notebook
+(`.ipynb`) files get a higher limit of `10MB`.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ A terminal UI for browsing folders and reviewing local artifacts. Built with
 [Textual](https://textual.textualize.io/).
 
 Point it at any directory to get a file tree on the left and a content preview on the
-right, with syntax highlighting, markdown rendering, split panes, and a **JSON inspector**
-that now supports `local node annotations`.
+right, with syntax highlighting, markdown rendering, split panes, flat `.ipynb`
+rendering, and a **JSON inspector** that now supports `local node annotations`.
 
 ## Install
 
@@ -27,20 +27,34 @@ uv run skim-dev          # launch Textual dev mode
 
 ## Keybindings
 
+### Shell And Pane Navigation
+
 | Key | Action |
 |---|---|
-| `f` | Toggle between the file tree and the active preview pane |
-| `Shift+Up/Down` | Move the file tree cursor |
-| `Enter` | Open the selected file from the tree |
-| `Esc` | Leave file-tree mode or return from trajectory detail to the trajectory tree |
 | `Up/Down` or `j/k` | Scroll the active preview pane |
-| `PageUp/PageDown` | Page-scroll the active preview pane or JSON detail panel |
+| `PageUp/PageDown` | Page-scroll the active preview pane |
+| `f` | Toggle file-tree mode |
+| `Shift+Up/Down` | Move the file-tree cursor without leaving the active preview |
+| `Enter` | Open the current file-tree selection in the active pane |
 | `s` then arrow or `h/j/k/l` | Split in a direction |
 | `d` | Close the active pane |
 | `w` | Cycle to the next pane |
 | `q` | Quit |
 
-Specialized previews also show local command footers.
+### File-Tree Mode
+
+| Key | Action |
+|---|---|
+| `Up/Down` or `j/k` | Move the file-tree cursor |
+| `Left/Right` | Collapse, expand, or move across file-tree branches |
+| `Right` on a file | Open that file in the active pane |
+| `Enter` | Open the selected file or directory entry |
+| `Esc` | Return to the active preview pane |
+
+Trajectory and JSON previews show their own local command footers when they have
+specialized navigation. Flat notebook previews use the generic pane scrolling above.
+
+### Trajectory Preview
 
 Trajectory previews use a tree/detail model:
 
@@ -51,6 +65,8 @@ Trajectory previews use a tree/detail model:
 | `Enter` | Open the selected trajectory node in the detail pane |
 | `Esc` | Return from the detail pane to the trajectory tree |
 
+### JSON Inspector
+
 JSON previews use a live inspector model:
 
 | Key | Action |
@@ -60,7 +76,7 @@ JSON previews use a live inspector model:
 | `PageUp/PageDown` | Scroll the right-hand detail panel |
 | `a` | Open the annotation editor for the selected annotatable node |
 
-Inside the annotation modal:
+### Annotation Modal
 
 | Key | Action |
 |---|---|
@@ -78,8 +94,7 @@ You can have up to 6 panes arranged in a 2 row by 3 column grid. Press `s` follo
 JSON files open in a structural inspector rather than a plain text dump. The inspector:
 
 - shows a tree on the left and detail panels on the right
-- adds schema-aware overlays for supported artifacts such as raw trajectories, bundles,
-  submissions, and Hermes-style transcripts
+- adds schema-aware overlays for supported artifacts such as raw agent trajectories.
 - keeps annotations local in `<browse-root>/.skim/review.json`
 - marks annotated nodes in the tree and shows annotation state in a separate status panel
 - opens a split annotation modal with tags and note editing on the left and a read-only

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ uv run skim-dev          # launch Textual dev mode
 | Key | Action |
 |---|---|
 | `Up/Down` or `j/k` | Scroll the active preview pane |
-| `PageUp/PageDown` | Page-scroll the active preview pane |
+| `PageUp/PageDown` | Page-scroll the active preview pane; in JSON inspector mode, scroll the detail panel |
 | `f` | Toggle file-tree mode |
 | `Shift+Up/Down` | Move the file-tree cursor without leaving the active preview |
 | `Enter` | Open the current file-tree selection in the active pane |

--- a/README.md
+++ b/README.md
@@ -88,15 +88,7 @@ JSON files open in a structural inspector rather than a plain text dump. The ins
 Annotations bind to the underlying raw JSON location, using `annotation_path` when an
 overlay node maps to a raw node and falling back to `raw_path` otherwise.
 
-## Supported file types and limits
-
-Syntax highlighting works for Python, JSON, JavaScript, TypeScript, HTML, CSS, YAML,
-TOML, Bash, Rust, Go, SQL, and XML. Markdown files are rendered with formatting.
-
-JSON files are parsed into the inspector described above. CSV files render as a compact
-table preview with the raw CSV available below it, capped for readability. Non-JSON,
-non-Markdown text formats fall back to syntax-highlighted source when a lexer is
-available.
+## File size limits
 
 Files over `1MB` are skipped to keep text previews responsive. JSON files get a higher
 limit of `10MB`.

--- a/src/skim/app.py
+++ b/src/skim/app.py
@@ -257,6 +257,7 @@ class SkimApp(App):
             return (
                 " [bold]q[/] Quit  "
                 "[bold]↑↓[/] Move tree  "
+                "[bold]←→[/] Branch  "
                 "[bold]Enter[/] Open  "
                 "[bold]Esc[/] Back  "
                 "[bold]⇧↑↓[/] Tree shortcut  "
@@ -368,6 +369,37 @@ class SkimApp(App):
             return
         self.query_one(DirectoryTree).action_select_cursor()
 
+    def action_tree_left(self) -> None:
+        """Collapse the current file-tree branch or move to its parent."""
+        if self._modal_is_active():
+            return
+        tree = self.query_one(DirectoryTree)
+        node = tree.cursor_node
+        if node is None:
+            return
+        if node.allow_expand and node.is_expanded:
+            node.collapse()
+            return
+        if node.parent is not None:
+            tree.move_cursor(node.parent, animate=False)
+
+    def action_tree_right(self) -> None:
+        """Expand the current file-tree branch, move into it, or open a file."""
+        if self._modal_is_active():
+            return
+        tree = self.query_one(DirectoryTree)
+        node = tree.cursor_node
+        if node is None:
+            return
+        if node.allow_expand:
+            if node.is_collapsed:
+                node.expand()
+                return
+            if node.children:
+                tree.move_cursor(node.children[0], animate=False)
+            return
+        self.action_tree_select()
+
     def action_page_down(self) -> None:
         """Scroll the active content by a page-sized amount."""
         if self._modal_is_active():
@@ -436,6 +468,16 @@ class SkimApp(App):
                 return
             if event.key in {"down", "j"}:
                 self.action_tree_down()
+                event.prevent_default()
+                event.stop()
+                return
+            if event.key == "left":
+                self.action_tree_left()
+                event.prevent_default()
+                event.stop()
+                return
+            if event.key == "right":
+                self.action_tree_right()
                 event.prevent_default()
                 event.stop()
                 return

--- a/src/skim/app.py
+++ b/src/skim/app.py
@@ -256,11 +256,9 @@ class SkimApp(App):
         if self.file_tree_mode:
             return (
                 " [bold]q[/] Quit  "
-                "[bold]↑↓[/] Move tree  "
+                "[bold]↑↓[/] Move  "
                 "[bold]←→[/] Branch  "
-                "[bold]Enter[/] Open  "
                 "[bold]Esc[/] Back  "
-                "[bold]⇧↑↓[/] Tree shortcut  "
                 "[bold]s[/]+arrow Split  "
                 "[bold]d[/] Close  "
                 "[bold]w[/] Next pane"
@@ -268,9 +266,8 @@ class SkimApp(App):
         return (
             " [bold]q[/] Quit  "
             "[bold]↑↓[/] Scroll  "
-            "[bold]f[/] Toggle tree  "
-            "[bold]⇧↑↓[/] Tree shortcut  "
-            "[bold]Enter[/] Open  "
+            "[bold]PgUp/Dn[/] Page  "
+            "[bold]f[/] Tree  "
             "[bold]s[/]+arrow Split  "
             "[bold]d[/] Close  "
             "[bold]w[/] Next pane"

--- a/src/skim/preview.py
+++ b/src/skim/preview.py
@@ -71,19 +71,6 @@ class CsvPreview(Vertical):
         yield from self._widgets
 
 
-class NotebookPreview(Vertical):
-    """Notebook preview with cell-aware rendering."""
-
-    def __init__(self, notebook: dict[str, Any]) -> None:
-        """Initialize the notebook preview from parsed notebook JSON."""
-        super().__init__(classes="notebook-preview")
-        self._widgets = _notebook_preview_widgets(notebook)
-
-    def compose(self) -> ComposeResult:
-        """Compose the notebook preview widgets."""
-        yield from self._widgets
-
-
 class PreviewPane(DragScrollMixin, VerticalScroll, can_focus=True):
     """Scrollable panel that shows file contents."""
 
@@ -168,7 +155,7 @@ def render_file(path: Path, *, browse_root: Path | None = None) -> list[Widget]:
         try:
             parsed = json.loads(content)
             if _looks_like_notebook(parsed):
-                return [NotebookPreview(parsed)]
+                return _notebook_preview_widgets(parsed)
         except json.JSONDecodeError:
             pass
 
@@ -307,7 +294,9 @@ def _notebook_preview_widgets(notebook: dict[str, Any]) -> list[Widget]:
         cells = []
     language = _notebook_language(notebook.get("metadata"))
 
-    widgets: list[Widget] = [Static(_notebook_summary_text(notebook, len(cells), language))]
+    widgets: list[Widget] = [
+        Static(_notebook_summary_text(notebook, len(cells), language), classes="notebook-summary")
+    ]
     for index, cell in enumerate(cells, start=1):
         widgets.extend(_notebook_cell_widgets(cell, index, language))
     if len(widgets) == 1:
@@ -343,41 +332,46 @@ def _notebook_summary_text(notebook: dict[str, Any], cell_count: int, language: 
 
 
 def _notebook_cell_widgets(cell: Any, index: int, language: str) -> list[Widget]:
-    """Return widgets for one notebook cell and its outputs."""
+    """Return flat widgets for one notebook cell and its outputs."""
     if not isinstance(cell, dict):
         return [
-            Collapsible(
-                Static(Text("Unsupported cell payload", style="yellow")),
-                title=f"Cell {index}",
-                collapsed=False,
-            )
+            Static(Text(f"Cell {index}", style="bold")),
+            Static(Text("Unsupported cell payload", style="yellow")),
         ]
     cell_type = cell.get("cell_type")
     if not isinstance(cell_type, str):
         cell_type = "raw"
     source = _notebook_text(cell.get("source"))
 
-    if cell_type == "markdown":
-        body: Widget = Markdown(source or "_Empty markdown cell_")
-    elif cell_type == "code":
-        body = Static(Syntax(source, language, line_numbers=True, word_wrap=True))
-    else:
-        body = Static(Text(source))
-
     widgets: list[Widget] = [
-        Collapsible(body, title=f"{cell_type.title()} Cell {index}", collapsed=False)
+        Static(
+            Text(f"{cell_type.title()} Cell {index}", style="bold"),
+            classes="notebook-cell-label",
+        )
     ]
+    if cell_type == "markdown":
+        widgets.append(Markdown(source or "_Empty markdown cell_"))
+    elif cell_type == "code":
+        widgets.append(
+            Static(
+                Syntax(source, language, line_numbers=True, word_wrap=True),
+                classes="notebook-code-cell",
+            )
+        )
+    else:
+        widgets.append(Static(Text(source), classes="notebook-raw-cell"))
+
     if cell_type == "code":
         outputs = cell.get("outputs")
         if isinstance(outputs, list):
             for output_index, output in enumerate(outputs, start=1):
                 widgets.append(
-                    Collapsible(
-                        _notebook_output_widget(output),
-                        title=f"Output {index}.{output_index}",
-                        collapsed=False,
+                    Static(
+                        Text(f"Output {index}.{output_index}", style="bold"),
+                        classes="notebook-output-label",
                     )
                 )
+                widgets.append(_notebook_output_widget(output))
     return widgets
 
 

--- a/src/skim/preview.py
+++ b/src/skim/preview.py
@@ -28,6 +28,8 @@ from .trajectory import JsonInspector, TrajectoryViewer
 SYNTAX_MAP = {
     ".py": "python",
     ".json": "json",
+    ".ipynb": "json",
+    ".ipynd": "json",
     ".js": "javascript",
     ".ts": "typescript",
     ".html": "html",
@@ -44,6 +46,7 @@ SYNTAX_MAP = {
     ".csv": "csv",
 }
 MARKDOWN_EXTENSIONS = {".md", ".markdown", ".mdown"}
+JSON_EXTENSIONS = {".json", ".ipynb", ".ipynd"}
 MAX_FILE_SIZE = 1_000_000
 MAX_JSON_FILE_SIZE = 10_000_000
 MAX_CSV_ROWS = 20
@@ -132,7 +135,7 @@ def render_file(path: Path, *, browse_root: Path | None = None) -> list[Widget]:
 
     suffix = path.suffix.lower()
     size = path.stat().st_size
-    max_size = MAX_JSON_FILE_SIZE if suffix == ".json" else MAX_FILE_SIZE
+    max_size = MAX_JSON_FILE_SIZE if suffix in JSON_EXTENSIONS else MAX_FILE_SIZE
     if size > max_size:
         return [Static(Text(f"{path.name} is too large ({size:,} bytes)", style="red"))]
 
@@ -144,7 +147,7 @@ def render_file(path: Path, *, browse_root: Path | None = None) -> list[Widget]:
     if suffix in MARKDOWN_EXTENSIONS:
         return [Markdown(content)]
 
-    if suffix == ".json":
+    if suffix in JSON_EXTENSIONS:
         try:
             parsed = json.loads(content)
             return [

--- a/src/skim/preview.py
+++ b/src/skim/preview.py
@@ -29,7 +29,6 @@ SYNTAX_MAP = {
     ".py": "python",
     ".json": "json",
     ".ipynb": "json",
-    ".ipynd": "json",
     ".js": "javascript",
     ".ts": "typescript",
     ".html": "html",
@@ -46,7 +45,8 @@ SYNTAX_MAP = {
     ".csv": "csv",
 }
 MARKDOWN_EXTENSIONS = {".md", ".markdown", ".mdown"}
-JSON_EXTENSIONS = {".json", ".ipynb", ".ipynd"}
+JSON_EXTENSIONS = {".json"}
+NOTEBOOK_EXTENSIONS = {".ipynb"}
 MAX_FILE_SIZE = 1_000_000
 MAX_JSON_FILE_SIZE = 10_000_000
 MAX_CSV_ROWS = 20
@@ -68,6 +68,19 @@ class CsvPreview(Vertical):
 
     def compose(self) -> ComposeResult:
         """Compose the CSV preview widgets."""
+        yield from self._widgets
+
+
+class NotebookPreview(Vertical):
+    """Notebook preview with cell-aware rendering."""
+
+    def __init__(self, notebook: dict[str, Any]) -> None:
+        """Initialize the notebook preview from parsed notebook JSON."""
+        super().__init__(classes="notebook-preview")
+        self._widgets = _notebook_preview_widgets(notebook)
+
+    def compose(self) -> ComposeResult:
+        """Compose the notebook preview widgets."""
         yield from self._widgets
 
 
@@ -135,7 +148,11 @@ def render_file(path: Path, *, browse_root: Path | None = None) -> list[Widget]:
 
     suffix = path.suffix.lower()
     size = path.stat().st_size
-    max_size = MAX_JSON_FILE_SIZE if suffix in JSON_EXTENSIONS else MAX_FILE_SIZE
+    max_size = (
+        MAX_JSON_FILE_SIZE
+        if suffix in JSON_EXTENSIONS or suffix in NOTEBOOK_EXTENSIONS
+        else MAX_FILE_SIZE
+    )
     if size > max_size:
         return [Static(Text(f"{path.name} is too large ({size:,} bytes)", style="red"))]
 
@@ -146,6 +163,14 @@ def render_file(path: Path, *, browse_root: Path | None = None) -> list[Widget]:
 
     if suffix in MARKDOWN_EXTENSIONS:
         return [Markdown(content)]
+
+    if suffix in NOTEBOOK_EXTENSIONS:
+        try:
+            parsed = json.loads(content)
+            if _looks_like_notebook(parsed):
+                return [NotebookPreview(parsed)]
+        except json.JSONDecodeError:
+            pass
 
     if suffix in JSON_EXTENSIONS:
         try:
@@ -264,3 +289,123 @@ def _raw_csv_section(content: str, *, collapsed: bool = True) -> Collapsible:
         collapsed=collapsed,
         classes="csv-raw-section",
     )
+
+
+def _looks_like_notebook(data: Any) -> bool:
+    """Return whether parsed JSON looks like a notebook payload."""
+    return (
+        isinstance(data, dict)
+        and isinstance(data.get("cells"), list)
+        and isinstance(data.get("nbformat"), int)
+    )
+
+
+def _notebook_preview_widgets(notebook: dict[str, Any]) -> list[Widget]:
+    """Build the notebook preview widgets."""
+    cells = notebook.get("cells")
+    if not isinstance(cells, list):
+        cells = []
+    language = _notebook_language(notebook.get("metadata"))
+
+    widgets: list[Widget] = [Static(_notebook_summary_text(notebook, len(cells), language))]
+    for index, cell in enumerate(cells, start=1):
+        widgets.extend(_notebook_cell_widgets(cell, index, language))
+    if len(widgets) == 1:
+        widgets.append(Static(Text("Empty notebook", style="dim italic")))
+    return widgets
+
+
+def _notebook_language(metadata: Any) -> str:
+    """Return the notebook language, defaulting to python."""
+    if isinstance(metadata, dict):
+        language_info = metadata.get("language_info")
+        if isinstance(language_info, dict):
+            candidate = language_info.get("name")
+            if isinstance(candidate, str) and candidate:
+                return candidate
+    return "python"
+
+
+def _notebook_summary_text(notebook: dict[str, Any], cell_count: int, language: str) -> Text:
+    """Return a short summary for the notebook preview."""
+    text = Text()
+    text.append("Notebook Preview", style="bold")
+    text.append(f"  {cell_count:,} cells", style="dim")
+    nbformat = notebook.get("nbformat")
+    nbformat_minor = notebook.get("nbformat_minor")
+    if isinstance(nbformat, int):
+        version = str(nbformat)
+        if isinstance(nbformat_minor, int):
+            version += f".{nbformat_minor}"
+        text.append(f"  nbformat {version}", style="dim")
+    text.append(f"  {language}", style="dim")
+    return text
+
+
+def _notebook_cell_widgets(cell: Any, index: int, language: str) -> list[Widget]:
+    """Return widgets for one notebook cell and its outputs."""
+    if not isinstance(cell, dict):
+        return [
+            Collapsible(
+                Static(Text("Unsupported cell payload", style="yellow")),
+                title=f"Cell {index}",
+                collapsed=False,
+            )
+        ]
+    cell_type = cell.get("cell_type")
+    if not isinstance(cell_type, str):
+        cell_type = "raw"
+    source = _notebook_text(cell.get("source"))
+
+    if cell_type == "markdown":
+        body: Widget = Markdown(source or "_Empty markdown cell_")
+    elif cell_type == "code":
+        body = Static(Syntax(source, language, line_numbers=True, word_wrap=True))
+    else:
+        body = Static(Text(source))
+
+    widgets: list[Widget] = [
+        Collapsible(body, title=f"{cell_type.title()} Cell {index}", collapsed=False)
+    ]
+    if cell_type == "code":
+        outputs = cell.get("outputs")
+        if isinstance(outputs, list):
+            for output_index, output in enumerate(outputs, start=1):
+                widgets.append(
+                    Collapsible(
+                        _notebook_output_widget(output),
+                        title=f"Output {index}.{output_index}",
+                        collapsed=False,
+                    )
+                )
+    return widgets
+
+
+def _notebook_output_widget(output: Any) -> Widget:
+    """Return a widget for one code-cell output."""
+    if not isinstance(output, dict):
+        return Static(Text(str(output)))
+    if output.get("output_type") == "stream":
+        return Static(Text(_notebook_text(output.get("text"))))
+    if output.get("output_type") in {"display_data", "execute_result"}:
+        data = output.get("data")
+        if isinstance(data, dict):
+            markdown = data.get("text/markdown")
+            if markdown is not None:
+                return Markdown(_notebook_text(markdown))
+            plain = data.get("text/plain")
+            if plain is not None:
+                return Static(Text(_notebook_text(plain)))
+    traceback = output.get("traceback") if isinstance(output, dict) else None
+    if traceback is not None:
+        return Static(Text(_notebook_text(traceback), style="red"))
+    return Static(Text(json.dumps(output, indent=2)))
+
+
+def _notebook_text(value: Any) -> str:
+    """Normalize notebook text content."""
+    if isinstance(value, list):
+        return "".join(str(item) for item in value)
+    if value is None:
+        return ""
+    return str(value)

--- a/src/skim/trajectory.py
+++ b/src/skim/trajectory.py
@@ -352,8 +352,6 @@ class AnnotationEditor(ModalScreen[AnnotationEditorResult | None]):
         text.append(" Close  ")
         text.append("Tab", style="bold")
         text.append(" Next field  ")
-        text.append("Enter", style="bold")
-        text.append(" Tags→Note  ")
         text.append("PgUp/Dn", style="bold")
         text.append(" Scroll preview")
         return text

--- a/tests/test_app_shell.py
+++ b/tests/test_app_shell.py
@@ -202,7 +202,9 @@ async def test_file_tree_mode_escape_returns_to_active_pane(tmp_path):
 
         assert not app.file_tree_mode
         assert app.focused is pane
-        assert "Toggle tree" in _static_content(footer)
+        content = _static_content(footer)
+        assert "Tree" in content
+        assert "Toggle tree" not in content
 
 
 async def test_right_outside_file_tree_mode_still_routes_to_json_viewer(tmp_path):
@@ -415,8 +417,11 @@ async def test_global_footer_only_shows_app_wide_commands():
 
         assert isinstance(content, str)
         assert "Scroll" in content
-        assert "Toggle tree" in content
-        assert "Open" in content
+        assert "PgUp/Dn" in content
+        assert "Tree" in content
+        assert "Open" not in content
+        assert "Toggle tree" not in content
+        assert "shortcut" not in content
         assert "JSON" not in content
         assert "Branch" not in content
         assert "Detail" not in content
@@ -439,6 +444,8 @@ async def test_file_tree_footer_shows_branch_controls(tmp_path):
         assert isinstance(content, str)
         assert "←→" in content
         assert "Branch" in content
+        assert "Open" not in content
+        assert "shortcut" not in content
 
 
 async def test_mouse_drag_scrolls_preview_pane(tmp_path):

--- a/tests/test_app_shell.py
+++ b/tests/test_app_shell.py
@@ -5,10 +5,12 @@ focus mode, global key routing, and generic scroll behavior. It does not cover
 preview classification or trajectory-specific rendering rules.
 """
 
+import json
+
 from conftest import _static_content
 from textual.widgets import Static
 
-from skim import PreviewPane, SkimApp
+from skim import JsonInspector, PreviewPane, SkimApp
 
 
 async def test_app_launches():
@@ -203,6 +205,146 @@ async def test_file_tree_mode_escape_returns_to_active_pane(tmp_path):
         assert "Toggle tree" in _static_content(footer)
 
 
+async def test_right_outside_file_tree_mode_still_routes_to_json_viewer(tmp_path):
+    """Outside file-tree mode, right should keep driving the active JSON tree."""
+    test_file = tmp_path / "plain.json"
+    test_file.write_text(json.dumps({"alpha": {"nested": 1}, "beta": 2}))
+    app = SkimApp(path=str(tmp_path))
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
+        pane.show_file(test_file)
+        await pilot.pause()
+
+        inspector = pane.query_one(JsonInspector)
+        first_node = inspector._tree.root.children[0]
+        inspector._tree.move_cursor(first_node, animate=False)
+        await pilot.pause()
+
+        assert inspector._tree.cursor_node is first_node
+        assert first_node.is_collapsed
+
+        await pilot.press("right")
+        await pilot.pause()
+
+        assert inspector._tree.cursor_node is first_node
+        assert first_node.is_expanded
+
+
+async def test_file_tree_mode_right_does_not_leak_to_json_viewer(tmp_path):
+    """File-tree mode should consume right without mutating the active JSON tree."""
+    (tmp_path / "folder").mkdir()
+    test_file = tmp_path / "plain.json"
+    test_file.write_text(json.dumps({"alpha": {"nested": 1}, "beta": 2}))
+    app = SkimApp(path=str(tmp_path))
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
+        pane.show_file(test_file)
+        await pilot.pause()
+
+        inspector = pane.query_one(JsonInspector)
+        first_node = inspector._tree.root.children[0]
+        inspector._tree.move_cursor(first_node, animate=False)
+        await pilot.pause()
+
+        await pilot.press("f")
+        await pilot.pause()
+        assert app.file_tree_mode
+
+        await pilot.press("right")
+        await pilot.pause()
+
+        assert inspector._tree.cursor_node is first_node
+        assert first_node.is_collapsed
+
+
+async def test_file_tree_mode_right_expands_directory(tmp_path):
+    """Right should branch into a collapsed directory while file-tree mode is active."""
+    child = tmp_path / "folder"
+    child.mkdir()
+    (child / "inside.txt").write_text("x")
+    app = SkimApp(path=str(tmp_path))
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        tree = app.query_one("DirectoryTree")
+        folder_node = tree.root.children[0]
+
+        await pilot.press("f")
+        await pilot.pause()
+        tree.move_cursor(folder_node, animate=False)
+        await pilot.pause()
+
+        assert folder_node.is_collapsed
+
+        await pilot.press("right")
+        await pilot.pause()
+
+        assert tree.cursor_node is folder_node
+        assert folder_node.is_expanded
+
+
+async def test_file_tree_mode_left_collapses_directory_then_moves_to_parent(tmp_path):
+    """Left should collapse the current branch, then move up on a second press."""
+    child = tmp_path / "folder"
+    child.mkdir()
+    (child / "inside.txt").write_text("x")
+    app = SkimApp(path=str(tmp_path))
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        tree = app.query_one("DirectoryTree")
+        folder_node = tree.root.children[0]
+
+        await pilot.press("f")
+        await pilot.pause()
+        tree.move_cursor(folder_node, animate=False)
+        folder_node.expand()
+        await pilot.pause()
+
+        assert tree.cursor_node is folder_node
+        assert folder_node.is_expanded
+
+        await pilot.press("left")
+        await pilot.pause()
+
+        assert tree.cursor_node is folder_node
+        assert folder_node.is_collapsed
+
+        await pilot.press("left")
+        await pilot.pause()
+
+        assert tree.cursor_node is tree.root
+
+
+async def test_file_tree_mode_right_on_file_opens_it_and_returns_to_pane(tmp_path):
+    """Right on a file should open it and leave file-tree mode."""
+    test_file = tmp_path / "open-me.txt"
+    test_file.write_text("hello")
+    app = SkimApp(path=str(tmp_path))
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
+        tree = app.query_one("DirectoryTree")
+        file_node = tree.root.children[0]
+
+        await pilot.press("f")
+        await pilot.pause()
+        tree.move_cursor(file_node, animate=False)
+        await pilot.pause()
+
+        await pilot.press("right")
+        await pilot.pause()
+
+        assert pane.current_path == test_file
+        assert not app.file_tree_mode
+        assert app.focused is pane
+
+
 async def test_down_outside_file_tree_mode_still_scrolls_preview_pane(tmp_path):
     """Outside file-tree mode, down should keep scrolling the active pane."""
     test_file = tmp_path / "long.txt"
@@ -279,6 +421,24 @@ async def test_global_footer_only_shows_app_wide_commands():
         assert "Branch" not in content
         assert "Detail" not in content
         assert "Esc" not in content
+
+
+async def test_file_tree_footer_shows_branch_controls(tmp_path):
+    """File-tree mode footer should advertise left/right branch navigation."""
+    (tmp_path / "one.txt").write_text("x")
+    app = SkimApp(path=str(tmp_path))
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        footer = app.query_one("#status-bar", Static)
+
+        await pilot.press("f")
+        await pilot.pause()
+
+        content = _static_content(footer)
+        assert isinstance(content, str)
+        assert "←→" in content
+        assert "Branch" in content
 
 
 async def test_mouse_drag_scrolls_preview_pane(tmp_path):

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -107,7 +107,7 @@ def test_ipynb_renders_code_cells_and_outputs(tmp_path):
 
     widgets = render_file(test_file)
 
-    assert len(widgets) >= 6
+    assert len(widgets) >= 7
     assert isinstance(widgets[1], Static)
     assert "Code Cell 1" in _static_content(widgets[1]).plain
     assert isinstance(_static_content(widgets[2]), Syntax)

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -26,7 +26,7 @@ from textual.widgets import Collapsible, Input, Markdown, Static, TextArea, Tree
 
 import skim.trajectory as trajectory_module
 from skim import JsonInspector, PreviewPane, SkimApp, render_file
-from skim.preview import CsvPreview, NotebookPreview
+from skim.preview import CsvPreview
 from skim.scrolling import FocusableDetailWrap
 from skim.trajectory import AnnotationStore
 
@@ -43,8 +43,8 @@ def test_generic_json_uses_json_inspector(tmp_path):
     assert _tree_labels(widgets[0]._tree) == ["Hello world"]
 
 
-def test_ipynb_uses_notebook_preview(tmp_path):
-    """Notebook files should use the specialized notebook preview."""
+def test_ipynb_uses_flat_notebook_document(tmp_path):
+    """Notebook files should render as a flat preview document."""
     test_file = tmp_path / "notebook.ipynb"
     test_file.write_text(
         json.dumps(
@@ -65,18 +65,16 @@ def test_ipynb_uses_notebook_preview(tmp_path):
 
     widgets = render_file(test_file)
 
-    assert len(widgets) == 1
-    preview = widgets[0]
-    assert isinstance(preview, NotebookPreview)
-    assert isinstance(preview._widgets[0], Static)
-    assert "Notebook Preview" in _static_content(preview._widgets[0]).plain
-    first_cell = preview._widgets[1]
-    assert isinstance(first_cell, Collapsible)
-    assert first_cell.title == "Markdown Cell 1"
+    assert len(widgets) >= 3
+    assert isinstance(widgets[0], Static)
+    assert "Notebook Preview" in _static_content(widgets[0]).plain
+    assert isinstance(widgets[1], Static)
+    assert "Markdown Cell 1" in _static_content(widgets[1]).plain
+    assert isinstance(widgets[2], Markdown)
 
 
 def test_ipynb_renders_code_cells_and_outputs(tmp_path):
-    """Notebook previews should render code cells with visible outputs."""
+    """Notebook previews should render code cells and outputs inline."""
     test_file = tmp_path / "notebook.ipynb"
     test_file.write_text(
         json.dumps(
@@ -92,6 +90,10 @@ def test_ipynb_renders_code_cells_and_outputs(tmp_path):
                                 "output_type": "stream",
                                 "name": "stdout",
                                 "text": ["hi\n"],
+                            },
+                            {
+                                "output_type": "execute_result",
+                                "data": {"text/plain": ["42"]},
                             }
                         ],
                     }
@@ -105,15 +107,19 @@ def test_ipynb_renders_code_cells_and_outputs(tmp_path):
 
     widgets = render_file(test_file)
 
-    assert len(widgets) == 1
-    preview = widgets[0]
-    assert isinstance(preview, NotebookPreview)
-    code_cell = preview._widgets[1]
-    assert isinstance(code_cell, Collapsible)
-    assert code_cell.title == "Code Cell 1"
-    output_cell = preview._widgets[2]
-    assert isinstance(output_cell, Collapsible)
-    assert output_cell.title == "Output 1.1"
+    assert len(widgets) >= 6
+    assert isinstance(widgets[1], Static)
+    assert "Code Cell 1" in _static_content(widgets[1]).plain
+    assert isinstance(_static_content(widgets[2]), Syntax)
+    assert "print('hi')" in _static_content(widgets[2]).code
+    assert isinstance(widgets[3], Static)
+    assert "Output 1.1" in _static_content(widgets[3]).plain
+    assert isinstance(widgets[4], Static)
+    assert "hi" in _static_content(widgets[4]).plain
+    assert isinstance(widgets[5], Static)
+    assert "Output 1.2" in _static_content(widgets[5]).plain
+    assert isinstance(widgets[6], Static)
+    assert "42" in _static_content(widgets[6]).plain
 
 
 def test_render_file_passes_source_context_to_json_inspector(tmp_path):
@@ -231,6 +237,76 @@ def test_ipynd_falls_back_to_plain_text_preview(tmp_path):
     assert len(widgets) == 1
     assert isinstance(widgets[0], Static)
     assert not isinstance(_static_content(widgets[0]), Syntax)
+
+
+async def test_long_ipynb_scrolls_in_outer_preview_pane(tmp_path):
+    """Notebook previews should scroll through the outer preview pane."""
+    long_markdown = "\n".join(f"line {index}" for index in range(400))
+    test_file = tmp_path / "notebook.ipynb"
+    test_file.write_text(
+        json.dumps(
+            {
+                "cells": [
+                    {
+                        "cell_type": "markdown",
+                        "metadata": {},
+                        "source": [long_markdown],
+                    }
+                ],
+                "metadata": {},
+                "nbformat": 4,
+                "nbformat_minor": 5,
+            }
+        )
+    )
+    app = SkimApp(path=str(tmp_path))
+
+    async with app.run_test() as pilot:
+        pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
+        pane.show_file(test_file)
+        await pilot.pause()
+
+        before = pane.scroll_y
+        await pilot.press("down")
+        await pilot.pause()
+
+        assert pane.scroll_y > before
+
+
+async def test_mouse_drag_scrolls_flat_ipynb_preview(tmp_path):
+    """Dragging inside a long notebook preview should scroll the pane."""
+    long_markdown = "\n".join(f"line {index}" for index in range(400))
+    test_file = tmp_path / "notebook.ipynb"
+    test_file.write_text(
+        json.dumps(
+            {
+                "cells": [
+                    {
+                        "cell_type": "markdown",
+                        "metadata": {},
+                        "source": [long_markdown],
+                    }
+                ],
+                "metadata": {},
+                "nbformat": 4,
+                "nbformat_minor": 5,
+            }
+        )
+    )
+    app = SkimApp(path=str(tmp_path))
+
+    async with app.run_test() as pilot:
+        pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
+        pane.show_file(test_file)
+        await pilot.pause()
+        before = pane.scroll_y
+
+        await pilot.mouse_down(pane, offset=(5, 10))
+        await pilot.hover(pane, offset=(5, 1))
+        await pilot.mouse_up(pane, offset=(5, 1))
+        await pilot.pause()
+
+        assert pane.scroll_y > before
 
 
 def test_wrapped_trajectory_json_uses_json_inspector(tmp_path):

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -26,7 +26,7 @@ from textual.widgets import Collapsible, Input, Markdown, Static, TextArea, Tree
 
 import skim.trajectory as trajectory_module
 from skim import JsonInspector, PreviewPane, SkimApp, render_file
-from skim.preview import CsvPreview
+from skim.preview import CsvPreview, NotebookPreview
 from skim.scrolling import FocusableDetailWrap
 from skim.trajectory import AnnotationStore
 
@@ -43,8 +43,8 @@ def test_generic_json_uses_json_inspector(tmp_path):
     assert _tree_labels(widgets[0]._tree) == ["Hello world"]
 
 
-def test_ipynb_uses_json_inspector(tmp_path):
-    """Notebook files should use the unified JSON inspector."""
+def test_ipynb_uses_notebook_preview(tmp_path):
+    """Notebook files should use the specialized notebook preview."""
     test_file = tmp_path / "notebook.ipynb"
     test_file.write_text(
         json.dumps(
@@ -66,17 +66,37 @@ def test_ipynb_uses_json_inspector(tmp_path):
     widgets = render_file(test_file)
 
     assert len(widgets) == 1
-    assert isinstance(widgets[0], JsonInspector)
+    preview = widgets[0]
+    assert isinstance(preview, NotebookPreview)
+    assert isinstance(preview._widgets[0], Static)
+    assert "Notebook Preview" in _static_content(preview._widgets[0]).plain
+    first_cell = preview._widgets[1]
+    assert isinstance(first_cell, Collapsible)
+    assert first_cell.title == "Markdown Cell 1"
 
 
-def test_ipynd_uses_json_inspector(tmp_path):
-    """The typo-tolerant notebook extension should route through the JSON inspector too."""
-    test_file = tmp_path / "notebook.ipynd"
+def test_ipynb_renders_code_cells_and_outputs(tmp_path):
+    """Notebook previews should render code cells with visible outputs."""
+    test_file = tmp_path / "notebook.ipynb"
     test_file.write_text(
         json.dumps(
             {
-                "cells": [],
-                "metadata": {},
+                "cells": [
+                    {
+                        "cell_type": "code",
+                        "execution_count": 1,
+                        "metadata": {},
+                        "source": ["print('hi')\n"],
+                        "outputs": [
+                            {
+                                "output_type": "stream",
+                                "name": "stdout",
+                                "text": ["hi\n"],
+                            }
+                        ],
+                    }
+                ],
+                "metadata": {"language_info": {"name": "python"}},
                 "nbformat": 4,
                 "nbformat_minor": 5,
             }
@@ -86,7 +106,14 @@ def test_ipynd_uses_json_inspector(tmp_path):
     widgets = render_file(test_file)
 
     assert len(widgets) == 1
-    assert isinstance(widgets[0], JsonInspector)
+    preview = widgets[0]
+    assert isinstance(preview, NotebookPreview)
+    code_cell = preview._widgets[1]
+    assert isinstance(code_cell, Collapsible)
+    assert code_cell.title == "Code Cell 1"
+    output_cell = preview._widgets[2]
+    assert isinstance(output_cell, Collapsible)
+    assert output_cell.title == "Output 1.1"
 
 
 def test_render_file_passes_source_context_to_json_inspector(tmp_path):
@@ -192,6 +219,18 @@ def test_invalid_ipynb_falls_back_to_syntax_preview(tmp_path):
     assert len(widgets) == 1
     assert isinstance(widgets[0], Static)
     assert isinstance(_static_content(widgets[0]), Syntax)
+
+
+def test_ipynd_falls_back_to_plain_text_preview(tmp_path):
+    """The misspelled extension should no longer get notebook handling."""
+    test_file = tmp_path / "broken.ipynd"
+    test_file.write_text('{"cells": []}')
+
+    widgets = render_file(test_file)
+
+    assert len(widgets) == 1
+    assert isinstance(widgets[0], Static)
+    assert not isinstance(_static_content(widgets[0]), Syntax)
 
 
 def test_wrapped_trajectory_json_uses_json_inspector(tmp_path):

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -43,6 +43,52 @@ def test_generic_json_uses_json_inspector(tmp_path):
     assert _tree_labels(widgets[0]._tree) == ["Hello world"]
 
 
+def test_ipynb_uses_json_inspector(tmp_path):
+    """Notebook files should use the unified JSON inspector."""
+    test_file = tmp_path / "notebook.ipynb"
+    test_file.write_text(
+        json.dumps(
+            {
+                "cells": [
+                    {
+                        "cell_type": "markdown",
+                        "metadata": {},
+                        "source": ["# Title\n"],
+                    }
+                ],
+                "metadata": {"kernelspec": {"display_name": "Python 3"}},
+                "nbformat": 4,
+                "nbformat_minor": 5,
+            }
+        )
+    )
+
+    widgets = render_file(test_file)
+
+    assert len(widgets) == 1
+    assert isinstance(widgets[0], JsonInspector)
+
+
+def test_ipynd_uses_json_inspector(tmp_path):
+    """The typo-tolerant notebook extension should route through the JSON inspector too."""
+    test_file = tmp_path / "notebook.ipynd"
+    test_file.write_text(
+        json.dumps(
+            {
+                "cells": [],
+                "metadata": {},
+                "nbformat": 4,
+                "nbformat_minor": 5,
+            }
+        )
+    )
+
+    widgets = render_file(test_file)
+
+    assert len(widgets) == 1
+    assert isinstance(widgets[0], JsonInspector)
+
+
 def test_render_file_passes_source_context_to_json_inspector(tmp_path):
     """JSON inspectors should know the source file and review root."""
     test_file = tmp_path / "plain.json"
@@ -127,6 +173,18 @@ def test_csv_preview_caps_wide_and_long_content(tmp_path):
 def test_invalid_json_falls_back_to_syntax_preview(tmp_path):
     """Invalid JSON still renders through the generic JSON path."""
     test_file = tmp_path / "broken.json"
+    test_file.write_text("{not json")
+
+    widgets = render_file(test_file)
+
+    assert len(widgets) == 1
+    assert isinstance(widgets[0], Static)
+    assert isinstance(_static_content(widgets[0]), Syntax)
+
+
+def test_invalid_ipynb_falls_back_to_syntax_preview(tmp_path):
+    """Invalid notebook JSON should still render as syntax-highlighted text."""
+    test_file = tmp_path / "broken.ipynb"
     test_file.write_text("{not json")
 
     widgets = render_file(test_file)

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -675,10 +675,10 @@ async def test_annotation_modal_footer_shows_modal_commands(tmp_path):
         assert "Close" in content.plain
         assert "Tab" in content.plain
         assert "Next field" in content.plain
-        assert "Enter" in content.plain
-        assert "Tags→Note" in content.plain
         assert "PgUp/Dn" in content.plain
         assert "Scroll preview" in content.plain
+        assert "Enter" not in content.plain
+        assert "Tags→Note" not in content.plain
         assert "Move" not in content.plain
         assert "Branch" not in content.plain
 

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -94,7 +94,7 @@ def test_ipynb_renders_code_cells_and_outputs(tmp_path):
                             {
                                 "output_type": "execute_result",
                                 "data": {"text/plain": ["42"]},
-                            }
+                            },
                         ],
                     }
                 ],


### PR DESCRIPTION
## Summary
- isolate file-tree mode so `left` and `right` no longer leak into the active JSON preview
- add file-tree branch navigation on `left`/`right`, with `right` opening files
- trim the global and annotation footers so they only advertise useful, non-duplicate commands

## Why
The app-level key router was still forwarding horizontal keys to the active JSON viewer even after focus was toggled to the file tree. That made file-tree mode feel leaky, and the footer text still advertised commands that were either duplicate or too context-specific to be reliable hints.

## Impact
File-tree mode now behaves like its own navigation context, with `left`/`right` matching the JSON tree’s branch navigation model. The bottom footers should be easier to trust because they only show commands that are valid and primary for each surface.

## Validation
- `uv run pytest tests/test_app_shell.py -q`
- `uv run pytest tests/test_preview.py -q -k 'json_inspector_footer_shows_live_preview_controls or annotation_modal_left_right_do_not_switch_focus'`
- `uv run pytest tests/test_trajectory_viewer.py -q -k 'trajectory_viewer_arrows_drive_tree_until_enter or escape_returns_from_trajectory_detail_to_tree_mode'`
- `uv run pytest tests/test_preview.py -q -k 'annotation_modal_footer_shows_modal_commands or json_inspector_footer_shows_live_preview_controls or non_trajectory_previews_do_not_mount_local_footer'`
- `uv run pytest tests/test_trajectory_viewer.py -q -k 'trajectory_viewer_mounts_local_footer or trajectory_footer_switches_between_tree_and_detail_modes'`
- `uv run ruff check src/ tests/`