### PR TITLE
Add multi-annotation support across skim

### DIFF
--- a/src/skim/app.py
+++ b/src/skim/app.py
@@ -75,8 +75,10 @@ class SkimApp(App):
         height: 1fr;
     }
     .annotation-status-panel {
-        height: 8;
+        width: 1fr;
+        height: auto;
         min-height: 8;
+        max-height: 1fr;
         border: round $panel-lighten-1;
         background: $surface-lighten-1;
         padding: 0 1;

--- a/src/skim/scrolling.py
+++ b/src/skim/scrolling.py
@@ -117,3 +117,16 @@ class FocusableDetailWrap(DragScrollMixin, VerticalScroll, can_focus=True):
     def _drag_scroll_requires_self_target(self) -> bool:
         """Only start drag-scroll from the detail container background."""
         return True
+
+
+class AnnotationStatusWrap(DragScrollMixin, VerticalScroll):
+    """Passive scroll container for JSON inspector annotation status content."""
+
+    def __init__(self, *children: Widget, **kwargs: Any) -> None:
+        """Initialize the annotation status wrapper."""
+        super().__init__(*children, **kwargs)
+        self._init_drag_scroll()
+
+    def _drag_scroll_requires_self_target(self) -> bool:
+        """Only start drag-scroll from the annotation container background."""
+        return True

--- a/src/skim/server.py
+++ b/src/skim/server.py
@@ -111,7 +111,7 @@ class SkimHandler(SimpleHTTPRequestHandler):
         super().do_GET()
 
     def do_POST(self) -> None:
-        """Persist or replace one annotation."""
+        """Create or update one annotation entry."""
         if self.path != "/api/annotations":
             self._error(404, "Not found")
             return
@@ -131,6 +131,10 @@ class SkimHandler(SimpleHTTPRequestHandler):
         if not isinstance(note, str):
             self._error(400, "Note must be a string")
             return
+        annotation_id = body.get("annotation_id")
+        if annotation_id is not None and not isinstance(annotation_id, str):
+            self._error(400, "annotation_id must be a string")
+            return
 
         source_path = self._resolve_browse_target(file_path)
         if source_path is None:
@@ -140,13 +144,36 @@ class SkimHandler(SimpleHTTPRequestHandler):
             self._error(404, "File not found")
             return
 
-        self.store.set_annotation(
-            source_path,
-            annotation_path,
-            tags=tuple(str(tag) for tag in tags),
-            note=note,
+        if annotation_id:
+            annotation = self.store.update_annotation(
+                source_path,
+                annotation_path,
+                annotation_id,
+                tags=tuple(str(tag) for tag in tags),
+                note=note,
+            )
+            if annotation is None:
+                self._error(404, "Annotation not found")
+                return
+        else:
+            annotation = self.store.add_annotation(
+                source_path,
+                annotation_path,
+                tags=tuple(str(tag) for tag in tags),
+                note=note,
+            )
+        self._json_response(
+            {
+                "ok": True,
+                "annotation": {
+                    "id": annotation.id,
+                    "created_at": annotation.created_at,
+                    "updated_at": annotation.updated_at,
+                    "tags": list(annotation.tags),
+                    "note": annotation.note,
+                },
+            }
         )
-        self._json_response({"ok": True})
 
     def do_DELETE(self) -> None:
         """Delete one annotation, if present."""
@@ -170,7 +197,12 @@ class SkimHandler(SimpleHTTPRequestHandler):
             self._error(404, "File not found")
             return
 
-        self.store.delete_annotation(source_path, annotation_path)
+        annotation_id = body.get("annotation_id")
+        if not isinstance(annotation_id, str):
+            self._error(400, "Missing annotation_id field")
+            return
+
+        self.store.delete_annotation(source_path, annotation_path, annotation_id)
         self._json_response({"ok": True})
 
     def do_OPTIONS(self) -> None:

--- a/src/skim/trajectory.py
+++ b/src/skim/trajectory.py
@@ -2268,11 +2268,7 @@ def _annotation_panel_widgets(
         return widgets
 
     selected = next(
-        (
-            annotation
-            for annotation in annotations
-            if annotation.id == selected_annotation_id
-        ),
+        (annotation for annotation in annotations if annotation.id == selected_annotation_id),
         annotations[0],
     )
     widgets.extend(

--- a/src/skim/trajectory.py
+++ b/src/skim/trajectory.py
@@ -10,8 +10,10 @@ from __future__ import annotations
 import json
 from collections.abc import Callable
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
+from uuid import uuid4
 
 from rich.syntax import Syntax
 from rich.text import Text
@@ -100,6 +102,9 @@ class TrajectoryTreeItem:
 class AnnotationRecord:
     """Persisted annotation for one JSON node."""
 
+    id: str
+    created_at: str
+    updated_at: str
     tags: tuple[str, ...]
     note: str
 
@@ -109,6 +114,7 @@ class AnnotationEditorResult:
     """Dismiss payload from the annotation editor modal."""
 
     action: str
+    annotation_id: str | None = None
     tags: tuple[str, ...] = ()
     note: str = ""
 
@@ -121,9 +127,9 @@ class AnnotationStore:
         self.review_root = review_root.resolve()
         self.path = self.review_root / ".skim" / "review.json"
         self._payload = self._load()
-        self._file_annotations: dict[str, dict[str, AnnotationRecord]] = {}
+        self._file_annotations: dict[str, dict[str, tuple[AnnotationRecord, ...]]] = {}
 
-    def annotations_for_file(self, source_path: Path) -> dict[str, AnnotationRecord]:
+    def annotations_for_file(self, source_path: Path) -> dict[str, tuple[AnnotationRecord, ...]]:
         """Return stored annotations for one source file."""
         relative_path = self.relative_file_path(source_path)
         cached = self._file_annotations.get(relative_path)
@@ -132,9 +138,73 @@ class AnnotationStore:
             self._file_annotations[relative_path] = cached
         return cached
 
+    def annotations_for_path(self, source_path: Path, path: str) -> tuple[AnnotationRecord, ...]:
+        """Return all annotations by file-relative JSON path, newest first."""
+        return self.annotations_for_file(source_path).get(path, ())
+
     def get_annotation(self, source_path: Path, path: str) -> AnnotationRecord | None:
-        """Return one annotation by file-relative JSON path."""
-        return self.annotations_for_file(source_path).get(path)
+        """Return the newest annotation by file-relative JSON path."""
+        records = self.annotations_for_path(source_path, path)
+        return records[0] if records else None
+
+    def add_annotation(
+        self,
+        source_path: Path,
+        path: str,
+        *,
+        tags: tuple[str, ...],
+        note: str,
+    ) -> AnnotationRecord:
+        """Append one annotation entry for a path and persist it."""
+        record = AnnotationRecord(
+            id=str(uuid4()),
+            created_at=_annotation_timestamp(),
+            updated_at=_annotation_timestamp(),
+            tags=_normalize_annotation_tags(tags),
+            note=note,
+        )
+        relative_path, annotations = self._persisted_annotations_for_file(source_path)
+        existing = annotations.get(path, [])
+        normalized = self._normalize_annotation_entries(existing)
+        updated = _sort_annotation_records([*normalized, record])
+        annotations[path] = [_annotation_payload(entry) for entry in updated]
+        self.annotations_for_file(source_path)[path] = tuple(updated)
+        self._save()
+        return record
+
+    def update_annotation(
+        self,
+        source_path: Path,
+        path: str,
+        annotation_id: str,
+        *,
+        tags: tuple[str, ...],
+        note: str,
+    ) -> AnnotationRecord | None:
+        """Update one persisted annotation entry by id."""
+        relative_path, annotations = self._persisted_annotations_for_file(source_path)
+        existing = self._normalize_annotation_entries(annotations.get(path, []))
+        updated_record: AnnotationRecord | None = None
+        updated_entries: list[AnnotationRecord] = []
+        for record in existing:
+            if record.id == annotation_id:
+                updated_record = AnnotationRecord(
+                    id=record.id,
+                    created_at=record.created_at,
+                    updated_at=_annotation_timestamp(),
+                    tags=_normalize_annotation_tags(tags),
+                    note=note,
+                )
+                updated_entries.append(updated_record)
+            else:
+                updated_entries.append(record)
+        if updated_record is None:
+            return None
+        sorted_entries = _sort_annotation_records(updated_entries)
+        annotations[path] = [_annotation_payload(entry) for entry in sorted_entries]
+        self.annotations_for_file(source_path)[path] = tuple(sorted_entries)
+        self._save()
+        return updated_record
 
     def set_annotation(
         self,
@@ -144,23 +214,41 @@ class AnnotationStore:
         tags: tuple[str, ...],
         note: str,
     ) -> None:
-        """Store or replace one annotation."""
-        relative_path = self.relative_file_path(source_path)
-        files = self._payload.setdefault("files", {})
-        file_entry = files.setdefault(relative_path, {"annotations": {}})
-        annotations = file_entry.setdefault("annotations", {})
-        annotations[path] = {"tags": list(tags), "note": note}
-        self.annotations_for_file(source_path)[path] = AnnotationRecord(tags=tags, note=note)
+        """Store one single-entry annotation, replacing existing entries for compatibility."""
+        record = AnnotationRecord(
+            id=str(uuid4()),
+            created_at=_annotation_timestamp(),
+            updated_at=_annotation_timestamp(),
+            tags=_normalize_annotation_tags(tags),
+            note=note,
+        )
+        _, annotations = self._persisted_annotations_for_file(source_path)
+        annotations[path] = [_annotation_payload(record)]
+        self.annotations_for_file(source_path)[path] = (record,)
         self._save()
 
-    def delete_annotation(self, source_path: Path, path: str) -> None:
-        """Delete one annotation if present."""
-        relative_path = self.relative_file_path(source_path)
-        files = self._payload.setdefault("files", {})
-        file_entry = files.setdefault(relative_path, {"annotations": {}})
-        annotations = file_entry.setdefault("annotations", {})
-        annotations.pop(path, None)
-        self.annotations_for_file(source_path).pop(path, None)
+    def delete_annotation(
+        self,
+        source_path: Path,
+        path: str,
+        annotation_id: str | None = None,
+    ) -> None:
+        """Delete one annotation entry by id, or all entries when no id is supplied."""
+        _, annotations = self._persisted_annotations_for_file(source_path)
+        if annotation_id is None:
+            annotations.pop(path, None)
+            self.annotations_for_file(source_path).pop(path, None)
+            self._save()
+            return
+        existing = self._normalize_annotation_entries(annotations.get(path, []))
+        remaining = [record for record in existing if record.id != annotation_id]
+        if remaining:
+            sorted_entries = _sort_annotation_records(remaining)
+            annotations[path] = [_annotation_payload(entry) for entry in sorted_entries]
+            self.annotations_for_file(source_path)[path] = tuple(sorted_entries)
+        else:
+            annotations.pop(path, None)
+            self.annotations_for_file(source_path).pop(path, None)
         self._save()
 
     def relative_file_path(self, source_path: Path) -> str:
@@ -183,28 +271,78 @@ class AnnotationStore:
             return {"version": 1, "files": {}}
         payload.setdefault("version", 1)
         payload.setdefault("files", {})
+        files = payload.get("files", {})
+        if isinstance(files, dict):
+            for file_entry in files.values():
+                if not isinstance(file_entry, dict):
+                    continue
+                annotations = file_entry.get("annotations")
+                if not isinstance(annotations, dict):
+                    file_entry["annotations"] = {}
+                    continue
+                normalized_annotations: dict[str, list[dict[str, Any]]] = {}
+                for path, entry in annotations.items():
+                    if not isinstance(path, str):
+                        continue
+                    records = self._normalize_annotation_entries(entry)
+                    normalized_annotations[path] = [
+                        _annotation_payload(record) for record in records
+                    ]
+                file_entry["annotations"] = normalized_annotations
         return payload
 
     def _build_annotations_for_relative_path(
         self,
         relative_path: str,
-    ) -> dict[str, AnnotationRecord]:
+    ) -> dict[str, tuple[AnnotationRecord, ...]]:
         """Normalize stored annotations for one file path."""
         files = self._payload.get("files", {})
         file_entry = files.get(relative_path, {})
         annotations = file_entry.get("annotations", {})
-        result: dict[str, AnnotationRecord] = {}
+        result: dict[str, tuple[AnnotationRecord, ...]] = {}
         for path, payload in annotations.items():
-            if not isinstance(path, str) or not isinstance(payload, dict):
+            if not isinstance(path, str):
                 continue
-            tags = payload.get("tags", [])
-            note = payload.get("note", "")
-            if isinstance(tags, list) and isinstance(note, str):
-                result[path] = AnnotationRecord(
-                    tags=tuple(str(tag) for tag in tags if str(tag).strip()),
+            records = self._normalize_annotation_entries(payload)
+            if records:
+                result[path] = tuple(records)
+        return result
+
+    def _persisted_annotations_for_file(
+        self,
+        source_path: Path,
+    ) -> tuple[str, dict[str, Any]]:
+        """Return the persisted file key and mutable annotation payload for one source."""
+        relative_path = self.relative_file_path(source_path)
+        files = self._payload.setdefault("files", {})
+        file_entry = files.setdefault(relative_path, {"annotations": {}})
+        annotations = file_entry.setdefault("annotations", {})
+        return relative_path, annotations
+
+    def _normalize_annotation_entries(self, payload: Any) -> list[AnnotationRecord]:
+        """Normalize legacy or list-shaped annotation payloads into sorted records."""
+        entries = payload if isinstance(payload, list) else [payload]
+        records: list[AnnotationRecord] = []
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            tags = entry.get("tags", [])
+            note = entry.get("note", "")
+            if not isinstance(tags, list) or not isinstance(note, str):
+                continue
+            created_at = str(entry.get("created_at") or _annotation_timestamp())
+            updated_at = str(entry.get("updated_at") or created_at)
+            record_id = str(entry.get("id") or uuid4())
+            records.append(
+                AnnotationRecord(
+                    id=record_id,
+                    created_at=created_at,
+                    updated_at=updated_at,
+                    tags=_normalize_annotation_tags(tags),
                     note=note,
                 )
-        return result
+            )
+        return _sort_annotation_records(records)
 
     def _save(self) -> None:
         """Write the annotation payload to disk."""
@@ -240,10 +378,11 @@ class AnnotationEditor(ModalScreen[AnnotationEditorResult | None]):
         """Compose the modal editor widgets."""
         tags = ", ".join(self.annotation.tags) if self.annotation is not None else ""
         note = self.annotation.note if self.annotation is not None else ""
+        title = "Edit Annotation" if self.annotation is not None else "New Annotation"
         yield Vertical(
             Horizontal(
                 Vertical(
-                    Static(Text("Edit Annotation", style="bold"), classes="annotation-modal-title"),
+                    Static(Text(title, style="bold"), classes="annotation-modal-title"),
                     Static(
                         Text(f"Path: {self.path}", style="dim"),
                         classes="annotation-modal-path",
@@ -317,6 +456,7 @@ class AnnotationEditor(ModalScreen[AnnotationEditorResult | None]):
         self._submit(
             AnnotationEditorResult(
                 action="save",
+                annotation_id=self.annotation.id if self.annotation is not None else None,
                 tags=_parse_annotation_tags(self.query_one("#annotation-tags", Input).value),
                 note=self.query_one("#annotation-note", TextArea).text.rstrip(),
             )
@@ -324,7 +464,12 @@ class AnnotationEditor(ModalScreen[AnnotationEditorResult | None]):
 
     def action_delete(self) -> None:
         """Dismiss with a delete payload."""
-        self._submit(AnnotationEditorResult(action="delete"))
+        self._submit(
+            AnnotationEditorResult(
+                action="delete",
+                annotation_id=self.annotation.id if self.annotation is not None else None,
+            )
+        )
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
         """Handle modal button clicks."""
@@ -1530,8 +1675,26 @@ class JsonInspector(Vertical):
         return False
 
     def handle_enter_key(self) -> bool:
-        """Consume Enter without switching JSON focus modes."""
-        self._ensure_tree_cursor()
+        """Edit the newest annotation when present, otherwise keep Enter local."""
+        item = self._annotation_item()
+        if item is None:
+            self._ensure_tree_cursor()
+            return True
+        annotations = self._annotations_for_item(item)
+        if not annotations:
+            self._ensure_tree_cursor()
+            return True
+        path = self._annotation_key(item)
+        if path is None:
+            return True
+        self.app.push_screen(
+            AnnotationEditor(
+                path,
+                annotations[0],
+                item,
+                on_submit=self._handle_annotation_result,
+            )
+        )
         return True
 
     def handle_escape_key(self) -> bool:
@@ -1539,7 +1702,7 @@ class JsonInspector(Vertical):
         return True
 
     def handle_annotation_key(self) -> bool:
-        """Open the annotation editor for the active JSON node."""
+        """Open the annotation editor to create a new entry for the active JSON node."""
         item = self._annotation_item()
         if item is None:
             return False
@@ -1550,7 +1713,7 @@ class JsonInspector(Vertical):
         self.app.push_screen(
             AnnotationEditor(
                 path,
-                self._annotation_for_item(item),
+                None,
                 item,
                 on_submit=self._handle_annotation_result,
             )
@@ -1842,7 +2005,7 @@ class JsonInspector(Vertical):
     def _annotation_widgets_for_item(self, item: JsonInspectorItem) -> list[Widget]:
         """Return annotation-panel widgets for one selected JSON node."""
         return _annotation_panel_widgets(
-            self._annotation_for_item(item),
+            self._annotations_for_item(item),
             self._is_annotatable(item),
         )
 
@@ -1865,17 +2028,17 @@ class JsonInspector(Vertical):
             return None
         return _format_raw_path(item.annotation_path or item.raw_path)
 
-    def _annotation_for_item(self, item: JsonInspectorItem) -> AnnotationRecord | None:
-        """Return the stored annotation for one item, if any."""
+    def _annotations_for_item(self, item: JsonInspectorItem) -> tuple[AnnotationRecord, ...]:
+        """Return stored annotations for one item, newest first."""
         path = self._annotation_key(item)
         if path is None:
-            return None
-        return self._file_annotations.get(path)
+            return ()
+        return self._file_annotations.get(path, ())
 
     def _tree_label_for_item(self, item: JsonInspectorItem) -> Text:
         """Return the rendered tree label for one item, including annotation state."""
         label = _json_tree_label(self.data, item)
-        if self._annotation_for_item(item) is None:
+        if not self._annotations_for_item(item):
             return label
         marked = Text("* ", style="bold green")
         marked.append_text(label)
@@ -1890,16 +2053,28 @@ class JsonInspector(Vertical):
         if path is None:
             return
         if result.action == "delete":
-            self._annotation_store.delete_annotation(self.source_path, path)
+            if result.annotation_id is None:
+                return
+            self._annotation_store.delete_annotation(self.source_path, path, result.annotation_id)
         elif result.action == "save":
-            self._annotation_store.set_annotation(
-                self.source_path,
-                path,
-                tags=result.tags,
-                note=result.note,
-            )
+            if result.annotation_id is None:
+                self._annotation_store.add_annotation(
+                    self.source_path,
+                    path,
+                    tags=result.tags,
+                    note=result.note,
+                )
+            else:
+                self._annotation_store.update_annotation(
+                    self.source_path,
+                    path,
+                    result.annotation_id,
+                    tags=result.tags,
+                    note=result.note,
+                )
         else:
             return
+        self._file_annotations = self._annotation_store.annotations_for_file(self.source_path)
         self._refresh_annotation_labels(path)
         self._show_detail(item)
 
@@ -1941,7 +2116,7 @@ def _json_detail_widgets(item: JsonInspectorItem) -> list[Widget]:
 
 
 def _annotation_panel_widgets(
-    annotation: AnnotationRecord | None,
+    annotations: tuple[AnnotationRecord, ...],
     annotatable: bool,
 ) -> list[Widget]:
     """Return the separate annotation-status panel for one selected JSON node."""
@@ -1964,7 +2139,7 @@ def _annotation_panel_widgets(
         )
         return widgets
 
-    if annotation is None:
+    if not annotations:
         widgets.extend(_metadata_fields([("Status", "No annotation"), ("Tags", "(none)")]))
         widgets.append(Static(Text("No annotation yet"), classes="annotation-status-body"))
         widgets.append(
@@ -1972,19 +2147,41 @@ def _annotation_panel_widgets(
         )
         return widgets
 
+    selected = annotations[0]
     widgets.extend(
         _metadata_fields(
             [
                 ("Status", "Annotated"),
-                ("Tags", ", ".join(annotation.tags) if annotation.tags else "(none)"),
+                ("Count", str(len(annotations))),
+                ("Tags", ", ".join(selected.tags) if selected.tags else "(none)"),
             ]
         )
     )
+    widgets.append(
+        Static(
+            Text(f"{len(annotations)} annotation{'s' if len(annotations) != 1 else ''}"),
+            classes="annotation-status-body",
+        )
+    )
+    for index, annotation in enumerate(annotations, start=1):
+        summary = Text()
+        summary.append(f"{index}. ", style="bold")
+        summary.append(f"{annotation.updated_at[:16].replace('T', ' ')} ", style="dim")
+        if annotation.tags:
+            summary.append(f"[{', '.join(annotation.tags)}] ", style="cyan")
+        first_line = (annotation.note or "(empty)").splitlines()[0]
+        summary.append(first_line[:80] + ("…" if len(first_line) > 80 else ""))
+        widgets.append(Static(summary, classes="annotation-status-body"))
     note = Text()
     note.append("Note: ", style="bold cyan")
-    note.append(annotation.note or "(empty)")
+    note.append(selected.note or "(empty)")
     widgets.append(Static(note, classes="annotation-status-body"))
-    widgets.append(Static(Text("Press a to edit", style="dim"), classes="annotation-status-hint"))
+    widgets.append(
+        Static(
+            Text("Press Enter to edit newest or a to add another", style="dim"),
+            classes="annotation-status-hint",
+        )
+    )
     return widgets
 
 
@@ -2022,6 +2219,36 @@ def _walk_tree_nodes(
 def _parse_annotation_tags(raw_tags: str) -> tuple[str, ...]:
     """Parse the comma-separated tag field used by the modal editor."""
     return tuple(tag.strip() for tag in raw_tags.split(",") if tag.strip())
+
+
+def _normalize_annotation_tags(tags: tuple[str, ...] | list[str]) -> tuple[str, ...]:
+    """Normalize stored or submitted annotation tags."""
+    return tuple(str(tag).strip() for tag in tags if str(tag).strip())
+
+
+def _annotation_payload(record: AnnotationRecord) -> dict[str, Any]:
+    """Serialize one annotation record for review.json persistence."""
+    return {
+        "id": record.id,
+        "created_at": record.created_at,
+        "updated_at": record.updated_at,
+        "tags": list(record.tags),
+        "note": record.note,
+    }
+
+
+def _annotation_timestamp() -> str:
+    """Return a stable UTC timestamp string for annotation metadata."""
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _sort_annotation_records(records: list[AnnotationRecord]) -> list[AnnotationRecord]:
+    """Return records ordered newest-first by updated timestamp."""
+    return sorted(
+        records,
+        key=lambda record: (record.updated_at, record.created_at, record.id),
+        reverse=True,
+    )
 
 
 def _json_type_name(value: Any) -> str:

--- a/src/skim/trajectory.py
+++ b/src/skim/trajectory.py
@@ -1570,12 +1570,19 @@ class JsonInspector(Vertical):
             if self.source_path is not None
             else {}
         )
+        self._annotation_mode = False
+        self._selected_annotation_ids: dict[str, str] = {}
         self._current_item: JsonInspectorItem | None = None
         self._tree: DragTree = DragTree("JSON", classes="trajectory-tree")
         self._build_tree()
         first_item = self._tree.root.children[0].data if self._tree.root.children else None
         initial_detail_widgets: list[Widget] = []
-        initial_annotation_widgets: list[Widget] = _annotation_panel_widgets(None, False)
+        initial_annotation_widgets: list[Widget] = _annotation_panel_widgets(
+            (),
+            False,
+            selected_annotation_id=None,
+            annotation_mode=False,
+        )
         if isinstance(first_item, JsonInspectorItem):
             self._current_item = first_item
             initial_detail_widgets = self._detail_widgets_for_item(first_item)
@@ -1622,11 +1629,18 @@ class JsonInspector(Vertical):
     def _show_detail(self, item: JsonInspectorItem) -> None:
         """Replace the detail pane with widgets for the selected tree item."""
         self._current_item = item
-        self._annotation_wrap.remove_children()
-        self._annotation_wrap.mount(*self._annotation_widgets_for_item(item))
+        self._mount_annotation_panel(item)
         self._detail_wrap.remove_children()
         self._detail_wrap.mount(*self._detail_widgets_for_item(item))
         self._detail_wrap.scroll_home(animate=False)
+        if self._annotation_mode and not self._annotations_for_item(item):
+            self.focus_tree_mode()
+
+    def _mount_annotation_panel(self, item: JsonInspectorItem) -> None:
+        """Replace the annotation panel for the selected tree item."""
+        self._annotation_wrap.remove_children()
+        self._annotation_wrap.mount(*self._annotation_widgets_for_item(item))
+        self._annotation_wrap.scroll_home(animate=False)
 
     def scroll_detail(self, delta: int) -> None:
         """Scroll the rendered detail panel."""
@@ -1634,20 +1648,57 @@ class JsonInspector(Vertical):
 
     def is_tree_mode(self) -> bool:
         """Return whether keyboard navigation is driving the left tree."""
-        return True
+        return not self._annotation_mode
 
     def focus_tree_mode(self) -> None:
         """Route keyboard focus to the JSON tree."""
+        self._annotation_mode = False
         self._ensure_tree_cursor()
         if self.is_attached:
             self._tree.focus(scroll_visible=False)
+        if self._current_item is not None:
+            self._mount_annotation_panel(self._current_item)
+        self._update_footer()
 
     def focus_detail_mode(self) -> None:
         """Keep compatibility with callers that expect a detail-focus method."""
-        self.focus_tree_mode()
+        self.focus_annotation_mode()
+
+    def focus_annotation_mode(self) -> None:
+        """Route keyboard navigation to the selected annotation list."""
+        item = self._annotation_item()
+        if item is None or not self._annotations_for_item(item):
+            self.focus_tree_mode()
+            return
+        self._annotation_mode = True
+        self._selected_annotation_for_item(item)
+        self._mount_annotation_panel(item)
+        self._update_footer()
 
     def handle_vertical_key(self, delta: int) -> bool:
         """Handle up/down keys by moving the JSON tree cursor."""
+        if self._annotation_mode:
+            item = self._annotation_item()
+            if item is None:
+                return True
+            annotations = self._annotations_for_item(item)
+            selected = self._selected_annotation_for_item(item)
+            if selected is None or not annotations:
+                return True
+            current_index = next(
+                (
+                    index
+                    for index, annotation in enumerate(annotations)
+                    if annotation.id == selected.id
+                ),
+                0,
+            )
+            next_index = max(0, min(len(annotations) - 1, current_index + (1 if delta > 0 else -1)))
+            path = self._annotation_key(item)
+            if path is not None:
+                self._selected_annotation_ids[path] = annotations[next_index].id
+                self._mount_annotation_panel(item)
+            return True
         self._ensure_tree_cursor()
         if delta < 0:
             self._tree.action_cursor_up()
@@ -1675,7 +1726,7 @@ class JsonInspector(Vertical):
         return False
 
     def handle_enter_key(self) -> bool:
-        """Edit the newest annotation when present, otherwise keep Enter local."""
+        """Enter annotation mode or edit the selected annotation from that mode."""
         item = self._annotation_item()
         if item is None:
             self._ensure_tree_cursor()
@@ -1684,13 +1735,19 @@ class JsonInspector(Vertical):
         if not annotations:
             self._ensure_tree_cursor()
             return True
+        if self.is_tree_mode():
+            self.focus_annotation_mode()
+            return True
         path = self._annotation_key(item)
         if path is None:
+            return True
+        annotation = self._selected_annotation_for_item(item)
+        if annotation is None:
             return True
         self.app.push_screen(
             AnnotationEditor(
                 path,
-                annotations[0],
+                annotation,
                 item,
                 on_submit=self._handle_annotation_result,
             )
@@ -1698,7 +1755,10 @@ class JsonInspector(Vertical):
         return True
 
     def handle_escape_key(self) -> bool:
-        """Consume Escape without switching JSON focus modes."""
+        """Return from annotation selection to the JSON tree when needed."""
+        if self._annotation_mode:
+            self.focus_tree_mode()
+            return True
         return True
 
     def handle_annotation_key(self) -> bool:
@@ -1731,14 +1791,26 @@ class JsonInspector(Vertical):
         text = Text()
         text.append(" JSON ", style="reverse")
         text.append(" ")
-        text.append("↑↓", style="bold")
-        text.append(" Move  ")
-        text.append("←→", style="bold")
-        text.append(" Branch  ")
-        text.append("PgUp/Dn", style="bold")
-        text.append(" Scroll  ")
-        text.append("a", style="bold")
-        text.append(" Annotate")
+        if self._annotation_mode:
+            text.append("↑↓", style="bold")
+            text.append(" Select  ")
+            text.append("Enter", style="bold")
+            text.append(" Edit  ")
+            text.append("Esc", style="bold")
+            text.append(" Back  ")
+            text.append("a", style="bold")
+            text.append(" New annotation")
+        else:
+            text.append("↑↓", style="bold")
+            text.append(" Move  ")
+            text.append("←→", style="bold")
+            text.append(" Branch  ")
+            text.append("Enter", style="bold")
+            text.append(" Annotations  ")
+            text.append("PgUp/Dn", style="bold")
+            text.append(" Scroll  ")
+            text.append("a", style="bold")
+            text.append(" Annotate")
         return text
 
     def _update_footer(self) -> None:
@@ -2007,6 +2079,8 @@ class JsonInspector(Vertical):
         return _annotation_panel_widgets(
             self._annotations_for_item(item),
             self._is_annotatable(item),
+            selected_annotation_id=self._selected_annotation_id_for_item(item),
+            annotation_mode=self._annotation_mode,
         )
 
     def _annotation_item(self) -> JsonInspectorItem | None:
@@ -2035,6 +2109,35 @@ class JsonInspector(Vertical):
             return ()
         return self._file_annotations.get(path, ())
 
+    def _selected_annotation_id_for_item(self, item: JsonInspectorItem) -> str | None:
+        """Return the selected annotation id for one item, defaulting to the newest."""
+        path = self._annotation_key(item)
+        if path is None:
+            return None
+        annotations = self._annotations_for_item(item)
+        if not annotations:
+            self._selected_annotation_ids.pop(path, None)
+            return None
+        selected_id = self._selected_annotation_ids.get(path)
+        if any(annotation.id == selected_id for annotation in annotations):
+            return selected_id
+        self._selected_annotation_ids[path] = annotations[0].id
+        return annotations[0].id
+
+    def _selected_annotation_for_item(self, item: JsonInspectorItem) -> AnnotationRecord | None:
+        """Return the currently selected annotation record for one item."""
+        selected_id = self._selected_annotation_id_for_item(item)
+        if selected_id is None:
+            return None
+        return next(
+            (
+                annotation
+                for annotation in self._annotations_for_item(item)
+                if annotation.id == selected_id
+            ),
+            None,
+        )
+
     def _tree_label_for_item(self, item: JsonInspectorItem) -> Text:
         """Return the rendered tree label for one item, including annotation state."""
         label = _json_tree_label(self.data, item)
@@ -2052,30 +2155,44 @@ class JsonInspector(Vertical):
         path = self._annotation_key(item)
         if path is None:
             return
+        selected_annotation_id: str | None = None
         if result.action == "delete":
             if result.annotation_id is None:
                 return
             self._annotation_store.delete_annotation(self.source_path, path, result.annotation_id)
         elif result.action == "save":
             if result.annotation_id is None:
-                self._annotation_store.add_annotation(
+                saved = self._annotation_store.add_annotation(
                     self.source_path,
                     path,
                     tags=result.tags,
                     note=result.note,
                 )
+                selected_annotation_id = saved.id
             else:
-                self._annotation_store.update_annotation(
+                updated = self._annotation_store.update_annotation(
                     self.source_path,
                     path,
                     result.annotation_id,
                     tags=result.tags,
                     note=result.note,
                 )
+                selected_annotation_id = updated.id if updated is not None else result.annotation_id
         else:
             return
         self._file_annotations = self._annotation_store.annotations_for_file(self.source_path)
+        updated_annotations = self._annotations_for_item(item)
+        if result.action == "delete":
+            selected_annotation_id = updated_annotations[0].id if updated_annotations else None
+        if selected_annotation_id is None:
+            self._selected_annotation_ids.pop(path, None)
+        else:
+            self._selected_annotation_ids[path] = selected_annotation_id
         self._refresh_annotation_labels(path)
+        if updated_annotations:
+            self.focus_annotation_mode()
+        else:
+            self.focus_tree_mode()
         self._show_detail(item)
 
     def _refresh_annotation_labels(self, path: str | None = None) -> None:
@@ -2118,6 +2235,9 @@ def _json_detail_widgets(item: JsonInspectorItem) -> list[Widget]:
 def _annotation_panel_widgets(
     annotations: tuple[AnnotationRecord, ...],
     annotatable: bool,
+    *,
+    selected_annotation_id: str | None,
+    annotation_mode: bool,
 ) -> list[Widget]:
     """Return the separate annotation-status panel for one selected JSON node."""
     widgets: list[Widget] = [
@@ -2147,7 +2267,14 @@ def _annotation_panel_widgets(
         )
         return widgets
 
-    selected = annotations[0]
+    selected = next(
+        (
+            annotation
+            for annotation in annotations
+            if annotation.id == selected_annotation_id
+        ),
+        annotations[0],
+    )
     widgets.extend(
         _metadata_fields(
             [
@@ -2165,6 +2292,9 @@ def _annotation_panel_widgets(
     )
     for index, annotation in enumerate(annotations, start=1):
         summary = Text()
+        marker = "▶ " if annotation.id == selected.id else "  "
+        marker_style = "bold green" if annotation.id == selected.id else "dim"
+        summary.append(marker, style=marker_style)
         summary.append(f"{index}. ", style="bold")
         summary.append(f"{annotation.updated_at[:16].replace('T', ' ')} ", style="dim")
         if annotation.tags:
@@ -2178,7 +2308,12 @@ def _annotation_panel_widgets(
     widgets.append(Static(note, classes="annotation-status-body"))
     widgets.append(
         Static(
-            Text("Press Enter to edit newest or a to add another", style="dim"),
+            Text(
+                "Use ↑↓ to select, Enter to edit, a to add another"
+                if annotation_mode
+                else "Press Enter to browse annotations or a to add another",
+                style="dim",
+            ),
             classes="annotation-status-hint",
         )
     )

--- a/src/skim/trajectory.py
+++ b/src/skim/trajectory.py
@@ -25,7 +25,7 @@ from textual.widget import Widget
 from textual.widgets import Button, Collapsible, Input, Markdown, Static, TextArea
 from textual.widgets import Tree as TextualTree
 
-from .scrolling import DragTree, FocusableDetailWrap
+from .scrolling import AnnotationStatusWrap, DragTree, FocusableDetailWrap
 
 HUMAN_TEXT_KEYS = {
     "arguments",
@@ -1580,7 +1580,7 @@ class JsonInspector(Vertical):
             self._current_item = first_item
             initial_detail_widgets = self._detail_widgets_for_item(first_item)
             initial_annotation_widgets = self._annotation_widgets_for_item(first_item)
-        self._annotation_wrap = Vertical(
+        self._annotation_wrap = AnnotationStatusWrap(
             *initial_annotation_widgets,
             classes="annotation-status-panel",
         )

--- a/src/skim/web/app.js
+++ b/src/skim/web/app.js
@@ -50,6 +50,7 @@ function createPaneState(id) {
     selectedJsonNodeId: null,
     selectedJsonPath: null,
     selectedStepId: null,
+    selectedAnnotationIds: {},
     jsonSplitRatio: loadStoredSplitRatio("json", DEFAULT_JSON_SPLIT_RATIO, id),
     trajectorySplitRatio: loadStoredSplitRatio("trajectory", DEFAULT_TRAJECTORY_SPLIT_RATIO, id),
   };
@@ -1057,13 +1058,32 @@ async function onPreviewClick(event, paneId = state.activePaneId) {
     return;
   }
 
+  const annotationSelection = event.target.closest("[data-select-annotation]");
+  if (annotationSelection) {
+    const annotationPath = annotationSelection.dataset.annotationPath;
+    const annotationId = annotationSelection.dataset.selectAnnotation;
+    if (annotationPath && annotationId) {
+      pane.selectedAnnotationIds[annotationPath] = annotationId;
+      if (pane.preview?.kind === "json_inspector") {
+        updateJsonInspectorPreview(paneId);
+      } else if (pane.preview?.kind === "trajectory") {
+        updateTrajectoryPreview(paneId);
+      }
+    }
+    return;
+  }
+
   const annotate = event.target.closest("[data-annotate]");
   if (annotate) {
+    const annotations = decodeAnnotationList(annotate.dataset.annotations);
+    const annotationId = annotate.dataset.annotationId || null;
     openModal({
       paneId,
       file: pane.path,
       path: annotate.dataset.annotate,
-      annotation: decodeAnnotation(annotate.dataset.annotation),
+      annotations,
+      annotation: annotationId ? annotations.find((entry) => entry.id === annotationId) || null : null,
+      annotationId,
     });
     return;
   }
@@ -1230,7 +1250,7 @@ function renderJsonInspector(pane) {
     <div class="split-view" data-json-shell style="grid-template-columns:${escapeAttribute(splitTemplate(splitRatio))}">
       <div class="pane-list" data-json-pane-list>${renderJsonPaneList(pane)}</div>
       <div class="split-resizer" data-resize-split="json" aria-hidden="true"></div>
-      <div class="detail-panel" data-json-detail>${renderJsonDetail(selected)}</div>
+      <div class="detail-panel" data-json-detail>${renderJsonDetail(selected, pane)}</div>
     </div>
   `;
 }
@@ -1246,8 +1266,10 @@ function renderJsonNode(node, depth, pane) {
   const toggle = node.children.length
     ? `<button class="tree-toggle" type="button" data-toggle-json="${escapeAttribute(node.path)}">${expanded ? "▾" : "▸"}</button>`
     : `<span class="tree-toggle"></span>`;
-  const rowClass = node.annotation ? "json-tree-row-annotated" : "";
-  const marker = node.annotation
+  const nodeAnnotations = normalizeAnnotations(node.annotations, node.annotation);
+  const hasAnnotations = nodeAnnotations.length > 0 || (node.annotation_count || 0) > 0;
+  const rowClass = hasAnnotations ? "json-tree-row-annotated" : "";
+  const marker = hasAnnotations
     ? `<span class="annotation-marker"><span class="annotation-dot"></span><span class="annotation-glyph" aria-hidden="true">✦</span></span>`
     : "";
   const key = node.display_key || node.label;
@@ -1307,15 +1329,27 @@ function toggleJsonNode(pane, node, options = {}) {
   updateJsonInspectorPreview(pane.id);
 }
 
-function renderJsonDetail(selected) {
+function renderJsonDetail(selected, pane) {
+  const annotations = normalizeAnnotations(selected.annotations, selected.annotation);
+  const selectedAnnotation = selectedAnnotationEntry(
+    pane,
+    selected.annotation_path,
+    annotations,
+  );
   return `
     <h3>${escapeHtml(selected.label)}</h3>
     <div class="detail-meta">
       <span class="path-pill">${escapeHtml(selected.path)}</span>
       <span class="badge">${escapeHtml(selected.type_name)}</span>
-      ${selected.annotatable ? renderAnnotateButton(selected.annotation_path, selected.annotation) : ""}
+      ${selected.annotatable ? renderAnnotationActions(pane, selected.annotation_path, annotations) : ""}
     </div>
-    ${renderAnnotationPanel(selected.annotation, selected.annotatable)}
+    ${renderAnnotationPanel(
+      annotations,
+      selected.annotatable,
+      selectedAnnotation ? selectedAnnotation.id : null,
+      pane.id,
+      selected.annotation_path,
+    )}
     ${renderDetailPayload(selected.detail)}
   `;
 }
@@ -1345,7 +1379,7 @@ function updateJsonInspectorPreview(paneId = state.activePaneId) {
   const paneScroll = paneList.scrollTop;
   const detailScroll = detail.scrollTop;
   paneList.innerHTML = renderJsonPaneList(pane);
-  detail.innerHTML = renderJsonDetail(selected);
+  detail.innerHTML = renderJsonDetail(selected, pane);
   paneList.scrollTop = paneScroll;
   detail.scrollTop = detailScroll;
 }
@@ -1372,7 +1406,7 @@ function renderTrajectoryPreview(pane) {
       </div>
       <div class="split-resizer" data-resize-split="trajectory" aria-hidden="true"></div>
       <div class="step-detail" data-trajectory-detail>
-        ${renderTrajectoryDetail(pane.preview, selected)}
+        ${renderTrajectoryDetail(pane.preview, selected, pane)}
       </div>
     </div>
   `;
@@ -1400,7 +1434,7 @@ function renderTrajectoryStepList(preview, selected) {
   `).join("");
 }
 
-function renderTrajectoryDetail(preview, selected) {
+function renderTrajectoryDetail(preview, selected, pane) {
   return `
     <h3>${escapeHtml(preview.header)}</h3>
     <div class="trajectory-meta">
@@ -1413,7 +1447,7 @@ function renderTrajectoryDetail(preview, selected) {
     <div class="preview-card">
       <h3>${escapeHtml(selected.title)}</h3>
       <div class="selection-subtitle">${escapeHtml(selected.path)}</div>
-      ${(selected.items || []).map(renderTrajectoryItem).join("")}
+      ${(selected.items || []).map((item) => renderTrajectoryItem(item, pane)).join("")}
     </div>
   `;
 }
@@ -1443,19 +1477,37 @@ function updateTrajectoryPreview(paneId = state.activePaneId) {
   const listScroll = list.scrollTop;
   const detailScroll = detail.scrollTop;
   list.innerHTML = renderTrajectoryStepList(pane.preview, selected);
-  detail.innerHTML = renderTrajectoryDetail(pane.preview, selected);
+  detail.innerHTML = renderTrajectoryDetail(pane.preview, selected, pane);
   list.scrollTop = listScroll;
   detail.scrollTop = detailScroll;
 }
 
-function renderTrajectoryItem(item) {
+function renderTrajectoryItem(item, pane) {
   if (item.kind === "tool") {
+    const annotations = normalizeAnnotations(item.annotations, item.annotation);
+    const inputAnnotations = normalizeAnnotations(item.input.annotations, item.input.annotation);
+    const outputAnnotations = normalizeAnnotations(item.output.annotations, item.output.annotation);
+    const selectedAnnotation = selectedAnnotationEntry(
+      pane,
+      item.annotation_path,
+      annotations,
+    );
+    const selectedInputAnnotation = selectedAnnotationEntry(
+      pane,
+      item.input.annotation_path,
+      inputAnnotations,
+    );
+    const selectedOutputAnnotation = selectedAnnotationEntry(
+      pane,
+      item.output.annotation_path,
+      outputAnnotations,
+    );
     return `
       <article class="item-card">
         <div class="item-header">
           <div>
             <div class="selection-title">
-              ${item.annotation ? `<span class="annotation-dot"></span>` : ""}
+              ${(annotations.length || (item.annotation_count || 0) > 0) ? `<span class="annotation-dot"></span>` : ""}
               <strong>${escapeHtml(item.title)}</strong>
             </div>
             <div class="item-meta">
@@ -1464,24 +1516,42 @@ function renderTrajectoryItem(item) {
               ${item.status ? `<span class="badge">${escapeHtml(item.status)}</span>` : ""}
             </div>
           </div>
-          ${renderAnnotateButton(item.annotation_path, item.annotation)}
+          ${renderAnnotationActions(pane, item.annotation_path, annotations)}
         </div>
-        ${renderAnnotationPanel(item.annotation, true)}
+        ${renderAnnotationPanel(
+          annotations,
+          true,
+          selectedAnnotation ? selectedAnnotation.id : null,
+          pane.id,
+          item.annotation_path,
+        )}
         <div class="subsection-grid">
           <section class="subsection-card">
             <div class="subsection-header">
               <strong>Input</strong>
-              ${renderAnnotateButton(item.input.annotation_path, item.input.annotation)}
+              ${renderAnnotationActions(pane, item.input.annotation_path, inputAnnotations)}
             </div>
-            ${renderAnnotationPanel(item.input.annotation, true)}
+            ${renderAnnotationPanel(
+              inputAnnotations,
+              true,
+              selectedInputAnnotation ? selectedInputAnnotation.id : null,
+              pane.id,
+              item.input.annotation_path,
+            )}
             ${renderRenderValue(item.input.render)}
           </section>
           <section class="subsection-card">
             <div class="subsection-header">
               <strong>Output</strong>
-              ${renderAnnotateButton(item.output.annotation_path, item.output.annotation)}
+              ${renderAnnotationActions(pane, item.output.annotation_path, outputAnnotations)}
             </div>
-            ${renderAnnotationPanel(item.output.annotation, true)}
+            ${renderAnnotationPanel(
+              outputAnnotations,
+              true,
+              selectedOutputAnnotation ? selectedOutputAnnotation.id : null,
+              pane.id,
+              item.output.annotation_path,
+            )}
             ${renderRenderValue(item.output.render)}
           </section>
         </div>
@@ -1489,12 +1559,18 @@ function renderTrajectoryItem(item) {
     `;
   }
 
+  const annotations = normalizeAnnotations(item.annotations, item.annotation);
+  const selectedAnnotation = selectedAnnotationEntry(
+    pane,
+    item.annotation_path,
+    annotations,
+  );
   return `
     <article class="item-card">
       <div class="item-header">
         <div>
           <div class="selection-title">
-            ${item.annotation ? `<span class="annotation-dot"></span>` : ""}
+            ${(annotations.length || (item.annotation_count || 0) > 0) ? `<span class="annotation-dot"></span>` : ""}
             <strong>${escapeHtml(item.title)}</strong>
           </div>
           <div class="item-meta">
@@ -1504,9 +1580,15 @@ function renderTrajectoryItem(item) {
             ${item.excerpt ? `<span class="badge">${escapeHtml(item.excerpt)}</span>` : ""}
           </div>
         </div>
-        ${renderAnnotateButton(item.annotation_path, item.annotation)}
+        ${renderAnnotationActions(pane, item.annotation_path, annotations)}
       </div>
-      ${renderAnnotationPanel(item.annotation, true)}
+      ${renderAnnotationPanel(
+        annotations,
+        true,
+        selectedAnnotation ? selectedAnnotation.id : null,
+        pane.id,
+        item.annotation_path,
+      )}
       ${renderRenderValue(item.render)}
     </article>
   `;
@@ -1564,19 +1646,53 @@ function renderAnnotateButton(path, annotation) {
   return `<button class="title-button annotate-button ${stateClass}" type="button" data-annotate="${escapeAttribute(path)}" data-annotation="${payload}">${label}</button>`;
 }
 
-function renderAnnotationPanel(annotation, annotatable) {
+function renderEditAnnotationButton(path, annotation, annotations) {
+  if (!path || !annotation) {
+    return "";
+  }
+  return `<button class="title-button annotate-button annotate-button-active" type="button" data-annotate="${escapeAttribute(path)}" data-annotation-id="${escapeAttribute(annotation.id)}" data-annotations="${escapeAttribute(JSON.stringify(annotations || []))}">Edit annotation</button>`;
+}
+
+function renderAnnotationActions(pane, path, annotations) {
+  if (!path) {
+    return "";
+  }
+  const selected = selectedAnnotationEntry(pane, path, annotations);
+  if (!annotations || !annotations.length) {
+    return renderAnnotateButton(path, null);
+  }
+  return `<div class="annotation-actions">${renderAnnotateButton(path, null)}${renderEditAnnotationButton(path, selected, annotations)}</div>`;
+}
+
+function renderAnnotationPanel(annotations, annotatable, selectedAnnotationId = null, paneId = "", annotationPath = "") {
   if (!annotatable) {
     return `<div class="annotation-panel"><div class="selection-subtitle">Annotations unavailable for this node.</div></div>`;
   }
-  if (!annotation) {
+  if (!annotations || !annotations.length) {
     return `<div class="annotation-panel"><div class="selection-subtitle">No annotation yet.</div></div>`;
   }
+  const selected = annotations.find((entry) => entry.id === selectedAnnotationId) || annotations[0];
   return `
     <div class="annotation-panel">
-      <div class="annotation-tags">
-        ${annotation.tags.map((tag) => `<span class="annotation-tag">${escapeHtml(tag)}</span>`).join("")}
+      <div class="selection-subtitle">${escapeHtml(`${annotations.length} annotation${annotations.length === 1 ? "" : "s"}`)}</div>
+      <div class="annotation-list">
+        ${annotations.map((annotation) => `
+          <button
+            class="annotation-entry ${annotation.id === selected.id ? "selected" : ""}"
+            type="button"
+            data-select-annotation="${escapeAttribute(annotation.id)}"
+            data-annotation-path="${escapeAttribute(annotationPath || "")}"
+            data-pane-id="${escapeAttribute(paneId || "")}"
+          >
+            <span class="annotation-entry-time">${escapeHtml(formatAnnotationTimestamp(annotation.updated_at))}</span>
+            <span class="annotation-entry-summary">${escapeHtml(annotation.note || "(empty)")}</span>
+          </button>
+        `).join("")}
       </div>
-      <div>${escapeHtml(annotation.note || "(empty)")}</div>
+      <div class="annotation-tags">
+        ${(selected.tags || []).map((tag) => `<span class="annotation-tag">${escapeHtml(tag)}</span>`).join("")}
+      </div>
+      <div>${escapeHtml(selected.note || "(empty)")}</div>
     </div>
   `;
 }
@@ -1736,6 +1852,39 @@ function decodeAnnotation(value) {
   }
 }
 
+function decodeAnnotationList(value) {
+  const decoded = decodeAnnotation(value);
+  return Array.isArray(decoded) ? decoded : [];
+}
+
+function normalizeAnnotations(annotations, annotation) {
+  if (Array.isArray(annotations)) {
+    return annotations;
+  }
+  return annotation ? [annotation] : [];
+}
+
+function selectedAnnotationEntry(pane, annotationPath, annotations) {
+  if (!annotations || !annotations.length) {
+    return null;
+  }
+  if (!pane || !annotationPath) {
+    return annotations[0];
+  }
+  const selectedId = pane.selectedAnnotationIds?.[annotationPath];
+  const selected = annotations.find((entry) => entry.id === selectedId) || annotations[0];
+  pane.selectedAnnotationIds[annotationPath] = selected.id;
+  return selected;
+}
+
+function formatAnnotationTimestamp(value) {
+  if (!value) {
+    return "";
+  }
+  const normalized = String(value).replace("T", " ").replace("Z", "");
+  return normalized.slice(0, 16);
+}
+
 function openModal(payload) {
   state.modal = payload;
   elements.modalFile && (elements.modalFile.textContent = payload.file || "");
@@ -1746,7 +1895,7 @@ function openModal(payload) {
   if (elements.modalNote) {
     elements.modalNote.value = payload.annotation ? payload.annotation.note : "";
   }
-  elements.modalDelete?.classList.toggle("hidden", !payload.annotation);
+  elements.modalDelete?.classList.toggle("hidden", !payload.annotationId);
   elements.modal?.classList.remove("hidden");
   elements.modalTags?.focus();
 }
@@ -1771,6 +1920,7 @@ async function onSaveAnnotation(event) {
     body: JSON.stringify({
       file: state.modal.file,
       path: state.modal.path,
+      ...(state.modal.annotationId ? { annotation_id: state.modal.annotationId } : {}),
       tags,
       note: elements.modalNote?.value || "",
     }),
@@ -1794,6 +1944,7 @@ async function onDeleteAnnotation() {
     body: JSON.stringify({
       file: state.modal.file,
       path: state.modal.path,
+      annotation_id: state.modal.annotationId,
     }),
   });
   const pane = paneById(state.modal.paneId);

--- a/src/skim/web/styles.css
+++ b/src/skim/web/styles.css
@@ -651,6 +651,7 @@ button {
 .trajectory-meta,
 .item-meta,
 .annotation-tags,
+.annotation-actions,
 .notebook-meta,
 .modal-meta {
   display: flex;
@@ -700,6 +701,49 @@ button {
 
 .annotate-button.annotate-button-active:hover {
   background: color-mix(in srgb, var(--green) 30%, var(--bg-hover));
+}
+
+.annotation-actions {
+  justify-content: flex-end;
+}
+
+.annotation-list {
+  display: grid;
+  gap: 6px;
+  margin-bottom: 10px;
+}
+
+.annotation-entry {
+  width: 100%;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--bg-primary);
+  color: var(--fg-primary);
+  padding: 8px 10px;
+  display: grid;
+  gap: 2px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.annotation-entry:hover {
+  background: var(--bg-hover);
+}
+
+.annotation-entry.selected {
+  border-color: color-mix(in srgb, var(--accent) 65%, var(--border));
+  background: color-mix(in srgb, var(--accent) 12%, var(--bg-surface));
+}
+
+.annotation-entry-time {
+  font-size: 11px;
+  color: var(--fg-muted);
+}
+
+.annotation-entry-summary {
+  font-size: 13px;
+  line-height: 1.4;
+  color: var(--fg-primary);
 }
 
 .annotation-dot {

--- a/src/skim/web_preview.py
+++ b/src/skim/web_preview.py
@@ -392,26 +392,31 @@ def serialize_trajectory_preview(
                     event_paths.get(id(result_event.raw)) if result_event is not None else None
                 )
                 parent_path = call_path or result_path or step_path
+                parent_annotations = _annotation_payload_for_path(file_annotations, parent_path)
+                input_annotations = _annotation_payload_for_path(
+                    file_annotations,
+                    call_path or parent_path,
+                )
+                output_annotations = _annotation_payload_for_path(
+                    file_annotations,
+                    result_path or parent_path,
+                )
                 blocks.append(
                     {
                         "id": block_id,
                         "kind": "tool",
                         "title": item.title.plain,
                         "annotation_path": _format_path(parent_path),
-                        "annotation": _annotation_payload_for_path(
-                            file_annotations,
-                            parent_path,
-                        ),
+                        "annotations": parent_annotations,
+                        "annotation_count": len(parent_annotations),
                         "tool_name": interaction.tool_name,
                         "call_id": interaction.call_id,
                         "status": _interaction_status(interaction),
                         "summary": _interaction_payload(interaction),
                         "input": {
                             "annotation_path": _format_path(call_path or parent_path),
-                            "annotation": _annotation_payload_for_path(
-                                file_annotations,
-                                call_path or parent_path,
-                            ),
+                            "annotations": input_annotations,
+                            "annotation_count": len(input_annotations),
                             "render": _render_value(
                                 _decoded_tool_result(call_event.raw.get("arguments"))
                                 if call_event is not None
@@ -421,10 +426,8 @@ def serialize_trajectory_preview(
                         },
                         "output": {
                             "annotation_path": _format_path(result_path or parent_path),
-                            "annotation": _annotation_payload_for_path(
-                                file_annotations,
-                                result_path or parent_path,
-                            ),
+                            "annotations": output_annotations,
+                            "annotation_count": len(output_annotations),
                             "render": _render_value(
                                 _decoded_tool_result(result_event.raw.get("output"))
                                 if result_event is not None
@@ -442,13 +445,15 @@ def serialize_trajectory_preview(
             event = item.event
             event_path = event_paths.get(id(event.raw)) or step_path
             render_value = _event_text(event.raw) or _event_payload(event.raw)
+            event_annotations = _annotation_payload_for_path(file_annotations, event_path)
             blocks.append(
                 {
                     "id": block_id,
                     "kind": "event",
                     "title": item.title.plain,
                     "annotation_path": _format_path(event_path),
-                    "annotation": _annotation_payload_for_path(file_annotations, event_path),
+                    "annotations": event_annotations,
+                    "annotation_count": len(event_annotations),
                     "event_kind": event.kind,
                     "excerpt": event.excerpt,
                     "role": _message_role(event.raw) if event.kind == "message" else None,
@@ -513,7 +518,7 @@ class _JsonInspectorSerializer:
         node_id = f"node-{self._next_id}"
         self._next_id += 1
         annotation_path = self._annotation_key(item)
-        annotation = self._annotation_for_path(annotation_path)
+        annotations = self._annotation_for_path(annotation_path)
         display_key, display_value, value_type, node_class = _node_display_metadata(item)
         payload: dict[str, Any] = {
             "id": node_id,
@@ -524,7 +529,8 @@ class _JsonInspectorSerializer:
             "raw_path": list(item.raw_path),
             "annotatable": annotation_path is not None,
             "annotation_path": annotation_path,
-            "annotation": annotation,
+            "annotations": annotations,
+            "annotation_count": len(annotations),
             "style": _node_style(item.kind),
             "type_name": _json_type_name(item.raw_value),
             "key": item.key,
@@ -730,11 +736,10 @@ class _JsonInspectorSerializer:
             return None
         return _format_raw_path(item.raw_path)
 
-    def _annotation_for_path(self, path: str | None) -> dict[str, Any] | None:
+    def _annotation_for_path(self, path: str | None) -> list[dict[str, Any]]:
         if path is None:
-            return None
-        record = self._file_annotations.get(path)
-        return _annotation_payload(record)
+            return []
+        return [_annotation_payload(record) for record in self._file_annotations.get(path, ())]
 
 
 def _serialize_csv_preview(content: str, *, name: str, relative_path: str) -> dict[str, Any]:
@@ -1065,22 +1070,23 @@ def _decode_json_value(value: Any) -> Any:
     return value
 
 
-def _annotation_payload(record: AnnotationRecord | None) -> dict[str, Any] | None:
-    if record is None:
-        return None
+def _annotation_payload(record: AnnotationRecord) -> dict[str, Any]:
     return {
+        "id": record.id,
+        "created_at": record.created_at,
+        "updated_at": record.updated_at,
         "tags": list(record.tags),
         "note": record.note,
     }
 
 
 def _annotation_payload_for_path(
-    annotations: dict[str, AnnotationRecord],
+    annotations: dict[str, tuple[AnnotationRecord, ...]],
     path: tuple[str | int, ...] | None,
-) -> dict[str, Any] | None:
+) -> list[dict[str, Any]]:
     if path is None:
-        return None
-    return _annotation_payload(annotations.get(_format_raw_path(path)))
+        return []
+    return [_annotation_payload(record) for record in annotations.get(_format_raw_path(path), ())]
 
 
 def _format_path(path: tuple[str | int, ...] | None) -> str | None:

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -566,7 +566,7 @@ def test_annotation_store_caches_one_file_lookup(tmp_path, monkeypatch):
     assert second is not None
     assert first.note == "cached"
     assert second.note == "cached"
-    assert records["$.hello"].note == "cached"
+    assert records["$.hello"][0].note == "cached"
     assert calls == 1
 
     store.set_annotation(source, "$.hello", tags=("updated",), note="changed")
@@ -575,6 +575,136 @@ def test_annotation_store_caches_one_file_lookup(tmp_path, monkeypatch):
     assert updated is not None
     assert updated.note == "changed"
     assert calls == 1
+
+
+def test_annotation_store_normalizes_legacy_single_record_entries(tmp_path):
+    """Legacy review.json entries should load as one-item annotation lists."""
+    source = tmp_path / "plain.json"
+    source.write_text(json.dumps({"hello": "world"}))
+    review_file = tmp_path / ".skim" / "review.json"
+    review_file.parent.mkdir()
+    review_file.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "files": {
+                    "plain.json": {
+                        "annotations": {
+                            "$.hello": {
+                                "tags": ["evidence"],
+                                "note": "cached",
+                            }
+                        }
+                    }
+                },
+            }
+        )
+    )
+
+    store = AnnotationStore(tmp_path)
+    records = store.annotations_for_path(source, "$.hello")
+
+    assert len(records) == 1
+    assert records[0].tags == ("evidence",)
+    assert records[0].note == "cached"
+    assert records[0].id
+    assert records[0].created_at
+    assert records[0].updated_at
+
+
+def test_annotation_store_adds_updates_and_deletes_individual_entries(tmp_path):
+    """Multi-entry annotation CRUD should preserve sibling annotations on one node."""
+    source = tmp_path / "plain.json"
+    source.write_text(json.dumps({"hello": "world"}))
+    store = AnnotationStore(tmp_path)
+
+    first = store.add_annotation(
+        source,
+        "$.hello",
+        tags=("evidence",),
+        note="first note",
+    )
+    second = store.add_annotation(
+        source,
+        "$.hello",
+        tags=("bug",),
+        note="second note",
+    )
+
+    records = store.annotations_for_path(source, "$.hello")
+    assert [record.id for record in records] == [second.id, first.id]
+
+    updated = store.update_annotation(
+        source,
+        "$.hello",
+        second.id,
+        tags=("bug", "confirmed"),
+        note="second note updated",
+    )
+    assert updated is not None
+    assert updated.id == second.id
+    assert updated.tags == ("bug", "confirmed")
+    assert updated.note == "second note updated"
+
+    store.delete_annotation(source, "$.hello", second.id)
+    after_delete = store.annotations_for_path(source, "$.hello")
+    assert [record.id for record in after_delete] == [first.id]
+
+    payload = json.loads((tmp_path / ".skim" / "review.json").read_text())
+    saved = payload["files"]["plain.json"]["annotations"]["$.hello"]
+    assert isinstance(saved, list)
+    assert saved[0]["id"] == first.id
+
+
+async def test_json_inspector_annotation_panel_lists_newest_first(tmp_path):
+    """Persisted multi-entry annotations should render as a newest-first list in the TUI."""
+    test_file = tmp_path / "plain.json"
+    test_file.write_text(json.dumps({"hello": "world"}))
+    review_file = tmp_path / ".skim" / "review.json"
+    review_file.parent.mkdir()
+    review_file.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "files": {
+                    "plain.json": {
+                        "annotations": {
+                            "$.hello": [
+                                {
+                                    "id": "older",
+                                    "created_at": "2026-04-20T10:00:00Z",
+                                    "updated_at": "2026-04-20T10:00:00Z",
+                                    "tags": ["evidence"],
+                                    "note": "older note",
+                                },
+                                {
+                                    "id": "newer",
+                                    "created_at": "2026-04-20T11:00:00Z",
+                                    "updated_at": "2026-04-20T11:30:00Z",
+                                    "tags": ["bug"],
+                                    "note": "newer note",
+                                },
+                            ]
+                        }
+                    }
+                },
+            }
+        )
+    )
+
+    widgets = render_file(test_file, browse_root=tmp_path)
+    inspector = widgets[0]
+    assert isinstance(inspector, JsonInspector)
+
+    app = SkimApp(path=str(tmp_path))
+    async with app.run_test() as pilot:
+        pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
+        await pane.mount(inspector)
+        await pilot.pause()
+
+        annotation = _annotation_text(inspector)
+        assert "2 annotations" in annotation
+        assert annotation.index("newer note") < annotation.index("older note")
 
 
 def test_trajectory_json_inspector_uses_one_overlay_normalization_pass(tmp_path, monkeypatch):
@@ -623,13 +753,17 @@ async def test_annotation_modal_saves_selected_node_annotation(tmp_path):
 
         review_file = tmp_path / ".skim" / "review.json"
         payload = json.loads(review_file.read_text())
-        assert payload["files"]["plain.json"]["annotations"]["$.hello"] == {
-            "tags": ["evidence", "bug"],
-            "note": "First concrete failure appears here.",
-        }
+        saved = payload["files"]["plain.json"]["annotations"]["$.hello"]
+        assert len(saved) == 1
+        assert saved[0]["tags"] == ["evidence", "bug"]
+        assert saved[0]["note"] == "First concrete failure appears here."
+        assert saved[0]["id"]
+        assert saved[0]["created_at"]
+        assert saved[0]["updated_at"]
         assert inspector._tree.root.children[0].label.plain.startswith("* ")
         annotation = _annotation_text(inspector)
         detail = _detail_text(inspector)
+        assert "1 annotation" in annotation
         assert "evidence, bug" in annotation
         assert "First concrete failure appears here." in annotation
         assert "First concrete failure appears here." not in detail
@@ -648,10 +782,15 @@ async def test_annotation_modal_delete_removes_selected_node_annotation(tmp_path
                 "files": {
                     "plain.json": {
                         "annotations": {
-                            "$.hello": {
-                                "tags": ["evidence"],
-                                "note": "First concrete failure appears here.",
-                            }
+                            "$.hello": [
+                                {
+                                    "id": "existing",
+                                    "created_at": "2026-04-20T10:00:00Z",
+                                    "updated_at": "2026-04-20T10:00:00Z",
+                                    "tags": ["evidence"],
+                                    "note": "First concrete failure appears here.",
+                                }
+                            ]
                         }
                     }
                 },
@@ -666,7 +805,7 @@ async def test_annotation_modal_delete_removes_selected_node_annotation(tmp_path
         await pilot.pause()
 
         inspector = pane.query_one(JsonInspector)
-        await pilot.press("a")
+        await pilot.press("enter")
         await pilot.pause()
         app.screen.action_delete()
         await pilot.pause()

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -707,6 +707,51 @@ async def test_json_inspector_annotation_panel_lists_newest_first(tmp_path):
         assert annotation.index("newer note") < annotation.index("older note")
 
 
+async def test_json_inspector_annotation_panel_expands_for_long_annotation_lists(tmp_path):
+    """Long annotation lists should not stay clipped to the old fixed-height TUI panel."""
+    test_file = tmp_path / "plain.json"
+    test_file.write_text(json.dumps({"hello": "world"}))
+    annotations = []
+    for index in range(12):
+        annotations.append(
+            {
+                "id": f"annotation-{index}",
+                "created_at": f"2026-04-20T10:{index:02d}:00Z",
+                "updated_at": f"2026-04-20T11:{index:02d}:00Z",
+                "tags": [f"tag-{index}"],
+                "note": f"note {index}",
+            }
+        )
+    review_file = tmp_path / ".skim" / "review.json"
+    review_file.parent.mkdir()
+    review_file.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "files": {
+                    "plain.json": {
+                        "annotations": {
+                            "$.hello": annotations,
+                        }
+                    }
+                },
+            }
+        )
+    )
+
+    widgets = render_file(test_file, browse_root=tmp_path)
+    inspector = widgets[0]
+    assert isinstance(inspector, JsonInspector)
+
+    app = SkimApp(path=str(tmp_path))
+    async with app.run_test() as pilot:
+        pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
+        await pane.mount(inspector)
+        await pilot.pause()
+
+        assert inspector._annotation_wrap.size.height > 6
+
+
 def test_trajectory_json_inspector_uses_one_overlay_normalization_pass(tmp_path, monkeypatch):
     """Opening trajectory JSON should normalize overlay data through one shared pass."""
     test_file = tmp_path / "trajectory.json"

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -752,6 +752,204 @@ async def test_json_inspector_annotation_panel_expands_for_long_annotation_lists
         assert inspector._annotation_wrap.size.height > 6
 
 
+async def test_json_inspector_enter_switches_into_annotation_selection_mode(tmp_path):
+    """Enter on a node with annotations should switch from tree navigation into annotation mode."""
+    test_file = tmp_path / "plain.json"
+    test_file.write_text(json.dumps({"hello": "world"}))
+    review_file = tmp_path / ".skim" / "review.json"
+    review_file.parent.mkdir()
+    review_file.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "files": {
+                    "plain.json": {
+                        "annotations": {
+                            "$.hello": [
+                                {
+                                    "id": "older",
+                                    "created_at": "2026-04-20T10:00:00Z",
+                                    "updated_at": "2026-04-20T10:00:00Z",
+                                    "tags": ["evidence"],
+                                    "note": "older note",
+                                },
+                                {
+                                    "id": "newer",
+                                    "created_at": "2026-04-20T11:00:00Z",
+                                    "updated_at": "2026-04-20T11:30:00Z",
+                                    "tags": ["bug"],
+                                    "note": "newer note",
+                                },
+                            ]
+                        }
+                    }
+                },
+            }
+        )
+    )
+    app = SkimApp(path=str(tmp_path))
+
+    async with app.run_test() as pilot:
+        pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
+        pane.show_file(test_file)
+        await pilot.pause()
+
+        inspector = pane.query_one(JsonInspector)
+        assert inspector.is_tree_mode()
+
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert not inspector.is_tree_mode()
+        footer = _static_content(inspector._footer)
+        assert isinstance(footer, Text)
+        assert "Select" in footer.plain
+        annotation = _annotation_text(inspector)
+        assert "▶ 1." in annotation
+        assert "newer note" in annotation
+
+        await pilot.press("down")
+        await pilot.pause()
+
+        annotation = _annotation_text(inspector)
+        assert "▶ 2." in annotation
+        assert "Note: older note" in annotation
+
+
+async def test_annotation_mode_edits_selected_non_newest_annotation(tmp_path):
+    """Enter from annotation mode should edit the currently selected older annotation."""
+    test_file = tmp_path / "plain.json"
+    test_file.write_text(json.dumps({"hello": "world"}))
+    review_file = tmp_path / ".skim" / "review.json"
+    review_file.parent.mkdir()
+    review_file.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "files": {
+                    "plain.json": {
+                        "annotations": {
+                            "$.hello": [
+                                {
+                                    "id": "older",
+                                    "created_at": "2026-04-20T10:00:00Z",
+                                    "updated_at": "2026-04-20T10:00:00Z",
+                                    "tags": ["evidence"],
+                                    "note": "older note",
+                                },
+                                {
+                                    "id": "newer",
+                                    "created_at": "2026-04-20T11:00:00Z",
+                                    "updated_at": "2026-04-20T11:30:00Z",
+                                    "tags": ["bug"],
+                                    "note": "newer note",
+                                },
+                            ]
+                        }
+                    }
+                },
+            }
+        )
+    )
+    app = SkimApp(path=str(tmp_path))
+
+    async with app.run_test() as pilot:
+        pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
+        pane.show_file(test_file)
+        await pilot.pause()
+
+        await pilot.press("enter")
+        await pilot.press("down")
+        await pilot.pause()
+        await pilot.press("enter")
+        await pilot.pause()
+
+        tags = app.screen.query_one("#annotation-tags", Input)
+        note = app.screen.query_one("#annotation-note", TextArea)
+        assert tags.value == "evidence"
+        assert note.text == "older note"
+
+        note.load_text("older note updated")
+        app.screen.action_save()
+        await pilot.pause()
+
+        payload = json.loads(review_file.read_text())
+        saved = payload["files"]["plain.json"]["annotations"]["$.hello"]
+        older = next(annotation for annotation in saved if annotation["id"] == "older")
+        assert older["note"] == "older note updated"
+        annotation = _annotation_text(pane.query_one(JsonInspector))
+        assert "Note: older note updated" in annotation
+        assert "▶ 1." in annotation
+
+
+async def test_annotation_mode_delete_and_add_keep_selection_stable(tmp_path):
+    """Deleting an older entry and adding a new one should keep selection sensible."""
+    test_file = tmp_path / "plain.json"
+    test_file.write_text(json.dumps({"hello": "world"}))
+    review_file = tmp_path / ".skim" / "review.json"
+    review_file.parent.mkdir()
+    review_file.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "files": {
+                    "plain.json": {
+                        "annotations": {
+                            "$.hello": [
+                                {
+                                    "id": "older",
+                                    "created_at": "2026-04-20T10:00:00Z",
+                                    "updated_at": "2026-04-20T10:00:00Z",
+                                    "tags": ["evidence"],
+                                    "note": "older note",
+                                },
+                                {
+                                    "id": "newer",
+                                    "created_at": "2026-04-20T11:00:00Z",
+                                    "updated_at": "2026-04-20T11:30:00Z",
+                                    "tags": ["bug"],
+                                    "note": "newer note",
+                                },
+                            ]
+                        }
+                    }
+                },
+            }
+        )
+    )
+    app = SkimApp(path=str(tmp_path))
+
+    async with app.run_test() as pilot:
+        pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
+        pane.show_file(test_file)
+        await pilot.pause()
+
+        await pilot.press("enter")
+        await pilot.press("down")
+        await pilot.pause()
+        await pilot.press("enter")
+        await pilot.pause()
+        app.screen.action_delete()
+        await pilot.pause()
+
+        annotation = _annotation_text(pane.query_one(JsonInspector))
+        assert "older note" not in annotation
+        assert "▶ 1." in annotation
+        assert "Note: newer note" in annotation
+
+        await pilot.press("a")
+        await pilot.pause()
+        app.screen.query_one("#annotation-tags", Input).value = "followup"
+        app.screen.query_one("#annotation-note", TextArea).load_text("brand new note")
+        app.screen.action_save()
+        await pilot.pause()
+
+        annotation = _annotation_text(pane.query_one(JsonInspector))
+        assert "brand new note" in annotation
+        assert "▶ 1." in annotation
+        assert "Note: brand new note" in annotation
+
+
 def test_trajectory_json_inspector_uses_one_overlay_normalization_pass(tmp_path, monkeypatch):
     """Opening trajectory JSON should normalize overlay data through one shared pass."""
     test_file = tmp_path / "trajectory.json"
@@ -850,6 +1048,8 @@ async def test_annotation_modal_delete_removes_selected_node_annotation(tmp_path
         await pilot.pause()
 
         inspector = pane.query_one(JsonInspector)
+        await pilot.press("enter")
+        await pilot.pause()
         await pilot.press("enter")
         await pilot.pause()
         app.screen.action_delete()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -352,7 +352,7 @@ def test_api_tree_skips_symlinks_that_escape_the_browse_root(tmp_path):
 
 
 def test_api_annotations_round_trip_to_review_json(tmp_path):
-    """Saving and deleting annotations should preserve skim's review.json contract."""
+    """Saving and deleting annotations should preserve skim's list-shaped review.json contract."""
     test_file = tmp_path / "plain.json"
     test_file.write_text(json.dumps({"hello": "world"}))
 
@@ -377,22 +377,104 @@ def test_api_annotations_round_trip_to_review_json(tmp_path):
             base_url,
             "/api/annotations",
             method="DELETE",
-            body={"file": "plain.json", "path": "$.hello"},
+            body={
+                "file": "plain.json",
+                "path": "$.hello",
+                "annotation_id": save_payload["annotation"]["id"],
+            },
         )
         _, after_delete = request_json(base_url, "/api/annotations")
 
     assert save_status == 200
-    assert save_payload == {"ok": True}
+    assert save_payload["ok"] is True
     assert get_status == 200
-    assert stored["files"]["plain.json"]["annotations"]["$.hello"] == {
-        "tags": ["important"],
-        "note": "keep this",
-    }
+    saved = stored["files"]["plain.json"]["annotations"]["$.hello"]
+    assert len(saved) == 1
+    assert saved[0]["id"] == save_payload["annotation"]["id"]
+    assert saved[0]["tags"] == ["important"]
+    assert saved[0]["note"] == "keep this"
     hello_node = next(node for node in preview["tree"] if node["path"] == "$.hello")
-    assert hello_node["annotation"] == {"tags": ["important"], "note": "keep this"}
+    assert hello_node["annotation_count"] == 1
+    assert hello_node["annotations"][0]["id"] == save_payload["annotation"]["id"]
     assert delete_status == 200
     assert delete_payload == {"ok": True}
     assert after_delete["files"]["plain.json"]["annotations"] == {}
+
+
+def test_api_annotations_support_multi_entry_round_trip(tmp_path):
+    """The annotation API should create, update, and delete one entry by id."""
+    test_file = tmp_path / "plain.json"
+    test_file.write_text(json.dumps({"hello": "world"}))
+
+    with running_server(tmp_path) as base_url:
+        _, first = request_json(
+            base_url,
+            "/api/annotations",
+            method="POST",
+            body={
+                "file": "plain.json",
+                "path": "$.hello",
+                "tags": ["important"],
+                "note": "first",
+            },
+        )
+        _, second = request_json(
+            base_url,
+            "/api/annotations",
+            method="POST",
+            body={
+                "file": "plain.json",
+                "path": "$.hello",
+                "tags": ["followup"],
+                "note": "second",
+            },
+        )
+        _, updated = request_json(
+            base_url,
+            "/api/annotations",
+            method="POST",
+            body={
+                "file": "plain.json",
+                "path": "$.hello",
+                "annotation_id": second["annotation"]["id"],
+                "tags": ["followup", "confirmed"],
+                "note": "second updated",
+            },
+        )
+        _, preview = request_json(
+            base_url,
+            "/api/preview?path=" + urllib.parse.quote("plain.json"),
+        )
+        _, stored = request_json(base_url, "/api/annotations")
+        delete_status, delete_payload = request_json(
+            base_url,
+            "/api/annotations",
+            method="DELETE",
+            body={
+                "file": "plain.json",
+                "path": "$.hello",
+                "annotation_id": second["annotation"]["id"],
+            },
+        )
+        _, after_delete = request_json(base_url, "/api/annotations")
+
+    assert first["ok"] is True
+    assert second["ok"] is True
+    assert updated["annotation"]["id"] == second["annotation"]["id"]
+    assert updated["annotation"]["note"] == "second updated"
+    saved = stored["files"]["plain.json"]["annotations"]["$.hello"]
+    assert len(saved) == 2
+    assert saved[0]["id"] == second["annotation"]["id"]
+    hello_node = next(node for node in preview["tree"] if node["path"] == "$.hello")
+    assert hello_node["annotation_count"] == 2
+    assert [entry["id"] for entry in hello_node["annotations"]] == [
+        second["annotation"]["id"],
+        first["annotation"]["id"],
+    ]
+    assert delete_status == 200
+    assert delete_payload == {"ok": True}
+    remaining = after_delete["files"]["plain.json"]["annotations"]["$.hello"]
+    assert [entry["id"] for entry in remaining] == [first["annotation"]["id"]]
 
 
 def test_root_serves_local_static_shell_without_cdn_dependencies(tmp_path):

--- a/tests/test_web_app_contract.py
+++ b/tests/test_web_app_contract.py
@@ -391,6 +391,47 @@ console.log(JSON.stringify({
     }
 
 
+def test_render_annotation_panel_lists_multiple_entries_and_defaults_to_newest():
+    """The annotation panel should show multiple entries newest-first for one node."""
+    result = run_app_js(
+        """
+const html = ctx.renderAnnotationPanel(
+  [
+    {
+      id: "newer",
+      created_at: "2026-04-20T11:00:00Z",
+      updated_at: "2026-04-20T11:30:00Z",
+      tags: ["bug"],
+      note: "newer note",
+    },
+    {
+      id: "older",
+      created_at: "2026-04-20T10:00:00Z",
+      updated_at: "2026-04-20T10:00:00Z",
+      tags: ["evidence"],
+      note: "older note",
+    },
+  ],
+  true,
+  "newer",
+);
+console.log(JSON.stringify({
+  hasList: html.includes('annotation-list'),
+  hasCount: html.includes('2 annotations'),
+  newerBeforeOlder: html.indexOf('newer note') < html.indexOf('older note'),
+  hasSelectedClass: html.includes('annotation-entry selected'),
+}));
+"""
+    )
+
+    assert result == {
+        "hasList": True,
+        "hasCount": True,
+        "newerBeforeOlder": True,
+        "hasSelectedClass": True,
+    }
+
+
 def test_render_json_node_marks_annotated_rows_more_obviously():
     """Annotated JSON rows should emit a dedicated row state and stronger marker glyph."""
     result = run_app_js(


### PR DESCRIPTION
## Summary
- add multi-annotation storage and API support with backward-compatible `review.json` loading
- update the web UI to render annotation lists and preserve selected annotation state per target
- add TUI follow-ups for readable annotation panels and selectable annotation entries

## Validation
- `uv run pytest -v`
- `uv run ruff check src/ tests/`