### PR TITLE
Add shared annotation triage for web and TUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Requires Python 3.12 or newer.
 ```bash
 uv run skim              # open current directory
 uv run skim ~/my/folder  # open a specific folder
+uv run skim . --triage   # start directly in triage mode
 uv run skim-dev          # launch Textual dev mode
 uv run skim-web .        # run the localhost web UI
 ```
@@ -35,10 +36,11 @@ uv run skim-web .
 ```
 
 The current implementation is Python-first and localhost-only, backed by typed
-preview payloads from `/api/preview`. The browser shell now includes multi-pane
-preview work, an active-pane file target, a command palette, local dark/light
-themes, bundled JetBrains Mono assets, and explicit notebook previews for
-`.ipynb` files.
+preview payloads from `/api/preview`. The browser shell now includes a
+`Browse | Triage` mode switch, multi-pane preview work, an active-pane file
+target, workspace-level annotation triage, local file-level annotations for
+non-JSON previews, a command palette, local dark/light themes, bundled
+JetBrains Mono assets, and explicit notebook previews for `.ipynb` files.
 
 See the full target design spec here:
 
@@ -121,6 +123,14 @@ JSON files open in a structural inspector rather than a plain text dump. The ins
 
 Annotations bind to the underlying raw JSON location, using `annotation_path` when an
 overlay node maps to a raw node and falling back to `raw_path` otherwise.
+
+## Workspace triage
+
+- `uv run skim . --triage` starts the TUI in a dedicated triage mode
+- the web UI exposes the same queue behind the `Browse | Triage` toggle
+- triage rows are normalized in Python from `.skim/review.json`
+- non-JSON previews store file-level annotations under the reserved `@file` target key
+- the web UI exposes `/api/triage` and `/api/annotation-version` for queue data and refresh
 
 ## File size limits
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ See the full target design spec here:
 | `Up/Down` or `j/k` | Scroll the active preview pane |
 | `PageUp/PageDown` | Page-scroll the active preview pane; in JSON inspector mode, scroll the detail panel |
 | `f` | Toggle file-tree mode |
+| `t` | Switch to triage mode |
+| `b` | Switch back to browse mode |
 | `Shift+Up/Down` | Move the file-tree cursor without leaving the active preview |
 | `Enter` | Open the current file-tree selection in the active pane |
 | `s` then arrow or `h/j/k/l` | Split in a direction |
@@ -126,8 +128,10 @@ overlay node maps to a raw node and falling back to `raw_path` otherwise.
 
 ## Workspace triage
 
-- `uv run skim . --triage` starts the TUI in a dedicated triage mode
+- `uv run skim . --triage` starts the TUI in triage mode
+- `t` and `b` switch between triage and browse in the same TUI session
 - the web UI exposes the same queue behind the `Browse | Triage` toggle
+- triage queues are grouped by file in both the TUI and web UI to reduce repeated metadata
 - triage rows are normalized in Python from `.skim/review.json`
 - non-JSON previews store file-level annotations under the reserved `@file` target key
 - the web UI exposes `/api/triage` and `/api/annotation-version` for queue data and refresh

--- a/docs/skim-web-ui-spec.md
+++ b/docs/skim-web-ui-spec.md
@@ -117,6 +117,8 @@ Multi-pane target:
 
 - `/api/tree` returns the browse tree
 - `/api/preview?path=<rel>` returns typed preview payloads
+- `/api/triage` returns normalized workspace annotation rows
+- `/api/annotation-version` returns the current review-version token
 - `/api/annotations` persists local review annotations under
   `<browse-root>/.skim/review.json`
 - Python owns preview routing, syntax HTML generation, and structured detail payloads
@@ -410,15 +412,35 @@ Step / item fields:
   "files": {
     "data/output.json": {
       "annotations": {
-        "$.trajectory.steps[0].output[3]": {
-          "tags": ["important"],
-          "note": "check this"
-        }
+        "$.trajectory.steps[0].output[3]": [
+          {
+            "id": "ann-json",
+            "created_at": "2026-04-21T14:00:00.000000Z",
+            "updated_at": "2026-04-21T14:05:00.000000Z",
+            "tags": ["important"],
+            "note": "check this"
+          }
+        ]
+      }
+    },
+    "docs/spec.md": {
+      "annotations": {
+        "@file": [
+          {
+            "id": "ann-file",
+            "created_at": "2026-04-21T14:10:00.000000Z",
+            "updated_at": "2026-04-21T14:15:00.000000Z",
+            "tags": ["follow-up"],
+            "note": "Review the whole file."
+          }
+        ]
       }
     }
   }
 }
 ```
+
+The reserved `@file` key stores file-level annotations for non-JSON previews.
 
 ### `POST /api/annotations`
 
@@ -430,6 +452,17 @@ Request:
   "path": "$.trajectory.steps[0].output[3]",
   "tags": ["important"],
   "note": "check this"
+}
+```
+
+File-level example:
+
+```json
+{
+  "file": "docs/spec.md",
+  "path": "@file",
+  "tags": ["follow-up"],
+  "note": "Review the whole file."
 }
 ```
 
@@ -461,6 +494,37 @@ Failure rules:
 - missing file → error
 - path outside browse root → forbidden
 - malformed request body → error
+
+### `GET /api/annotation-version`
+
+```json
+{
+  "annotation_version": "1761087327123456789:214"
+}
+```
+
+### `GET /api/triage`
+
+```json
+{
+  "annotation_version": "1761087327123456789:214",
+  "items": [
+    {
+      "annotation_id": "ann-file",
+      "file_path": "docs/spec.md",
+      "target_kind": "file",
+      "target_label": "File",
+      "target_path": null,
+      "preview_kind": "markdown",
+      "tags": ["follow-up"],
+      "note_preview": "Review the whole file.",
+      "note_full": "Review the whole file.",
+      "created_at": "2026-04-21T14:10:00.000000Z",
+      "updated_at": "2026-04-21T14:15:00.000000Z"
+    }
+  ]
+}
+```
 
 ---
 

--- a/src/skim/app.py
+++ b/src/skim/app.py
@@ -509,7 +509,7 @@ class SkimApp(App):
 
     def _selected_triage_item(self):
         """Return the selected triage row, defaulting to the first visible item."""
-        visible = self._visible_triage_items()
+        visible = self._visible_triage_sequence()
         selected = next(
             (item for item in visible if item.annotation_id == self.triage_selected_annotation_id),
             visible[0] if visible else None,
@@ -524,9 +524,10 @@ class SkimApp(App):
         previous = self.triage_selected_annotation_id if preserve_selection else None
         self.triage_items = self.review_store.triage_items()
         visible = self._visible_triage_items()
+        sequence = self._visible_triage_sequence(visible)
         selected = next(
-            (item for item in visible if item.annotation_id == previous),
-            visible[0] if visible else None,
+            (item for item in sequence if item.annotation_id == previous),
+            sequence[0] if sequence else None,
         )
         self.triage_selected_annotation_id = (
             selected.annotation_id if selected is not None else None
@@ -545,6 +546,14 @@ class SkimApp(App):
         for item in items:
             grouped.setdefault(item.file_path, []).append(item)
         return list(grouped.items())
+
+    def _visible_triage_sequence(self, items=None):
+        """Return visible triage rows in the same order the grouped queue renders them."""
+        visible = self._visible_triage_items() if items is None else items
+        sequence = []
+        for _, group_items in self._group_triage_items(visible):
+            sequence.extend(group_items)
+        return sequence
 
     def _triage_queue_text(self, items) -> str:
         """Return the rendered triage queue text."""
@@ -598,7 +607,7 @@ class SkimApp(App):
 
     def _move_triage_selection(self, delta: int) -> None:
         """Move the triage selection up or down."""
-        visible = self._visible_triage_items()
+        visible = self._visible_triage_sequence()
         if not visible:
             self.triage_selected_annotation_id = None
             self._refresh_triage_view()
@@ -672,31 +681,58 @@ class SkimApp(App):
         if result is None:
             return
         source_path = self.browse_path / file_path
+        selected_annotation_id: str | None = None
         if result.action == "delete":
             if result.annotation_id is None:
                 return
             self.review_store.delete_annotation(source_path, target_path, result.annotation_id)
         elif result.action == "save":
             if result.annotation_id is None:
-                self.review_store.add_annotation(
+                saved = self.review_store.add_annotation(
                     source_path,
                     target_path,
                     tags=result.tags,
                     note=result.note,
                 )
+                selected_annotation_id = saved.id
             else:
-                self.review_store.update_annotation(
+                updated = self.review_store.update_annotation(
                     source_path,
                     target_path,
                     result.annotation_id,
                     tags=result.tags,
                     note=result.note,
                 )
+                selected_annotation_id = updated.id if updated is not None else result.annotation_id
         self.triage_last_annotation_version = self.review_store.annotation_version
         self._refresh_triage_view()
-        active_path = self.pane_files.get(self.active_pane_id)
-        if active_path is not None and active_path.resolve() == source_path.resolve():
-            self.query_one(f"#{self.active_pane_id}", PreviewPane).show_file(source_path)
+        try:
+            pane = self.query_one(f"#{self.active_pane_id}", PreviewPane)
+        except Exception:
+            pane = None
+        active_path = (
+            pane.current_path
+            if pane is not None
+            else self.pane_files.get(self.active_pane_id)
+        )
+        if (
+            pane is not None
+            and active_path is not None
+            and active_path.resolve() == source_path.resolve()
+        ):
+            self.pane_files[self.active_pane_id] = source_path
+            if target_path == FILE_ANNOTATION_KEY:
+                updated_annotations = self.review_store.annotations_for_path(
+                    source_path,
+                    FILE_ANNOTATION_KEY,
+                )
+                if result.action == "delete":
+                    selected_annotation_id = (
+                        updated_annotations[0].id if updated_annotations else None
+                    )
+                pane.set_selected_file_annotation_id(selected_annotation_id)
+                pane.file_annotation_mode = bool(updated_annotations)
+            pane.show_file(source_path)
 
     def _edit_selected_triage_item(self) -> None:
         """Edit the currently selected triage item."""
@@ -704,7 +740,17 @@ class SkimApp(App):
         if item is None:
             return
         target = item.target_path or FILE_ANNOTATION_KEY
-        annotation = self.review_store.get_annotation(self.browse_path / item.file_path, target)
+        annotation = next(
+            (
+                record
+                for record in self.review_store.annotations_for_path(
+                    self.browse_path / item.file_path,
+                    target,
+                )
+                if record.id == item.annotation_id
+            ),
+            None,
+        )
         self._open_review_annotation_editor(
             file_path=item.file_path,
             target_path=target,
@@ -727,16 +773,88 @@ class SkimApp(App):
 
     def _open_file_annotation_editor_for_active_pane(self) -> bool:
         """Open a file-level annotation editor for the active non-JSON preview."""
+        return self._open_file_annotation_editor_for_active_pane_selection(add_new=False)
+
+    def _active_file_annotation_pane(self) -> PreviewPane | None:
+        """Return the active non-JSON preview pane when file annotations are available."""
         try:
             pane = self.query_one(f"#{self.active_pane_id}", PreviewPane)
         except Exception:
-            return False
+            return None
         if pane.current_path is None:
-            return False
+            return None
         viewer = pane.active_json_navigator()
         if viewer is not None:
+            return None
+        return pane
+
+    def _active_file_annotations(
+        self, pane: PreviewPane | None = None
+    ) -> tuple[AnnotationRecord, ...]:
+        """Return file-level annotations for the active non-JSON pane."""
+        active_pane = pane or self._active_file_annotation_pane()
+        if active_pane is None or active_pane.current_path is None:
+            return ()
+        return self.review_store.annotations_for_path(active_pane.current_path, FILE_ANNOTATION_KEY)
+
+    def _selected_file_annotation(
+        self, pane: PreviewPane | None = None
+    ) -> AnnotationRecord | None:
+        """Return the selected file-level annotation for the active non-JSON pane."""
+        active_pane = pane or self._active_file_annotation_pane()
+        annotations = self._active_file_annotations(active_pane)
+        if active_pane is None or not annotations:
+            return None
+        selected_id = active_pane.selected_file_annotation_id(annotations)
+        return next(
+            (annotation for annotation in annotations if annotation.id == selected_id),
+            annotations[0],
+        )
+
+    def _set_file_annotation_mode(self, enabled: bool) -> bool:
+        """Enter or leave file-annotation selection mode for the active pane."""
+        pane = self._active_file_annotation_pane()
+        if pane is None or pane.current_path is None:
             return False
-        annotation = self.review_store.get_annotation(pane.current_path, FILE_ANNOTATION_KEY)
+        annotations = self._active_file_annotations(pane)
+        if enabled and not annotations:
+            return False
+        pane.file_annotation_mode = enabled
+        pane.show_file(pane.current_path)
+        return True
+
+    def _move_file_annotation_selection(self, delta: int) -> bool:
+        """Move the selected file-level annotation within the active pane."""
+        pane = self._active_file_annotation_pane()
+        if pane is None or pane.current_path is None or not pane.file_annotation_mode:
+            return False
+        annotations = self._active_file_annotations(pane)
+        if not annotations:
+            pane.file_annotation_mode = False
+            pane.show_file(pane.current_path)
+            return False
+        selected_id = pane.selected_file_annotation_id(annotations)
+        current = next(
+            (
+                index
+                for index, annotation in enumerate(annotations)
+                if annotation.id == selected_id
+            ),
+            0,
+        )
+        next_index = max(0, min(len(annotations) - 1, current + delta))
+        pane.set_selected_file_annotation_id(annotations[next_index].id)
+        pane.show_file(pane.current_path)
+        return True
+
+    def _open_file_annotation_editor_for_active_pane_selection(
+        self, *, add_new: bool
+    ) -> bool:
+        """Open the file-level annotation editor for the active non-JSON preview."""
+        pane = self._active_file_annotation_pane()
+        if pane is None or pane.current_path is None:
+            return False
+        annotation = None if add_new else self._selected_file_annotation(pane)
         self._open_review_annotation_editor(
             file_path=self.review_store.relative_file_path(pane.current_path),
             target_path=FILE_ANNOTATION_KEY,
@@ -875,6 +993,8 @@ class SkimApp(App):
             if not isinstance(self.focused, Input):
                 self._move_triage_selection(1)
             return
+        if self._move_file_annotation_selection(1):
+            return
         if self.split_mode:
             self.split_mode = False
             self._split("down")
@@ -895,6 +1015,8 @@ class SkimApp(App):
         if self.app_mode == "triage":
             if not isinstance(self.focused, Input):
                 self._move_triage_selection(-1)
+            return
+        if self._move_file_annotation_selection(-1):
             return
         if self.split_mode:
             self.split_mode = False
@@ -1097,7 +1219,26 @@ class SkimApp(App):
             active_pane = self.query_one(f"#{self.active_pane_id}", PreviewPane)
             viewer = active_pane.active_json_navigator()
         except Exception:
+            active_pane = None
             viewer = None
+
+        if active_pane is not None and viewer is None:
+            file_annotations = self._active_file_annotations(active_pane)
+            if event.key == "escape" and active_pane.file_annotation_mode:
+                if self._set_file_annotation_mode(False):
+                    event.prevent_default()
+                    event.stop()
+                    return
+            if event.key == "enter":
+                if active_pane.file_annotation_mode:
+                    if self._open_file_annotation_editor_for_active_pane():
+                        event.prevent_default()
+                        event.stop()
+                        return
+                elif file_annotations and self._set_file_annotation_mode(True):
+                    event.prevent_default()
+                    event.stop()
+                    return
 
         if viewer is not None and event.key in {"left", "right"}:
             if viewer.handle_horizontal_key(event.key):
@@ -1122,7 +1263,9 @@ class SkimApp(App):
                 event.prevent_default()
                 event.stop()
                 return
-        if event.key == "a" and self._open_file_annotation_editor_for_active_pane():
+        if event.key == "a" and self._open_file_annotation_editor_for_active_pane_selection(
+            add_new=True
+        ):
             event.prevent_default()
             event.stop()
             return

--- a/src/skim/app.py
+++ b/src/skim/app.py
@@ -8,6 +8,7 @@ trajectory rendering internals, which live in dedicated modules.
 from __future__ import annotations
 
 import subprocess
+from collections import OrderedDict
 from pathlib import Path
 
 from textual.app import App, ComposeResult
@@ -15,7 +16,7 @@ from textual.binding import Binding
 from textual.containers import Horizontal, Vertical
 from textual.events import Key
 from textual.screen import ModalScreen
-from textual.widgets import Button, Header, Input, Static, TextArea
+from textual.widgets import Button, Input, Static, TextArea
 
 from .preview import PreviewPane
 from .review import FILE_ANNOTATION_KEY, AnnotationRecord, AnnotationStore
@@ -160,6 +161,13 @@ class SkimApp(App):
 
     TITLE = "skim"
     CSS = """
+    #app-titlebar {
+        dock: top;
+        height: 1;
+        background: $surface;
+        color: $text;
+        padding: 0 1;
+    }
     #outer {
         height: 1fr;
     }
@@ -338,6 +346,8 @@ class SkimApp(App):
         Binding("s", "enter_split", show=False),
         Binding("d", "close_pane", show=False),
         Binding("w", "cycle_pane", show=False),
+        Binding("t", "show_triage", show=False),
+        Binding("b", "show_browse", show=False),
     ]
 
     def __init__(self, path: str | Path = ".", *, triage: bool = False):
@@ -376,7 +386,7 @@ class SkimApp(App):
 
     def compose(self) -> ComposeResult:
         """Compose the directory tree and preview area."""
-        yield Header()
+        yield Static("", id="app-titlebar")
         with Horizontal(id="outer"):
             with Horizontal(id="browser-shell"):
                 yield DirectoryTree(str(self.browse_path))
@@ -447,10 +457,18 @@ class SkimApp(App):
             browser.add_class("hidden-view")
             triage.remove_class("hidden-view")
             self.file_tree_mode = False
+            self.query_one("#triage-queue", TriageQueue).focus(scroll_visible=False)
         else:
             triage.add_class("hidden-view")
             browser.remove_class("hidden-view")
+            self.exit_file_tree_mode()
+        self._update_titlebar()
         self._update_status_bar()
+
+    def _update_titlebar(self) -> None:
+        """Refresh the skim-owned title bar."""
+        mode_label = "Triage" if self.app_mode == "triage" else "Browse"
+        self.query_one("#app-titlebar", Static).update(f"skim [{mode_label}]")
 
     def _triage_filters(self) -> tuple[str, str, str]:
         """Return the active triage filter values."""
@@ -520,18 +538,33 @@ class SkimApp(App):
         detail = self.query_one("#triage-detail", TriageDetail)
         detail.update(self._triage_detail_text(selected))
 
+    def _group_triage_items(self, items):
+        """Group visible triage items by file while preserving newest-first file order."""
+        grouped: OrderedDict[str, list] = OrderedDict()
+        for item in items:
+            grouped.setdefault(item.file_path, []).append(item)
+        return list(grouped.items())
+
     def _triage_queue_text(self, items) -> str:
         """Return the rendered triage queue text."""
         if not items:
             return "No annotations match the current filters."
         lines: list[str] = []
-        for item in items:
-            marker = ">" if item.annotation_id == self.triage_selected_annotation_id else " "
-            tags = f" [{' '.join(item.tags)}]" if item.tags else ""
+        grouped_items = self._group_triage_items(items)
+        for index, (file_path, group_items) in enumerate(grouped_items):
+            latest = group_items[0]
+            annotation_count = len(group_items)
+            updated = latest.updated_at[:16].replace("T", " ")
             lines.append(
-                f"{marker} {item.preview_kind:<8} {item.file_path} :: {item.target_label}{tags}"
+                f"{file_path} [{latest.preview_kind}] {annotation_count} annotation"
+                f"{'s' if annotation_count != 1 else ''} · {updated}"
             )
-            lines.append(f"  {item.note_preview or '(empty)'}")
+            for item in group_items:
+                marker = ">" if item.annotation_id == self.triage_selected_annotation_id else " "
+                note_preview = item.note_preview or "(empty)"
+                lines.append(f"{marker} {item.target_label or 'File'} :: {note_preview}")
+            if index != len(grouped_items) - 1:
+                lines.append("")
         return "\n".join(lines)
 
     def _triage_detail_text(self, item) -> str:
@@ -739,6 +772,7 @@ class SkimApp(App):
         if self.app_mode == "triage":
             return (
                 " [bold]q[/] Quit  "
+                "[bold]b[/] Browse  "
                 "[bold]↑↓[/] Select  "
                 "[bold]/[/] Search  "
                 "[bold]Tab[/] Focus  "
@@ -750,6 +784,7 @@ class SkimApp(App):
         if self.file_tree_mode:
             return (
                 " [bold]q[/] Quit  "
+                "[bold]t[/] Triage  "
                 "[bold]↑↓[/] Move  "
                 "[bold]←→[/] Branch  "
                 "[bold]Esc[/] Back  "
@@ -759,6 +794,7 @@ class SkimApp(App):
             )
         return (
             " [bold]q[/] Quit  "
+            "[bold]t[/] Triage  "
             "[bold]↑↓[/] Scroll  "
             "[bold]PgUp/Dn[/] Page  "
             "[bold]f[/] Tree  "
@@ -804,6 +840,19 @@ class SkimApp(App):
         self.file_tree_mode = True
         self.query_one(DirectoryTree).focus(scroll_visible=False)
         self._update_status_bar()
+
+    def action_show_triage(self) -> None:
+        """Switch into the triage shell without losing browse pane state."""
+        if self._modal_is_active():
+            return
+        self._refresh_triage_view()
+        self._show_mode("triage")
+
+    def action_show_browse(self) -> None:
+        """Switch back into the browse shell."""
+        if self._modal_is_active():
+            return
+        self._show_mode("browse")
 
     def exit_file_tree_mode(self) -> None:
         """Leave file-tree focus mode and return to the active preview pane."""

--- a/src/skim/app.py
+++ b/src/skim/app.py
@@ -492,11 +492,7 @@ class SkimApp(App):
         """Return the selected triage row, defaulting to the first visible item."""
         visible = self._visible_triage_items()
         selected = next(
-            (
-                item
-                for item in visible
-                if item.annotation_id == self.triage_selected_annotation_id
-            ),
+            (item for item in visible if item.annotation_id == self.triage_selected_annotation_id),
             visible[0] if visible else None,
         )
         self.triage_selected_annotation_id = (
@@ -596,10 +592,12 @@ class SkimApp(App):
         self.pane_files[self.active_pane_id] = path
         if item.target_kind == "json_path":
             target_path = item.target_path or ""
+
             def select_target() -> None:
                 viewer = pane.active_json_navigator()
                 if isinstance(viewer, JsonInspector):
                     viewer.select_annotation_path(target_path)
+
             pane.call_after_refresh(select_target)
         self._show_mode("browse")
         self.exit_file_tree_mode()

--- a/src/skim/app.py
+++ b/src/skim/app.py
@@ -711,9 +711,7 @@ class SkimApp(App):
         except Exception:
             pane = None
         active_path = (
-            pane.current_path
-            if pane is not None
-            else self.pane_files.get(self.active_pane_id)
+            pane.current_path if pane is not None else self.pane_files.get(self.active_pane_id)
         )
         if (
             pane is not None
@@ -797,9 +795,7 @@ class SkimApp(App):
             return ()
         return self.review_store.annotations_for_path(active_pane.current_path, FILE_ANNOTATION_KEY)
 
-    def _selected_file_annotation(
-        self, pane: PreviewPane | None = None
-    ) -> AnnotationRecord | None:
+    def _selected_file_annotation(self, pane: PreviewPane | None = None) -> AnnotationRecord | None:
         """Return the selected file-level annotation for the active non-JSON pane."""
         active_pane = pane or self._active_file_annotation_pane()
         annotations = self._active_file_annotations(active_pane)
@@ -835,11 +831,7 @@ class SkimApp(App):
             return False
         selected_id = pane.selected_file_annotation_id(annotations)
         current = next(
-            (
-                index
-                for index, annotation in enumerate(annotations)
-                if annotation.id == selected_id
-            ),
+            (index for index, annotation in enumerate(annotations) if annotation.id == selected_id),
             0,
         )
         next_index = max(0, min(len(annotations) - 1, current + delta))
@@ -847,9 +839,7 @@ class SkimApp(App):
         pane.show_file(pane.current_path)
         return True
 
-    def _open_file_annotation_editor_for_active_pane_selection(
-        self, *, add_new: bool
-    ) -> bool:
+    def _open_file_annotation_editor_for_active_pane_selection(self, *, add_new: bool) -> bool:
         """Open the file-level annotation editor for the active non-JSON preview."""
         pane = self._active_file_annotation_pane()
         if pane is None or pane.current_path is None:

--- a/src/skim/app.py
+++ b/src/skim/app.py
@@ -8,7 +8,6 @@ trajectory rendering internals, which live in dedicated modules.
 from __future__ import annotations
 
 import subprocess
-import sys
 from pathlib import Path
 
 from textual.app import App, ComposeResult
@@ -16,16 +15,144 @@ from textual.binding import Binding
 from textual.containers import Horizontal, Vertical
 from textual.events import Key
 from textual.screen import ModalScreen
-from textual.widgets import Header, Static
+from textual.widgets import Button, Header, Input, Static, TextArea
 
 from .preview import PreviewPane
+from .review import FILE_ANNOTATION_KEY, AnnotationRecord, AnnotationStore
 from .scrolling import DirectoryTree
-from .trajectory import JsonInspector, TrajectoryViewer
+from .trajectory import AnnotationEditorResult, JsonInspector, TrajectoryViewer
 
 MAX_ROWS = 2
 MAX_COLS = 3
 SCROLL_STEP = 3
 PAGE_SCROLL_STEP = 20
+
+
+class TriageQueue(Static):
+    """Focusable triage queue surface."""
+
+    can_focus = True
+
+
+class TriageDetail(Static):
+    """Focusable triage detail surface."""
+
+    can_focus = True
+
+
+class ReviewAnnotationEditor(ModalScreen[AnnotationEditorResult | None]):
+    """Generic file/triage annotation editor modal."""
+
+    BINDINGS = [Binding("escape", "cancel", show=False)]
+
+    def __init__(
+        self,
+        *,
+        heading: str,
+        file_path: str,
+        target_path: str,
+        preview_text: str,
+        annotation: AnnotationRecord | None,
+        on_submit=None,
+    ) -> None:
+        """Initialize the modal for one annotation target."""
+        super().__init__()
+        self.heading = heading
+        self.file_path = file_path
+        self.target_path = target_path
+        self.preview_text = preview_text
+        self.annotation = annotation
+        self._on_submit = on_submit
+
+    def compose(self) -> ComposeResult:
+        """Compose the shared annotation modal."""
+        tags = ", ".join(self.annotation.tags) if self.annotation is not None else ""
+        note = self.annotation.note if self.annotation is not None else ""
+        yield Vertical(
+            Horizontal(
+                Vertical(
+                    Static(self.heading, classes="annotation-modal-title"),
+                    Static(f"File: {self.file_path}", classes="annotation-modal-path"),
+                    Static(f"Target: {self.target_path}", classes="annotation-modal-path"),
+                    Input(value=tags, placeholder="tags, comma, separated", id="annotation-tags"),
+                    TextArea(note, id="annotation-note"),
+                    Horizontal(
+                        Button("Save", id="annotation-save", variant="primary"),
+                        Button(
+                            "Delete",
+                            id="annotation-delete",
+                            variant="error",
+                            disabled=self.annotation is None,
+                        ),
+                        Button("Cancel", id="annotation-cancel"),
+                        classes="annotation-modal-actions",
+                    ),
+                    id="annotation-editor-panel",
+                    classes="annotation-modal-panel",
+                ),
+                Vertical(
+                    Static("Target Preview", classes="annotation-modal-preview-title"),
+                    Static(
+                        self.preview_text,
+                        id="annotation-preview",
+                        classes="annotation-modal-preview",
+                    ),
+                    id="annotation-preview-panel",
+                    classes="annotation-modal-panel",
+                ),
+                classes="annotation-modal-body",
+            ),
+            id="annotation-modal",
+        )
+
+    def on_mount(self) -> None:
+        """Focus the tags field when the modal opens."""
+        self.query_one("#annotation-tags", Input).focus()
+
+    def action_cancel(self) -> None:
+        """Dismiss the modal without changes."""
+        self.dismiss(None)
+
+    def action_save(self) -> None:
+        """Dismiss with a save payload."""
+        self._submit(
+            AnnotationEditorResult(
+                action="save",
+                annotation_id=self.annotation.id if self.annotation is not None else None,
+                tags=_parse_annotation_tags(self.query_one("#annotation-tags", Input).value),
+                note=self.query_one("#annotation-note", TextArea).text.rstrip(),
+            )
+        )
+
+    def action_delete(self) -> None:
+        """Dismiss with a delete payload."""
+        self._submit(
+            AnnotationEditorResult(
+                action="delete",
+                annotation_id=self.annotation.id if self.annotation is not None else None,
+            )
+        )
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        """Handle modal button clicks."""
+        if event.button.id == "annotation-save":
+            self.action_save()
+        elif event.button.id == "annotation-delete":
+            self.action_delete()
+        else:
+            self.action_cancel()
+        event.stop()
+
+    def _submit(self, result: AnnotationEditorResult) -> None:
+        """Invoke the save/delete callback before dismissing the modal."""
+        if self._on_submit is not None:
+            self._on_submit(result)
+        self.dismiss(result)
+
+
+def _parse_annotation_tags(raw_tags: str) -> tuple[str, ...]:
+    """Parse the comma-separated tag field used by the modal editor."""
+    return tuple(tag.strip() for tag in raw_tags.split(",") if tag.strip())
 
 
 class SkimApp(App):
@@ -35,6 +162,13 @@ class SkimApp(App):
     CSS = """
     #outer {
         height: 1fr;
+    }
+    #browser-shell, #triage-shell {
+        width: 1fr;
+        height: 1fr;
+    }
+    .hidden-view {
+        display: none;
     }
     DirectoryTree {
         width: 1fr;
@@ -160,6 +294,36 @@ class SkimApp(App):
         color: $text;
         padding: 0 1;
     }
+    #triage-shell {
+        padding: 0 1;
+    }
+    #triage-filters {
+        width: 28;
+        padding: 0 1;
+        border-right: solid $primary-background;
+    }
+    #triage-queue {
+        width: 2fr;
+        padding: 0 1;
+        border-right: solid $primary-background;
+    }
+    #triage-detail {
+        width: 2fr;
+        padding: 0 1;
+    }
+    .triage-panel {
+        height: 1fr;
+    }
+    .triage-label {
+        margin: 1 0 0 0;
+    }
+    .triage-filter-input {
+        margin: 0 0 1 0;
+    }
+    #triage-summary {
+        margin: 1 0 0 0;
+        color: $text-muted;
+    }
     """
 
     BINDINGS = [
@@ -176,16 +340,21 @@ class SkimApp(App):
         Binding("w", "cycle_pane", show=False),
     ]
 
-    def __init__(self, path: str | Path = "."):
+    def __init__(self, path: str | Path = ".", *, triage: bool = False):
         """Initialize the app for a directory path."""
         super().__init__()
         self.browse_path = Path(path).expanduser().resolve()
+        self.review_store = AnnotationStore(self.browse_path)
         self.pane_counter = 0
         self.active_pane_id: str = ""
         self.grid: list[list[str]] = []
         self.pane_files: dict[str, Path | None] = {}
         self.split_mode = False
         self.file_tree_mode = False
+        self.app_mode = "triage" if triage else "browse"
+        self.triage_items = []
+        self.triage_selected_annotation_id: str | None = None
+        self.triage_last_annotation_version = self.review_store.annotation_version
 
     def _new_pane_id(self) -> str:
         """Return the next stable preview-pane identifier."""
@@ -209,8 +378,32 @@ class SkimApp(App):
         """Compose the directory tree and preview area."""
         yield Header()
         with Horizontal(id="outer"):
-            yield DirectoryTree(str(self.browse_path))
-            yield Vertical(id="preview-area")
+            with Horizontal(id="browser-shell"):
+                yield DirectoryTree(str(self.browse_path))
+                yield Vertical(id="preview-area")
+            with Horizontal(id="triage-shell"):
+                with Vertical(id="triage-filters", classes="triage-panel"):
+                    yield Static("Search", classes="triage-label")
+                    yield Input(
+                        placeholder="file, tag, note",
+                        id="triage-search",
+                        classes="triage-filter-input",
+                    )
+                    yield Static("Tag", classes="triage-label")
+                    yield Input(
+                        placeholder="exact tag",
+                        id="triage-tag-filter",
+                        classes="triage-filter-input",
+                    )
+                    yield Static("File Type", classes="triage-label")
+                    yield Input(
+                        placeholder="markdown, json, csv",
+                        id="triage-kind-filter",
+                        classes="triage-filter-input",
+                    )
+                    yield Static("", id="triage-summary")
+                yield TriageQueue("", id="triage-queue", classes="triage-panel")
+                yield TriageDetail("", id="triage-detail", classes="triage-panel")
         yield Static("", id="status-bar")
 
     def on_mount(self) -> None:
@@ -220,7 +413,13 @@ class SkimApp(App):
         self.pane_files[pane_id] = None
         self.active_pane_id = pane_id
         self._rebuild_layout()
-        self.exit_file_tree_mode()
+        self._refresh_triage_view(preserve_selection=False)
+        self._show_mode(self.app_mode)
+        self.set_interval(2, self._poll_annotation_updates, pause=False)
+        if self.app_mode == "browse":
+            self.exit_file_tree_mode()
+        else:
+            self.query_one("#triage-queue", TriageQueue).focus()
 
     def _rebuild_layout(self) -> None:
         """Rebuild the preview pane grid from current state."""
@@ -239,6 +438,290 @@ class SkimApp(App):
                     pane.show_placeholder()
         self._update_active_indicator()
 
+    def _show_mode(self, mode: str) -> None:
+        """Show either the browse shell or the triage shell."""
+        self.app_mode = mode
+        browser = self.query_one("#browser-shell", Horizontal)
+        triage = self.query_one("#triage-shell", Horizontal)
+        if mode == "triage":
+            browser.add_class("hidden-view")
+            triage.remove_class("hidden-view")
+            self.file_tree_mode = False
+        else:
+            triage.add_class("hidden-view")
+            browser.remove_class("hidden-view")
+        self._update_status_bar()
+
+    def _triage_filters(self) -> tuple[str, str, str]:
+        """Return the active triage filter values."""
+        return (
+            self.query_one("#triage-search", Input).value.strip().lower(),
+            self.query_one("#triage-tag-filter", Input).value.strip(),
+            self.query_one("#triage-kind-filter", Input).value.strip().lower(),
+        )
+
+    def _visible_triage_items(self):
+        """Return triage items filtered by the current TUI controls."""
+        search, tag, kind = self._triage_filters()
+        items = []
+        for item in self.review_store.triage_items():
+            if tag and tag not in item.tags:
+                continue
+            if kind and item.preview_kind.lower() != kind:
+                continue
+            if search:
+                haystack = " ".join(
+                    filter(
+                        None,
+                        [
+                            item.file_path,
+                            item.target_label,
+                            item.target_path or "",
+                            item.note_preview,
+                            item.note_full,
+                            *item.tags,
+                        ],
+                    )
+                ).lower()
+                if search not in haystack:
+                    continue
+            items.append(item)
+        return items
+
+    def _selected_triage_item(self):
+        """Return the selected triage row, defaulting to the first visible item."""
+        visible = self._visible_triage_items()
+        selected = next(
+            (
+                item
+                for item in visible
+                if item.annotation_id == self.triage_selected_annotation_id
+            ),
+            visible[0] if visible else None,
+        )
+        self.triage_selected_annotation_id = (
+            selected.annotation_id if selected is not None else None
+        )
+        return selected
+
+    def _refresh_triage_view(self, *, preserve_selection: bool = True) -> None:
+        """Refresh triage state and repaint the triage panels."""
+        previous = self.triage_selected_annotation_id if preserve_selection else None
+        self.triage_items = self.review_store.triage_items()
+        visible = self._visible_triage_items()
+        selected = next(
+            (item for item in visible if item.annotation_id == previous),
+            visible[0] if visible else None,
+        )
+        self.triage_selected_annotation_id = (
+            selected.annotation_id if selected is not None else None
+        )
+        self.triage_last_annotation_version = self.review_store.annotation_version
+        summary = self.query_one("#triage-summary", Static)
+        summary.update(f"{len(visible)} item{'s' if len(visible) != 1 else ''}")
+        queue = self.query_one("#triage-queue", TriageQueue)
+        queue.update(self._triage_queue_text(visible))
+        detail = self.query_one("#triage-detail", TriageDetail)
+        detail.update(self._triage_detail_text(selected))
+
+    def _triage_queue_text(self, items) -> str:
+        """Return the rendered triage queue text."""
+        if not items:
+            return "No annotations match the current filters."
+        lines: list[str] = []
+        for item in items:
+            marker = ">" if item.annotation_id == self.triage_selected_annotation_id else " "
+            tags = f" [{' '.join(item.tags)}]" if item.tags else ""
+            lines.append(
+                f"{marker} {item.preview_kind:<8} {item.file_path} :: {item.target_label}{tags}"
+            )
+            lines.append(f"  {item.note_preview or '(empty)'}")
+        return "\n".join(lines)
+
+    def _triage_detail_text(self, item) -> str:
+        """Return the rendered triage detail text."""
+        if item is None:
+            return "No annotation selected."
+        tags = ", ".join(item.tags) if item.tags else "(none)"
+        return (
+            f"File: {item.file_path}\n"
+            f"Target: {item.target_label}\n"
+            f"Kind: {item.preview_kind}\n"
+            f"Tags: {tags}\n"
+            f"Created: {item.created_at}\n"
+            f"Updated: {item.updated_at}\n\n"
+            f"{item.note_full or '(empty)'}"
+        )
+
+    def _cycle_triage_focus(self) -> None:
+        """Cycle focus among the triage controls."""
+        widgets = [
+            self.query_one("#triage-search", Input),
+            self.query_one("#triage-tag-filter", Input),
+            self.query_one("#triage-kind-filter", Input),
+            self.query_one("#triage-queue", TriageQueue),
+            self.query_one("#triage-detail", TriageDetail),
+        ]
+        focused = self.focused if self.focused in widgets else widgets[0]
+        index = widgets.index(focused) if focused in widgets else 0
+        widgets[(index + 1) % len(widgets)].focus(scroll_visible=False)
+
+    def _move_triage_selection(self, delta: int) -> None:
+        """Move the triage selection up or down."""
+        visible = self._visible_triage_items()
+        if not visible:
+            self.triage_selected_annotation_id = None
+            self._refresh_triage_view()
+            return
+        current = next(
+            (
+                index
+                for index, item in enumerate(visible)
+                if item.annotation_id == self.triage_selected_annotation_id
+            ),
+            0,
+        )
+        next_index = max(0, min(len(visible) - 1, current + delta))
+        self.triage_selected_annotation_id = visible[next_index].annotation_id
+        self._refresh_triage_view()
+
+    def _open_triage_item(self) -> None:
+        """Open the selected triage item into browse mode."""
+        item = self._selected_triage_item()
+        if item is None:
+            return
+        path = self.browse_path / item.file_path
+        pane = self.query_one(f"#{self.active_pane_id}", PreviewPane)
+        pane.show_file(path)
+        self.pane_files[self.active_pane_id] = path
+        if item.target_kind == "json_path":
+            target_path = item.target_path or ""
+            def select_target() -> None:
+                viewer = pane.active_json_navigator()
+                if isinstance(viewer, JsonInspector):
+                    viewer.select_annotation_path(target_path)
+            pane.call_after_refresh(select_target)
+        self._show_mode("browse")
+        self.exit_file_tree_mode()
+
+    def _open_review_annotation_editor(
+        self,
+        *,
+        file_path: str,
+        target_path: str,
+        annotation: AnnotationRecord | None,
+        heading: str,
+    ) -> None:
+        """Open the generic annotation editor modal."""
+        preview = f"File: {file_path}\nTarget: {target_path}"
+        self.push_screen(
+            ReviewAnnotationEditor(
+                heading=heading,
+                file_path=file_path,
+                target_path=target_path,
+                preview_text=preview,
+                annotation=annotation,
+                on_submit=lambda result: self._handle_review_annotation_result(
+                    file_path=file_path,
+                    target_path=target_path,
+                    result=result,
+                ),
+            )
+        )
+
+    def _handle_review_annotation_result(
+        self,
+        *,
+        file_path: str,
+        target_path: str,
+        result: AnnotationEditorResult | None,
+    ) -> None:
+        """Persist one generic annotation modal result."""
+        if result is None:
+            return
+        source_path = self.browse_path / file_path
+        if result.action == "delete":
+            if result.annotation_id is None:
+                return
+            self.review_store.delete_annotation(source_path, target_path, result.annotation_id)
+        elif result.action == "save":
+            if result.annotation_id is None:
+                self.review_store.add_annotation(
+                    source_path,
+                    target_path,
+                    tags=result.tags,
+                    note=result.note,
+                )
+            else:
+                self.review_store.update_annotation(
+                    source_path,
+                    target_path,
+                    result.annotation_id,
+                    tags=result.tags,
+                    note=result.note,
+                )
+        self.triage_last_annotation_version = self.review_store.annotation_version
+        self._refresh_triage_view()
+        active_path = self.pane_files.get(self.active_pane_id)
+        if active_path is not None and active_path.resolve() == source_path.resolve():
+            self.query_one(f"#{self.active_pane_id}", PreviewPane).show_file(source_path)
+
+    def _edit_selected_triage_item(self) -> None:
+        """Edit the currently selected triage item."""
+        item = self._selected_triage_item()
+        if item is None:
+            return
+        target = item.target_path or FILE_ANNOTATION_KEY
+        annotation = self.review_store.get_annotation(self.browse_path / item.file_path, target)
+        self._open_review_annotation_editor(
+            file_path=item.file_path,
+            target_path=target,
+            annotation=annotation,
+            heading="Edit Annotation",
+        )
+
+    def _delete_selected_triage_item(self) -> None:
+        """Delete the currently selected triage item."""
+        item = self._selected_triage_item()
+        if item is None:
+            return
+        self.review_store.delete_annotation(
+            self.browse_path / item.file_path,
+            item.target_path or FILE_ANNOTATION_KEY,
+            item.annotation_id,
+        )
+        self.triage_last_annotation_version = self.review_store.annotation_version
+        self._refresh_triage_view()
+
+    def _open_file_annotation_editor_for_active_pane(self) -> bool:
+        """Open a file-level annotation editor for the active non-JSON preview."""
+        try:
+            pane = self.query_one(f"#{self.active_pane_id}", PreviewPane)
+        except Exception:
+            return False
+        if pane.current_path is None:
+            return False
+        viewer = pane.active_json_navigator()
+        if viewer is not None:
+            return False
+        annotation = self.review_store.get_annotation(pane.current_path, FILE_ANNOTATION_KEY)
+        self._open_review_annotation_editor(
+            file_path=self.review_store.relative_file_path(pane.current_path),
+            target_path=FILE_ANNOTATION_KEY,
+            annotation=annotation,
+            heading="File Annotation",
+        )
+        return True
+
+    def _poll_annotation_updates(self) -> None:
+        """Refresh triage when the annotation version changes."""
+        version = self.review_store.annotation_version
+        if version == self.triage_last_annotation_version:
+            return
+        self.triage_last_annotation_version = version
+        if self.app_mode == "triage":
+            self._refresh_triage_view()
+
     def set_active_pane(self, pane_id: str) -> None:
         """Set the active preview pane by id."""
         self.active_pane_id = pane_id
@@ -255,6 +738,17 @@ class SkimApp(App):
 
     def _status_text(self) -> str:
         """Return status-bar text for the current app mode."""
+        if self.app_mode == "triage":
+            return (
+                " [bold]q[/] Quit  "
+                "[bold]↑↓[/] Select  "
+                "[bold]/[/] Search  "
+                "[bold]Tab[/] Focus  "
+                "[bold]Enter[/] Open  "
+                "[bold]e[/] Edit  "
+                "[bold]x[/] Delete  "
+                "[bold]r[/] Refresh"
+            )
         if self.file_tree_mode:
             return (
                 " [bold]q[/] Quit  "
@@ -283,6 +777,11 @@ class SkimApp(App):
         """Return whether a modal screen currently owns keyboard interaction."""
         return isinstance(self.screen, ModalScreen)
 
+    def on_input_changed(self, event: Input.Changed) -> None:
+        """Refresh triage when one of its filter inputs changes."""
+        if event.input.id in {"triage-search", "triage-tag-filter", "triage-kind-filter"}:
+            self._refresh_triage_view()
+
     def check_action(self, action: str, parameters: tuple[object, ...]) -> bool | None:
         """Disable app-level arrow scrolling while a modal owns focus."""
         if self._modal_is_active() and action in {"scroll_up", "scroll_down"}:
@@ -299,6 +798,8 @@ class SkimApp(App):
         """Toggle focus between the file tree and the active preview pane."""
         if self._modal_is_active():
             return
+        if self.app_mode == "triage":
+            return
         if self.file_tree_mode:
             self.exit_file_tree_mode()
             return
@@ -308,6 +809,8 @@ class SkimApp(App):
 
     def exit_file_tree_mode(self) -> None:
         """Leave file-tree focus mode and return to the active preview pane."""
+        if self.app_mode == "triage":
+            return
         self.file_tree_mode = False
         self._update_active_indicator()
         try:
@@ -319,6 +822,10 @@ class SkimApp(App):
     def action_scroll_down(self) -> None:
         """Scroll down in the active pane or confirm a downward split."""
         if self._modal_is_active():
+            return
+        if self.app_mode == "triage":
+            if not isinstance(self.focused, Input):
+                self._move_triage_selection(1)
             return
         if self.split_mode:
             self.split_mode = False
@@ -336,6 +843,10 @@ class SkimApp(App):
     def action_scroll_up(self) -> None:
         """Scroll up in the active pane or confirm an upward split."""
         if self._modal_is_active():
+            return
+        if self.app_mode == "triage":
+            if not isinstance(self.focused, Input):
+                self._move_triage_selection(-1)
             return
         if self.split_mode:
             self.split_mode = False
@@ -407,6 +918,8 @@ class SkimApp(App):
             if callable(action):
                 action()
             return
+        if self.app_mode == "triage":
+            return
         try:
             pane = self.query_one(f"#{self.active_pane_id}", PreviewPane)
             viewer = pane.active_json_navigator()
@@ -425,6 +938,8 @@ class SkimApp(App):
             if callable(action):
                 action()
             return
+        if self.app_mode == "triage":
+            return
         try:
             pane = self.query_one(f"#{self.active_pane_id}", PreviewPane)
             viewer = pane.active_json_navigator()
@@ -439,6 +954,54 @@ class SkimApp(App):
         """Handle split-mode keys and tree navigation shortcuts."""
         if self._modal_is_active():
             return
+
+        if self.app_mode == "triage":
+            if event.key == "/":
+                self.query_one("#triage-search", Input).focus(scroll_visible=False)
+                event.prevent_default()
+                event.stop()
+                return
+            if event.key == "tab":
+                self._cycle_triage_focus()
+                event.prevent_default()
+                event.stop()
+                return
+            if event.key == "escape":
+                if isinstance(self.focused, Input):
+                    self.query_one("#triage-queue", TriageQueue).focus(scroll_visible=False)
+                event.prevent_default()
+                event.stop()
+                return
+            if event.key in {"up", "k"} and not isinstance(self.focused, Input):
+                self._move_triage_selection(-1)
+                event.prevent_default()
+                event.stop()
+                return
+            if event.key in {"down", "j"} and not isinstance(self.focused, Input):
+                self._move_triage_selection(1)
+                event.prevent_default()
+                event.stop()
+                return
+            if event.key == "enter":
+                self._open_triage_item()
+                event.prevent_default()
+                event.stop()
+                return
+            if event.key == "e":
+                self._edit_selected_triage_item()
+                event.prevent_default()
+                event.stop()
+                return
+            if event.key == "x":
+                self._delete_selected_triage_item()
+                event.prevent_default()
+                event.stop()
+                return
+            if event.key == "r":
+                self._refresh_triage_view()
+                event.prevent_default()
+                event.stop()
+                return
 
         if self.split_mode:
             direction_map = {
@@ -521,6 +1084,10 @@ class SkimApp(App):
                 event.prevent_default()
                 event.stop()
                 return
+        if event.key == "a" and self._open_file_annotation_editor_for_active_pane():
+            event.prevent_default()
+            event.stop()
+            return
 
         if event.key == "shift+down":
             self.action_tree_down()
@@ -531,6 +1098,8 @@ class SkimApp(App):
             event.prevent_default()
             event.stop()
         elif event.key == "enter":
+            if self.app_mode == "triage":
+                return
             self.action_tree_select()
             event.prevent_default()
             event.stop()
@@ -634,8 +1203,14 @@ class SkimApp(App):
 
 def main() -> None:
     """Run the app from the command line."""
-    path = sys.argv[1] if len(sys.argv) > 1 else "."
-    app = SkimApp(path)
+    import argparse
+
+    parser = argparse.ArgumentParser(description="skim TUI")
+    parser.add_argument("path", nargs="?", default=".")
+    parser.add_argument("--triage", action="store_true")
+    args = parser.parse_args()
+
+    app = SkimApp(args.path, triage=args.triage)
     app.run()
 
 

--- a/src/skim/app.py
+++ b/src/skim/app.py
@@ -451,6 +451,7 @@ class SkimApp(App):
     def _show_mode(self, mode: str) -> None:
         """Show either the browse shell or the triage shell."""
         self.app_mode = mode
+        self.split_mode = False
         browser = self.query_one("#browser-shell", Horizontal)
         triage = self.query_one("#triage-shell", Horizontal)
         if mode == "triage":
@@ -1019,16 +1020,6 @@ class SkimApp(App):
                 event.prevent_default()
                 event.stop()
                 return
-            if event.key in {"up", "k"} and not isinstance(self.focused, Input):
-                self._move_triage_selection(-1)
-                event.prevent_default()
-                event.stop()
-                return
-            if event.key in {"down", "j"} and not isinstance(self.focused, Input):
-                self._move_triage_selection(1)
-                event.prevent_default()
-                event.stop()
-                return
             if event.key == "enter":
                 self._open_triage_item()
                 event.prevent_default()
@@ -1163,6 +1154,8 @@ class SkimApp(App):
     def action_enter_split(self) -> None:
         """Enter split mode for the next direction key."""
         if self._modal_is_active():
+            return
+        if self.app_mode == "triage":
             return
         if self._total_panes() >= MAX_ROWS * MAX_COLS:
             self.notify("Maximum 6 panes reached", severity="warning")

--- a/src/skim/app.py
+++ b/src/skim/app.py
@@ -642,6 +642,9 @@ class SkimApp(App):
                     viewer.select_annotation_path(target_path)
 
             pane.call_after_refresh(select_target)
+        elif item.target_kind == "file":
+            pane.set_selected_file_annotation_id(item.annotation_id)
+            pane.show_file(path)
         self._show_mode("browse")
         self.exit_file_tree_mode()
 

--- a/src/skim/preview.py
+++ b/src/skim/preview.py
@@ -23,6 +23,7 @@ from textual.css.query import NoMatches
 from textual.widget import Widget
 from textual.widgets import Collapsible, Markdown, Static
 
+from .review import FILE_ANNOTATION_KEY, AnnotationStore
 from .scrolling import DragScrollMixin
 from .trajectory import JsonInspector, TrajectoryViewer
 
@@ -108,6 +109,15 @@ class XlsxPreview(Vertical):
         yield from self._widgets
 
 
+class FileAnnotationStatus(Static):
+    """Compact file-level annotation summary for non-JSON previews."""
+
+    def __init__(self, annotations, **kwargs: Any) -> None:
+        """Initialize the status widget from stored file annotations."""
+        super().__init__("", **kwargs)
+        self.update(_file_annotation_status_text(annotations))
+
+
 class PreviewPane(DragScrollMixin, VerticalScroll, can_focus=True):
     """Scrollable panel that shows file contents."""
 
@@ -129,6 +139,16 @@ class PreviewPane(DragScrollMixin, VerticalScroll, can_focus=True):
         self.remove_children()
         browse_root = getattr(self.app, "browse_path", path.parent)
         widgets = render_file(path, browse_root=browse_root)
+        store = getattr(self.app, "review_store", None)
+        if widgets and not isinstance(widgets[0], (JsonInspector, TrajectoryViewer)):
+            if isinstance(store, AnnotationStore):
+                widgets = [
+                    FileAnnotationStatus(
+                        store.annotations_for_path(path, FILE_ANNOTATION_KEY),
+                        classes="annotation-status-panel",
+                    ),
+                    *widgets,
+                ]
         for widget in widgets:
             self.mount(widget)
         self.scroll_home(animate=False)
@@ -596,6 +616,24 @@ def _notebook_output_widget(output: Any) -> Widget:
     if traceback is not None:
         return Static(Text(_notebook_text(traceback), style="red"))
     return Static(Text(json.dumps(output, indent=2)))
+
+
+def _file_annotation_status_text(annotations) -> Text:
+    """Return a compact summary of file-level annotation state."""
+    title = Text("File Annotation", style="bold")
+    if not annotations:
+        title.append("\nNo annotation yet", style="white")
+        title.append("\nPress a to annotate this file", style="dim")
+        return title
+    selected = annotations[0]
+    title.append(
+        f"\n{len(annotations)} annotation{'s' if len(annotations) != 1 else ''}",
+        style="white",
+    )
+    if selected.tags:
+        title.append(f"\nTags: {', '.join(selected.tags)}", style="cyan")
+    title.append(f"\nNote: {selected.note or '(empty)'}", style="white")
+    return title
 
 
 def _notebook_text(value: Any) -> str:

--- a/src/skim/preview.py
+++ b/src/skim/preview.py
@@ -212,9 +212,7 @@ class PreviewPane(DragScrollMixin, VerticalScroll, can_focus=True):
             return None
         return f"{self.current_path.resolve().as_posix()}::{FILE_ANNOTATION_KEY}"
 
-    def selected_file_annotation_id(
-        self, annotations: tuple[AnnotationRecord, ...]
-    ) -> str | None:
+    def selected_file_annotation_id(self, annotations: tuple[AnnotationRecord, ...]) -> str | None:
         """Return the selected file annotation id, defaulting to the newest."""
         key = self.file_annotation_selection_key()
         if key is None or not annotations:

--- a/src/skim/preview.py
+++ b/src/skim/preview.py
@@ -23,7 +23,7 @@ from textual.css.query import NoMatches
 from textual.widget import Widget
 from textual.widgets import Collapsible, Markdown, Static
 
-from .review import FILE_ANNOTATION_KEY, AnnotationStore
+from .review import FILE_ANNOTATION_KEY, AnnotationRecord, AnnotationStore
 from .scrolling import DragScrollMixin
 from .trajectory import JsonInspector, TrajectoryViewer
 
@@ -112,10 +112,23 @@ class XlsxPreview(Vertical):
 class FileAnnotationStatus(Static):
     """Compact file-level annotation summary for non-JSON previews."""
 
-    def __init__(self, annotations, **kwargs: Any) -> None:
+    def __init__(
+        self,
+        annotations: tuple[AnnotationRecord, ...],
+        *,
+        selected_annotation_id: str | None = None,
+        annotation_mode: bool = False,
+        **kwargs: Any,
+    ) -> None:
         """Initialize the status widget from stored file annotations."""
         super().__init__("", **kwargs)
-        self.update(_file_annotation_status_text(annotations))
+        self.update(
+            _file_annotation_status_text(
+                annotations,
+                selected_annotation_id=selected_annotation_id,
+                annotation_mode=annotation_mode,
+            )
+        )
 
 
 class PreviewPane(DragScrollMixin, VerticalScroll, can_focus=True):
@@ -126,25 +139,34 @@ class PreviewPane(DragScrollMixin, VerticalScroll, can_focus=True):
         super().__init__(**kwargs)
         self._init_drag_scroll()
         self.current_path: Path | None = None
+        self.selected_annotation_ids: dict[str, str] = {}
+        self.file_annotation_mode = False
 
     def show_placeholder(self, message: str = "Select a file") -> None:
         """Show placeholder text when no file is selected."""
         self.current_path = None
+        self.file_annotation_mode = False
         self.remove_children()
         self.mount(Static(Text(message, style="dim italic")))
 
     def show_file(self, path: Path) -> None:
         """Render a file into the pane."""
+        same_file = self.current_path is not None and self.current_path.resolve() == path.resolve()
         self.current_path = path
+        if not same_file:
+            self.file_annotation_mode = False
         self.remove_children()
         browse_root = getattr(self.app, "browse_path", path.parent)
         widgets = render_file(path, browse_root=browse_root)
         store = getattr(self.app, "review_store", None)
         if widgets and not isinstance(widgets[0], (JsonInspector, TrajectoryViewer)):
             if isinstance(store, AnnotationStore):
+                annotations = store.annotations_for_path(path, FILE_ANNOTATION_KEY)
                 widgets = [
                     FileAnnotationStatus(
-                        store.annotations_for_path(path, FILE_ANNOTATION_KEY),
+                        annotations,
+                        selected_annotation_id=self.selected_file_annotation_id(annotations),
+                        annotation_mode=self.file_annotation_mode,
                         classes="annotation-status-panel",
                     ),
                     *widgets,
@@ -183,6 +205,37 @@ class PreviewPane(DragScrollMixin, VerticalScroll, can_focus=True):
                 return None
             return viewer if isinstance(viewer, TrajectoryViewer) else None
         return viewer if isinstance(viewer, JsonInspector) else None
+
+    def file_annotation_selection_key(self) -> str | None:
+        """Return the pane-local selection key for the current file annotation target."""
+        if self.current_path is None:
+            return None
+        return f"{self.current_path.resolve().as_posix()}::{FILE_ANNOTATION_KEY}"
+
+    def selected_file_annotation_id(
+        self, annotations: tuple[AnnotationRecord, ...]
+    ) -> str | None:
+        """Return the selected file annotation id, defaulting to the newest."""
+        key = self.file_annotation_selection_key()
+        if key is None or not annotations:
+            if key is not None:
+                self.selected_annotation_ids.pop(key, None)
+            return None
+        selected_id = self.selected_annotation_ids.get(key)
+        if any(annotation.id == selected_id for annotation in annotations):
+            return selected_id
+        self.selected_annotation_ids[key] = annotations[0].id
+        return annotations[0].id
+
+    def set_selected_file_annotation_id(self, annotation_id: str | None) -> None:
+        """Set or clear the selected file annotation id for the current file."""
+        key = self.file_annotation_selection_key()
+        if key is None:
+            return
+        if annotation_id is None:
+            self.selected_annotation_ids.pop(key, None)
+        else:
+            self.selected_annotation_ids[key] = annotation_id
 
 
 def render_file(path: Path, *, browse_root: Path | None = None) -> list[Widget]:
@@ -618,21 +671,47 @@ def _notebook_output_widget(output: Any) -> Widget:
     return Static(Text(json.dumps(output, indent=2)))
 
 
-def _file_annotation_status_text(annotations) -> Text:
+def _file_annotation_status_text(
+    annotations: tuple[AnnotationRecord, ...],
+    *,
+    selected_annotation_id: str | None,
+    annotation_mode: bool,
+) -> Text:
     """Return a compact summary of file-level annotation state."""
     title = Text("File Annotation", style="bold")
     if not annotations:
         title.append("\nNo annotation yet", style="white")
         title.append("\nPress a to annotate this file", style="dim")
         return title
-    selected = annotations[0]
+    selected = next(
+        (annotation for annotation in annotations if annotation.id == selected_annotation_id),
+        annotations[0],
+    )
     title.append(
         f"\n{len(annotations)} annotation{'s' if len(annotations) != 1 else ''}",
         style="white",
     )
-    if selected.tags:
-        title.append(f"\nTags: {', '.join(selected.tags)}", style="cyan")
+    for index, annotation in enumerate(annotations, start=1):
+        marker = "▶ " if annotation.id == selected.id else "  "
+        title.append(
+            f"\n{marker}{index}. {annotation.updated_at[:16].replace('T', ' ')} ",
+            style="bold green" if annotation.id == selected.id else "dim",
+        )
+        if annotation.tags:
+            title.append(f"[{', '.join(annotation.tags)}] ", style="cyan")
+        first_line = (annotation.note or "(empty)").splitlines()[0]
+        title.append(first_line[:80] + ("…" if len(first_line) > 80 else ""))
+    title.append(
+        f"\nTags: {', '.join(selected.tags) if selected.tags else '(none)'}",
+        style="cyan",
+    )
     title.append(f"\nNote: {selected.note or '(empty)'}", style="white")
+    title.append(
+        "\nUse ↑↓ to select, Enter to edit, a to add another"
+        if annotation_mode
+        else "\nPress Enter to browse annotations or a to add another",
+        style="dim",
+    )
     return title
 
 

--- a/src/skim/review.py
+++ b/src/skim/review.py
@@ -1,0 +1,476 @@
+"""Shared local review storage and triage helpers for skim.
+
+This module owns persisted annotation records, file-level annotation support,
+annotation-version reloads, and the normalized triage item contract used by the
+web UI and TUI.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+FILE_ANNOTATION_KEY = "@file"
+FILE_TARGET_KIND = "file"
+JSON_PATH_TARGET_KIND = "json_path"
+REVIEW_VERSION = 1
+
+MARKDOWN_EXTENSIONS = {".md", ".markdown", ".mdown"}
+JSON_EXTENSIONS = {".json"}
+NOTEBOOK_EXTENSIONS = {".ipynb"}
+CSV_EXTENSIONS = {".csv"}
+XLSX_EXTENSIONS = {".xlsx"}
+CODE_EXTENSIONS = {
+    ".py",
+    ".js",
+    ".ts",
+    ".html",
+    ".css",
+    ".yaml",
+    ".yml",
+    ".toml",
+    ".sh",
+    ".bash",
+    ".rs",
+    ".go",
+    ".sql",
+    ".xml",
+}
+TEXT_EXTENSIONS = {
+    "",
+    ".txt",
+    ".log",
+    ".rst",
+    ".ini",
+    ".cfg",
+    ".conf",
+}
+
+
+@dataclass(frozen=True)
+class AnnotationRecord:
+    """Persisted annotation for one file target."""
+
+    id: str
+    created_at: str
+    updated_at: str
+    tags: tuple[str, ...]
+    note: str
+
+
+@dataclass(frozen=True)
+class TriageItem:
+    """Normalized workspace-level review row."""
+
+    annotation_id: str
+    file_path: str
+    target_kind: str
+    target_label: str
+    target_path: str | None
+    preview_kind: str
+    tags: tuple[str, ...]
+    note_preview: str
+    note_full: str
+    created_at: str
+    updated_at: str
+
+    def to_payload(self) -> dict[str, Any]:
+        """Return a JSON-serializable representation."""
+        payload = asdict(self)
+        payload["tags"] = list(self.tags)
+        return payload
+
+
+class AnnotationStore:
+    """Local JSON-backed annotation storage rooted at the current browse path."""
+
+    def __init__(self, review_root: Path) -> None:
+        """Initialize the annotation store for one browse root."""
+        self.review_root = review_root.resolve()
+        self.path = self.review_root / ".skim" / "review.json"
+        self._payload = self._load()
+        self._file_annotations: dict[str, dict[str, tuple[AnnotationRecord, ...]]] = {}
+        self._annotation_version = self._compute_annotation_version()
+
+    @property
+    def payload(self) -> dict[str, Any]:
+        """Return the current persisted payload after refreshing from disk."""
+        self._ensure_fresh()
+        return self._payload
+
+    @property
+    def annotation_version(self) -> str:
+        """Return a stable version token for the current review payload."""
+        self._ensure_fresh()
+        return self._annotation_version
+
+    def annotations_for_file(self, source_path: Path) -> dict[str, tuple[AnnotationRecord, ...]]:
+        """Return stored annotations for one source file."""
+        self._ensure_fresh()
+        relative_path = self.relative_file_path(source_path)
+        cached = self._file_annotations.get(relative_path)
+        if cached is None:
+            cached = self._build_annotations_for_relative_path(relative_path)
+            self._file_annotations[relative_path] = cached
+        return cached
+
+    def annotations_for_path(self, source_path: Path, path: str) -> tuple[AnnotationRecord, ...]:
+        """Return all annotations by file-relative target path, newest first."""
+        return self.annotations_for_file(source_path).get(path, ())
+
+    def get_annotation(self, source_path: Path, path: str) -> AnnotationRecord | None:
+        """Return the newest annotation by file-relative target path."""
+        records = self.annotations_for_path(source_path, path)
+        return records[0] if records else None
+
+    def add_annotation(
+        self,
+        source_path: Path,
+        path: str,
+        *,
+        tags: tuple[str, ...],
+        note: str,
+    ) -> AnnotationRecord:
+        """Append one annotation entry for a target path and persist it."""
+        self._ensure_fresh()
+        timestamp = _annotation_timestamp()
+        record = AnnotationRecord(
+            id=str(uuid4()),
+            created_at=timestamp,
+            updated_at=timestamp,
+            tags=_normalize_annotation_tags(tags),
+            note=note,
+        )
+        _, annotations = self._persisted_annotations_for_file(source_path)
+        existing = annotations.get(path, [])
+        normalized = self._normalize_annotation_entries(existing)
+        updated = _sort_annotation_records([*normalized, record])
+        annotations[path] = [_annotation_payload(entry) for entry in updated]
+        self.annotations_for_file(source_path)[path] = tuple(updated)
+        self._save()
+        return record
+
+    def update_annotation(
+        self,
+        source_path: Path,
+        path: str,
+        annotation_id: str,
+        *,
+        tags: tuple[str, ...],
+        note: str,
+    ) -> AnnotationRecord | None:
+        """Update one persisted annotation entry by id."""
+        self._ensure_fresh()
+        _, annotations = self._persisted_annotations_for_file(source_path)
+        existing = self._normalize_annotation_entries(annotations.get(path, []))
+        updated_record: AnnotationRecord | None = None
+        updated_entries: list[AnnotationRecord] = []
+        for record in existing:
+            if record.id == annotation_id:
+                updated_record = AnnotationRecord(
+                    id=record.id,
+                    created_at=record.created_at,
+                    updated_at=_annotation_timestamp(),
+                    tags=_normalize_annotation_tags(tags),
+                    note=note,
+                )
+                updated_entries.append(updated_record)
+            else:
+                updated_entries.append(record)
+        if updated_record is None:
+            return None
+        sorted_entries = _sort_annotation_records(updated_entries)
+        annotations[path] = [_annotation_payload(entry) for entry in sorted_entries]
+        self.annotations_for_file(source_path)[path] = tuple(sorted_entries)
+        self._save()
+        return updated_record
+
+    def set_annotation(
+        self,
+        source_path: Path,
+        path: str,
+        *,
+        tags: tuple[str, ...],
+        note: str,
+    ) -> None:
+        """Store one single-entry annotation, replacing existing entries."""
+        self._ensure_fresh()
+        timestamp = _annotation_timestamp()
+        record = AnnotationRecord(
+            id=str(uuid4()),
+            created_at=timestamp,
+            updated_at=timestamp,
+            tags=_normalize_annotation_tags(tags),
+            note=note,
+        )
+        _, annotations = self._persisted_annotations_for_file(source_path)
+        annotations[path] = [_annotation_payload(record)]
+        self.annotations_for_file(source_path)[path] = (record,)
+        self._save()
+
+    def delete_annotation(
+        self,
+        source_path: Path,
+        path: str,
+        annotation_id: str | None = None,
+    ) -> None:
+        """Delete one annotation entry by id, or all entries when no id is supplied."""
+        self._ensure_fresh()
+        _, annotations = self._persisted_annotations_for_file(source_path)
+        if annotation_id is None:
+            annotations.pop(path, None)
+            self.annotations_for_file(source_path).pop(path, None)
+            self._save()
+            return
+        existing = self._normalize_annotation_entries(annotations.get(path, []))
+        remaining = [record for record in existing if record.id != annotation_id]
+        if remaining:
+            sorted_entries = _sort_annotation_records(remaining)
+            annotations[path] = [_annotation_payload(entry) for entry in sorted_entries]
+            self.annotations_for_file(source_path)[path] = tuple(sorted_entries)
+        else:
+            annotations.pop(path, None)
+            self.annotations_for_file(source_path).pop(path, None)
+        self._save()
+
+    def relative_file_path(self, source_path: Path) -> str:
+        """Return the normalized file key used in persisted review data."""
+        resolved = source_path.resolve()
+        try:
+            return resolved.relative_to(self.review_root).as_posix()
+        except ValueError:
+            return resolved.name
+
+    def triage_items(self) -> list[TriageItem]:
+        """Return all annotations normalized as triage rows."""
+        self._ensure_fresh()
+        files = self._payload.get("files", {})
+        items: list[TriageItem] = []
+        if not isinstance(files, dict):
+            return items
+        for file_path, file_entry in files.items():
+            if not isinstance(file_path, str) or not isinstance(file_entry, dict):
+                continue
+            annotations = file_entry.get("annotations", {})
+            if not isinstance(annotations, dict):
+                continue
+            for target_path, payload in annotations.items():
+                if not isinstance(target_path, str):
+                    continue
+                target_kind = (
+                    FILE_TARGET_KIND
+                    if target_path == FILE_ANNOTATION_KEY
+                    else JSON_PATH_TARGET_KIND
+                )
+                target_label = "File" if target_kind == FILE_TARGET_KIND else target_path
+                normalized_path = None if target_kind == FILE_TARGET_KIND else target_path
+                for record in self._normalize_annotation_entries(payload):
+                    items.append(
+                        TriageItem(
+                            annotation_id=record.id,
+                            file_path=file_path,
+                            target_kind=target_kind,
+                            target_label=target_label,
+                            target_path=normalized_path,
+                            preview_kind=triage_preview_kind(file_path),
+                            tags=record.tags,
+                            note_preview=_note_preview(record.note),
+                            note_full=record.note,
+                            created_at=record.created_at,
+                            updated_at=record.updated_at,
+                        )
+                    )
+        return sorted(
+            items,
+            key=lambda item: (
+                -_timestamp_sort_key(item.updated_at),
+                item.file_path,
+                item.annotation_id,
+            ),
+        )
+
+    def _load(self) -> dict[str, Any]:
+        """Load the persisted annotation payload with safe fallbacks."""
+        if not self.path.is_file():
+            return {"version": REVIEW_VERSION, "files": {}}
+        try:
+            payload = json.loads(self.path.read_text())
+        except (OSError, json.JSONDecodeError):
+            return {"version": REVIEW_VERSION, "files": {}}
+        if not isinstance(payload, dict):
+            return {"version": REVIEW_VERSION, "files": {}}
+        payload.setdefault("version", REVIEW_VERSION)
+        payload.setdefault("files", {})
+        files = payload.get("files", {})
+        if isinstance(files, dict):
+            for file_entry in files.values():
+                if not isinstance(file_entry, dict):
+                    continue
+                annotations = file_entry.get("annotations")
+                if not isinstance(annotations, dict):
+                    file_entry["annotations"] = {}
+                    continue
+                normalized_annotations: dict[str, list[dict[str, Any]]] = {}
+                for path, entry in annotations.items():
+                    if not isinstance(path, str):
+                        continue
+                    records = self._normalize_annotation_entries(entry)
+                    normalized_annotations[path] = [
+                        _annotation_payload(record) for record in records
+                    ]
+                file_entry["annotations"] = normalized_annotations
+        return payload
+
+    def _build_annotations_for_relative_path(
+        self,
+        relative_path: str,
+    ) -> dict[str, tuple[AnnotationRecord, ...]]:
+        """Normalize stored annotations for one file path."""
+        files = self._payload.get("files", {})
+        file_entry = files.get(relative_path, {})
+        annotations = file_entry.get("annotations", {})
+        result: dict[str, tuple[AnnotationRecord, ...]] = {}
+        for path, payload in annotations.items():
+            if not isinstance(path, str):
+                continue
+            records = self._normalize_annotation_entries(payload)
+            if records:
+                result[path] = tuple(records)
+        return result
+
+    def _persisted_annotations_for_file(
+        self,
+        source_path: Path,
+    ) -> tuple[str, dict[str, Any]]:
+        """Return the persisted file key and mutable annotation payload for one source."""
+        relative_path = self.relative_file_path(source_path)
+        files = self._payload.setdefault("files", {})
+        file_entry = files.setdefault(relative_path, {"annotations": {}})
+        annotations = file_entry.setdefault("annotations", {})
+        return relative_path, annotations
+
+    def _normalize_annotation_entries(self, payload: Any) -> list[AnnotationRecord]:
+        """Normalize legacy or list-shaped annotation payloads into sorted records."""
+        entries = payload if isinstance(payload, list) else [payload]
+        records: list[AnnotationRecord] = []
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            tags = entry.get("tags", [])
+            note = entry.get("note", "")
+            if not isinstance(tags, list) or not isinstance(note, str):
+                continue
+            created_at = str(entry.get("created_at") or _annotation_timestamp())
+            updated_at = str(entry.get("updated_at") or created_at)
+            record_id = str(entry.get("id") or uuid4())
+            records.append(
+                AnnotationRecord(
+                    id=record_id,
+                    created_at=created_at,
+                    updated_at=updated_at,
+                    tags=_normalize_annotation_tags(tags),
+                    note=note,
+                )
+            )
+        return _sort_annotation_records(records)
+
+    def _save(self) -> None:
+        """Write the annotation payload to disk."""
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.path.write_text(json.dumps(self._payload, indent=2, sort_keys=True))
+        self._annotation_version = self._compute_annotation_version()
+
+    def _ensure_fresh(self) -> None:
+        """Reload the persisted payload when another process changed it on disk."""
+        version = self._compute_annotation_version()
+        if version == self._annotation_version:
+            return
+        self._payload = self._load()
+        self._file_annotations = {}
+        self._annotation_version = version
+
+    def _compute_annotation_version(self) -> str:
+        """Return a token that changes whenever the review file changes."""
+        try:
+            stat = self.path.stat()
+        except FileNotFoundError:
+            return "missing"
+        return f"{stat.st_mtime_ns}:{stat.st_size}"
+
+
+def triage_preview_kind(file_path: str) -> str:
+    """Return the triage filter bucket for one relative file path."""
+    suffix = Path(file_path).suffix.lower()
+    if suffix in MARKDOWN_EXTENSIONS:
+        return "markdown"
+    if suffix in JSON_EXTENSIONS:
+        return "json"
+    if suffix in NOTEBOOK_EXTENSIONS:
+        return "notebook"
+    if suffix in CSV_EXTENSIONS:
+        return "csv"
+    if suffix in XLSX_EXTENSIONS:
+        return "xlsx"
+    if suffix in CODE_EXTENSIONS:
+        return "code"
+    if suffix in TEXT_EXTENSIONS:
+        return "text"
+    return "other"
+
+
+def _annotation_timestamp() -> str:
+    """Return a UTC timestamp for persisted annotations."""
+    from datetime import UTC, datetime
+
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _normalize_annotation_tags(tags: tuple[str, ...] | list[str]) -> tuple[str, ...]:
+    """Return a stable tuple of non-empty tag strings."""
+    result: list[str] = []
+    for tag in tags:
+        value = str(tag).strip()
+        if value:
+            result.append(value)
+    return tuple(result)
+
+
+def _annotation_payload(record: AnnotationRecord) -> dict[str, Any]:
+    """Return a persisted JSON payload for one annotation record."""
+    return {
+        "id": record.id,
+        "created_at": record.created_at,
+        "updated_at": record.updated_at,
+        "tags": list(record.tags),
+        "note": record.note,
+    }
+
+
+def _sort_annotation_records(records: list[AnnotationRecord]) -> list[AnnotationRecord]:
+    """Return annotations newest-first, then stable by id."""
+    return sorted(
+        records,
+        key=lambda record: (-_timestamp_sort_key(record.updated_at), record.id),
+    )
+
+
+def _timestamp_sort_key(value: str) -> int:
+    """Return a comparable integer for ISO timestamps."""
+    normalized = str(value).replace("Z", "+00:00")
+    try:
+        from datetime import datetime
+
+        return int(datetime.fromisoformat(normalized).timestamp() * 1_000_000)
+    except ValueError:
+        return 0
+
+
+def _note_preview(note: str, limit: int = 96) -> str:
+    """Return a compact one-line preview for a note body."""
+    single_line = " ".join(note.split())
+    if len(single_line) <= limit:
+        return single_line
+    return single_line[: limit - 1].rstrip() + "…"

--- a/src/skim/server.py
+++ b/src/skim/server.py
@@ -15,7 +15,7 @@ from http.server import HTTPServer, SimpleHTTPRequestHandler
 from pathlib import Path
 from urllib.parse import parse_qs, urlparse
 
-from .trajectory import AnnotationStore
+from .review import AnnotationStore
 from .web_preview import serialize_preview
 
 SKIP_DIRS = {
@@ -106,7 +106,18 @@ class SkimHandler(SimpleHTTPRequestHandler):
             self._serve_preview(parse_qs(parsed.query))
             return
         if parsed.path == "/api/annotations":
-            self._json_response(self.store._payload)
+            self._json_response(self.store.payload)
+            return
+        if parsed.path == "/api/annotation-version":
+            self._json_response({"annotation_version": self.store.annotation_version})
+            return
+        if parsed.path == "/api/triage":
+            self._json_response(
+                {
+                    "annotation_version": self.store.annotation_version,
+                    "items": [item.to_payload() for item in self.store.triage_items()],
+                }
+            )
             return
         super().do_GET()
 

--- a/src/skim/trajectory.py
+++ b/src/skim/trajectory.py
@@ -10,10 +10,8 @@ from __future__ import annotations
 import json
 from collections.abc import Callable
 from dataclasses import dataclass
-from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
-from uuid import uuid4
 
 from rich.syntax import Syntax
 from rich.text import Text
@@ -25,6 +23,7 @@ from textual.widget import Widget
 from textual.widgets import Button, Collapsible, Input, Markdown, Static, TextArea
 from textual.widgets import Tree as TextualTree
 
+from .review import AnnotationRecord, AnnotationStore
 from .scrolling import AnnotationStatusWrap, DragTree, FocusableDetailWrap
 
 HUMAN_TEXT_KEYS = {
@@ -99,17 +98,6 @@ class TrajectoryTreeItem:
 
 
 @dataclass(frozen=True)
-class AnnotationRecord:
-    """Persisted annotation for one JSON node."""
-
-    id: str
-    created_at: str
-    updated_at: str
-    tags: tuple[str, ...]
-    note: str
-
-
-@dataclass(frozen=True)
 class AnnotationEditorResult:
     """Dismiss payload from the annotation editor modal."""
 
@@ -117,237 +105,6 @@ class AnnotationEditorResult:
     annotation_id: str | None = None
     tags: tuple[str, ...] = ()
     note: str = ""
-
-
-class AnnotationStore:
-    """Local JSON-backed annotation storage rooted at the current browse path."""
-
-    def __init__(self, review_root: Path) -> None:
-        """Initialize the annotation store for one browse root."""
-        self.review_root = review_root.resolve()
-        self.path = self.review_root / ".skim" / "review.json"
-        self._payload = self._load()
-        self._file_annotations: dict[str, dict[str, tuple[AnnotationRecord, ...]]] = {}
-
-    def annotations_for_file(self, source_path: Path) -> dict[str, tuple[AnnotationRecord, ...]]:
-        """Return stored annotations for one source file."""
-        relative_path = self.relative_file_path(source_path)
-        cached = self._file_annotations.get(relative_path)
-        if cached is None:
-            cached = self._build_annotations_for_relative_path(relative_path)
-            self._file_annotations[relative_path] = cached
-        return cached
-
-    def annotations_for_path(self, source_path: Path, path: str) -> tuple[AnnotationRecord, ...]:
-        """Return all annotations by file-relative JSON path, newest first."""
-        return self.annotations_for_file(source_path).get(path, ())
-
-    def get_annotation(self, source_path: Path, path: str) -> AnnotationRecord | None:
-        """Return the newest annotation by file-relative JSON path."""
-        records = self.annotations_for_path(source_path, path)
-        return records[0] if records else None
-
-    def add_annotation(
-        self,
-        source_path: Path,
-        path: str,
-        *,
-        tags: tuple[str, ...],
-        note: str,
-    ) -> AnnotationRecord:
-        """Append one annotation entry for a path and persist it."""
-        record = AnnotationRecord(
-            id=str(uuid4()),
-            created_at=_annotation_timestamp(),
-            updated_at=_annotation_timestamp(),
-            tags=_normalize_annotation_tags(tags),
-            note=note,
-        )
-        relative_path, annotations = self._persisted_annotations_for_file(source_path)
-        existing = annotations.get(path, [])
-        normalized = self._normalize_annotation_entries(existing)
-        updated = _sort_annotation_records([*normalized, record])
-        annotations[path] = [_annotation_payload(entry) for entry in updated]
-        self.annotations_for_file(source_path)[path] = tuple(updated)
-        self._save()
-        return record
-
-    def update_annotation(
-        self,
-        source_path: Path,
-        path: str,
-        annotation_id: str,
-        *,
-        tags: tuple[str, ...],
-        note: str,
-    ) -> AnnotationRecord | None:
-        """Update one persisted annotation entry by id."""
-        relative_path, annotations = self._persisted_annotations_for_file(source_path)
-        existing = self._normalize_annotation_entries(annotations.get(path, []))
-        updated_record: AnnotationRecord | None = None
-        updated_entries: list[AnnotationRecord] = []
-        for record in existing:
-            if record.id == annotation_id:
-                updated_record = AnnotationRecord(
-                    id=record.id,
-                    created_at=record.created_at,
-                    updated_at=_annotation_timestamp(),
-                    tags=_normalize_annotation_tags(tags),
-                    note=note,
-                )
-                updated_entries.append(updated_record)
-            else:
-                updated_entries.append(record)
-        if updated_record is None:
-            return None
-        sorted_entries = _sort_annotation_records(updated_entries)
-        annotations[path] = [_annotation_payload(entry) for entry in sorted_entries]
-        self.annotations_for_file(source_path)[path] = tuple(sorted_entries)
-        self._save()
-        return updated_record
-
-    def set_annotation(
-        self,
-        source_path: Path,
-        path: str,
-        *,
-        tags: tuple[str, ...],
-        note: str,
-    ) -> None:
-        """Store one single-entry annotation, replacing existing entries for compatibility."""
-        record = AnnotationRecord(
-            id=str(uuid4()),
-            created_at=_annotation_timestamp(),
-            updated_at=_annotation_timestamp(),
-            tags=_normalize_annotation_tags(tags),
-            note=note,
-        )
-        _, annotations = self._persisted_annotations_for_file(source_path)
-        annotations[path] = [_annotation_payload(record)]
-        self.annotations_for_file(source_path)[path] = (record,)
-        self._save()
-
-    def delete_annotation(
-        self,
-        source_path: Path,
-        path: str,
-        annotation_id: str | None = None,
-    ) -> None:
-        """Delete one annotation entry by id, or all entries when no id is supplied."""
-        _, annotations = self._persisted_annotations_for_file(source_path)
-        if annotation_id is None:
-            annotations.pop(path, None)
-            self.annotations_for_file(source_path).pop(path, None)
-            self._save()
-            return
-        existing = self._normalize_annotation_entries(annotations.get(path, []))
-        remaining = [record for record in existing if record.id != annotation_id]
-        if remaining:
-            sorted_entries = _sort_annotation_records(remaining)
-            annotations[path] = [_annotation_payload(entry) for entry in sorted_entries]
-            self.annotations_for_file(source_path)[path] = tuple(sorted_entries)
-        else:
-            annotations.pop(path, None)
-            self.annotations_for_file(source_path).pop(path, None)
-        self._save()
-
-    def relative_file_path(self, source_path: Path) -> str:
-        """Return the normalized file key used in persisted review data."""
-        resolved = source_path.resolve()
-        try:
-            return resolved.relative_to(self.review_root).as_posix()
-        except ValueError:
-            return resolved.name
-
-    def _load(self) -> dict[str, Any]:
-        """Load the persisted annotation payload with safe fallbacks."""
-        if not self.path.is_file():
-            return {"version": 1, "files": {}}
-        try:
-            payload = json.loads(self.path.read_text())
-        except (OSError, json.JSONDecodeError):
-            return {"version": 1, "files": {}}
-        if not isinstance(payload, dict):
-            return {"version": 1, "files": {}}
-        payload.setdefault("version", 1)
-        payload.setdefault("files", {})
-        files = payload.get("files", {})
-        if isinstance(files, dict):
-            for file_entry in files.values():
-                if not isinstance(file_entry, dict):
-                    continue
-                annotations = file_entry.get("annotations")
-                if not isinstance(annotations, dict):
-                    file_entry["annotations"] = {}
-                    continue
-                normalized_annotations: dict[str, list[dict[str, Any]]] = {}
-                for path, entry in annotations.items():
-                    if not isinstance(path, str):
-                        continue
-                    records = self._normalize_annotation_entries(entry)
-                    normalized_annotations[path] = [
-                        _annotation_payload(record) for record in records
-                    ]
-                file_entry["annotations"] = normalized_annotations
-        return payload
-
-    def _build_annotations_for_relative_path(
-        self,
-        relative_path: str,
-    ) -> dict[str, tuple[AnnotationRecord, ...]]:
-        """Normalize stored annotations for one file path."""
-        files = self._payload.get("files", {})
-        file_entry = files.get(relative_path, {})
-        annotations = file_entry.get("annotations", {})
-        result: dict[str, tuple[AnnotationRecord, ...]] = {}
-        for path, payload in annotations.items():
-            if not isinstance(path, str):
-                continue
-            records = self._normalize_annotation_entries(payload)
-            if records:
-                result[path] = tuple(records)
-        return result
-
-    def _persisted_annotations_for_file(
-        self,
-        source_path: Path,
-    ) -> tuple[str, dict[str, Any]]:
-        """Return the persisted file key and mutable annotation payload for one source."""
-        relative_path = self.relative_file_path(source_path)
-        files = self._payload.setdefault("files", {})
-        file_entry = files.setdefault(relative_path, {"annotations": {}})
-        annotations = file_entry.setdefault("annotations", {})
-        return relative_path, annotations
-
-    def _normalize_annotation_entries(self, payload: Any) -> list[AnnotationRecord]:
-        """Normalize legacy or list-shaped annotation payloads into sorted records."""
-        entries = payload if isinstance(payload, list) else [payload]
-        records: list[AnnotationRecord] = []
-        for entry in entries:
-            if not isinstance(entry, dict):
-                continue
-            tags = entry.get("tags", [])
-            note = entry.get("note", "")
-            if not isinstance(tags, list) or not isinstance(note, str):
-                continue
-            created_at = str(entry.get("created_at") or _annotation_timestamp())
-            updated_at = str(entry.get("updated_at") or created_at)
-            record_id = str(entry.get("id") or uuid4())
-            records.append(
-                AnnotationRecord(
-                    id=record_id,
-                    created_at=created_at,
-                    updated_at=updated_at,
-                    tags=_normalize_annotation_tags(tags),
-                    note=note,
-                )
-            )
-        return _sort_annotation_records(records)
-
-    def _save(self) -> None:
-        """Write the annotation payload to disk."""
-        self.path.parent.mkdir(parents=True, exist_ok=True)
-        self.path.write_text(json.dumps(self._payload, indent=2, sort_keys=True))
 
 
 class AnnotationEditor(ModalScreen[AnnotationEditorResult | None]):
@@ -1660,6 +1417,20 @@ class JsonInspector(Vertical):
             self._mount_annotation_panel(self._current_item)
         self._update_footer()
 
+    def select_annotation_path(self, path: str) -> bool:
+        """Move the tree selection to one persisted annotation path, if present."""
+        for node in _walk_tree_nodes(self._tree.root):
+            item = node.data
+            if not isinstance(item, JsonInspectorItem):
+                continue
+            if self._annotation_key(item) != path:
+                continue
+            self._tree.move_cursor(node, animate=False)
+            self._show_detail(item)
+            self.focus_tree_mode()
+            return True
+        return False
+
     def focus_detail_mode(self) -> None:
         """Keep compatibility with callers that expect a detail-focus method."""
         self.focus_annotation_mode()
@@ -2366,20 +2137,6 @@ def _annotation_payload(record: AnnotationRecord) -> dict[str, Any]:
         "tags": list(record.tags),
         "note": record.note,
     }
-
-
-def _annotation_timestamp() -> str:
-    """Return a stable UTC timestamp string for annotation metadata."""
-    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
-
-
-def _sort_annotation_records(records: list[AnnotationRecord]) -> list[AnnotationRecord]:
-    """Return records ordered newest-first by updated timestamp."""
-    return sorted(
-        records,
-        key=lambda record: (record.updated_at, record.created_at, record.id),
-        reverse=True,
-    )
 
 
 def _json_type_name(value: Any) -> str:

--- a/src/skim/web/app.js
+++ b/src/skim/web/app.js
@@ -15,6 +15,7 @@ const DEFAULT_TRAJECTORY_SPLIT_RATIO = loadStoredSplitRatio("trajectory", 38);
 const elements = {};
 
 const state = {
+  mode: "browse",
   tree: null,
   browseRoot: "",
   expandedDirs: new Set(["."]),
@@ -30,6 +31,15 @@ const state = {
     query: "",
     selectedIndex: 0,
     matches: [],
+  },
+  triage: {
+    items: [],
+    search: "",
+    selectedTag: "",
+    selectedPreviewKind: "",
+    selectedAnnotationId: null,
+    lastAnnotationVersion: null,
+    pollId: null,
   },
   modal: null,
 };
@@ -60,6 +70,8 @@ function createPaneState(id) {
 function bindElements() {
   elements.appShell = document.getElementById("app-shell");
   elements.browseRoot = document.getElementById("browse-root");
+  elements.modeBrowse = document.getElementById("mode-browse");
+  elements.modeTriage = document.getElementById("mode-triage");
   elements.fileTree = document.getElementById("file-tree");
   elements.previewWork = document.getElementById("preview-work");
   elements.paneGrid = document.getElementById("pane-grid");
@@ -89,7 +101,11 @@ function bindEvents() {
   elements.fileTree?.addEventListener("click", onTreeClick);
   elements.fileTree?.addEventListener("keydown", onTreeKeyDown);
   elements.previewWork?.addEventListener("click", onWorkspaceClick);
+  elements.previewWork?.addEventListener("input", onWorkspaceInput);
+  elements.previewWork?.addEventListener("change", onWorkspaceInput);
   elements.previewWork?.addEventListener("pointerdown", onPreviewPointerDown);
+  elements.modeBrowse?.addEventListener("click", () => setMode("browse"));
+  elements.modeTriage?.addEventListener("click", () => setMode("triage"));
   elements.sidebarToggle?.addEventListener("click", toggleSidebar);
   elements.sidebarResizer?.addEventListener("pointerdown", beginSidebarResize);
   elements.splitPane?.addEventListener("click", splitActivePane);
@@ -121,7 +137,9 @@ async function bootstrap() {
   try {
     state.tree = await apiJson("/api/tree");
     state.browseRoot = state.tree.root_path || state.tree.name || ".";
+    await loadTriage({ preserveSelection: false });
     render();
+    startAnnotationPolling();
   } catch (error) {
     renderFailure(error);
   }
@@ -162,10 +180,18 @@ function paneById(paneId) {
 
 function render() {
   applyTheme();
+  renderViewToggle();
   renderTree();
   renderWorkspace();
   renderStatusBar();
   renderPalette();
+}
+
+function renderViewToggle() {
+  elements.modeBrowse?.classList.toggle("active", state.mode === "browse");
+  elements.modeBrowse?.setAttribute("aria-pressed", state.mode === "browse" ? "true" : "false");
+  elements.modeTriage?.classList.toggle("active", state.mode === "triage");
+  elements.modeTriage?.setAttribute("aria-pressed", state.mode === "triage" ? "true" : "false");
 }
 
 function renderTree() {
@@ -210,13 +236,21 @@ function renderTreeNode(node, depth) {
 }
 
 function renderWorkspace() {
-  if (!elements.paneGrid) {
+  if (!elements.previewWork || !elements.workspace) {
     return;
   }
+  elements.workspace.classList.toggle("sidebar-hidden", !state.sidebarVisible && state.mode === "browse");
+  elements.workspace.classList.toggle("triage-mode", state.mode === "triage");
+  elements.sidebarResizer?.classList.toggle("hidden", state.mode !== "browse" || !canResizeSidebar());
+  if (state.mode === "triage") {
+    elements.previewWork.innerHTML = renderTriageView();
+    elements.paneGrid = null;
+    return;
+  }
+  elements.previewWork.innerHTML = `<div class="pane-grid" id="pane-grid"></div>`;
+  elements.paneGrid = document.getElementById("pane-grid");
   const count = state.panes.length;
   const layoutMode = paneLayoutMode(count);
-  elements.workspace?.classList.toggle("sidebar-hidden", !state.sidebarVisible);
-  elements.sidebarResizer?.classList.toggle("hidden", !canResizeSidebar());
   elements.paneGrid.className = `pane-grid panes-${count} layout-${layoutMode}`;
   applySidebarWidth();
   elements.paneGrid.innerHTML = renderPaneGridMarkup(state.panes);
@@ -228,6 +262,7 @@ function renderPaneShell(pane) {
   const title = pane.preview?.name || "Preview";
   const kind = previewLabel(pane.preview);
   const path = pane.path || "No file selected";
+  const annotationActions = renderPaneHeaderAnnotationActions(pane);
   const closeButton = state.panes.length > 1
     ? `<button class="title-button" type="button" data-close-pane="${escapeAttribute(pane.id)}">×</button>`
     : "";
@@ -240,6 +275,7 @@ function renderPaneShell(pane) {
           <div class="pane-path">${escapeHtml(path)}</div>
         </div>
         <div class="title-actions">
+          ${annotationActions}
           <span class="pane-kind">${escapeHtml(kind)}</span>
           ${closeButton}
         </div>
@@ -249,6 +285,17 @@ function renderPaneShell(pane) {
       </div>
     </article>
   `;
+}
+
+function renderPaneHeaderAnnotationActions(pane) {
+  if (!pane?.path || !isFileAnnotationPreview(pane.preview)) {
+    return "";
+  }
+  return renderAnnotationActions(
+    pane,
+    pane.preview.annotation_path,
+    normalizeAnnotations(pane.preview.annotations, pane.preview.annotation),
+  );
 }
 
 function previewLabel(preview) {
@@ -269,6 +316,17 @@ function previewLabel(preview) {
     error: "Error",
   };
   return kindLabels[preview.kind] || languageLabel(preview.language);
+}
+
+function isFileAnnotationPreview(preview) {
+  return Boolean(
+    preview &&
+    preview.annotation_path &&
+    preview.kind !== "json_inspector" &&
+    preview.kind !== "trajectory" &&
+    preview.kind !== "error" &&
+    preview.kind !== "too_large",
+  );
 }
 
 function languageLabel(language) {
@@ -365,14 +423,286 @@ function renderPaneContent(pane) {
 
 function renderStatusBar() {
   if (elements.statusPaneCount) {
-    elements.statusPaneCount.textContent = `${state.panes.length} pane${state.panes.length === 1 ? "" : "s"}`;
+    if (state.mode === "triage") {
+      const visible = visibleTriageItems();
+      elements.statusPaneCount.textContent = `${visible.length} item${visible.length === 1 ? "" : "s"}`;
+    } else {
+      elements.statusPaneCount.textContent = `${state.panes.length} pane${state.panes.length === 1 ? "" : "s"}`;
+    }
   }
   if (elements.statusActivePath) {
-    elements.statusActivePath.textContent = activePane()?.path || "No file selected";
+    if (state.mode === "triage") {
+      elements.statusActivePath.textContent = selectedTriageItem()?.file_path || "No annotation selected";
+    } else {
+      elements.statusActivePath.textContent = activePane()?.path || "No file selected";
+    }
   }
   if (elements.browseRoot) {
     elements.browseRoot.textContent = state.browseRoot || "Loading…";
   }
+}
+
+function setMode(mode) {
+  if (mode !== "browse" && mode !== "triage") {
+    return;
+  }
+  state.mode = mode;
+  render();
+}
+
+async function loadTriage(options = {}) {
+  const payload = await apiJson("/api/triage");
+  const previous = options.preferredAnnotationId || (options.preserveSelection !== false ? state.triage.selectedAnnotationId : null);
+  state.triage.items = Array.isArray(payload.items) ? payload.items : [];
+  state.triage.lastAnnotationVersion = payload.annotation_version || null;
+  const visible = visibleTriageItems();
+  const preferred = visible.find((item) => item.annotation_id === previous) || visible[0] || null;
+  state.triage.selectedAnnotationId = preferred?.annotation_id || null;
+  return payload;
+}
+
+function startAnnotationPolling() {
+  if (!globalThis.setInterval || state.triage.pollId != null) {
+    return;
+  }
+  state.triage.pollId = globalThis.setInterval(() => {
+    void refreshAnnotationsIfNeeded();
+  }, 2000);
+}
+
+async function refreshAnnotationsIfNeeded() {
+  const payload = await apiJson("/api/annotation-version");
+  const version = payload.annotation_version || null;
+  if (!version || version === state.triage.lastAnnotationVersion) {
+    return;
+  }
+  await loadTriage({ preserveSelection: true });
+  await refreshOpenPanes();
+  renderWorkspace();
+  renderStatusBar();
+}
+
+async function refreshOpenPanes() {
+  for (const pane of state.panes) {
+    if (!pane.path) {
+      continue;
+    }
+    await loadPreviewForPane(pane.path, pane.id, {
+      selectedJsonPath: pane.selectedJsonPath,
+      selectedStepId: pane.selectedStepId,
+    });
+  }
+}
+
+function visibleTriageItems() {
+  const search = (state.triage.search || "").trim().toLowerCase();
+  return state.triage.items.filter((item) => {
+    if (state.triage.selectedTag && !(item.tags || []).includes(state.triage.selectedTag)) {
+      return false;
+    }
+    if (state.triage.selectedPreviewKind && item.preview_kind !== state.triage.selectedPreviewKind) {
+      return false;
+    }
+    if (!search) {
+      return true;
+    }
+    const haystack = [
+      item.file_path,
+      item.target_label,
+      item.target_path,
+      item.note_preview,
+      item.note_full,
+      ...(item.tags || []),
+    ]
+      .filter(Boolean)
+      .join(" ")
+      .toLowerCase();
+    return haystack.includes(search);
+  });
+}
+
+function selectedTriageItem() {
+  const visible = visibleTriageItems();
+  const selected =
+    visible.find((item) => item.annotation_id === state.triage.selectedAnnotationId) ||
+    visible[0] ||
+    null;
+  state.triage.selectedAnnotationId = selected?.annotation_id || null;
+  return selected;
+}
+
+function triageTagOptions() {
+  const tags = new Set();
+  for (const item of state.triage.items) {
+    for (const tag of item.tags || []) {
+      tags.add(tag);
+    }
+  }
+  return Array.from(tags).sort((left, right) => left.localeCompare(right));
+}
+
+function triagePreviewKindOptions() {
+  const kinds = new Set();
+  for (const item of state.triage.items) {
+    if (item.preview_kind) {
+      kinds.add(item.preview_kind);
+    }
+  }
+  return Array.from(kinds).sort((left, right) => left.localeCompare(right));
+}
+
+function renderTriageView() {
+  const visible = visibleTriageItems();
+  const selected = selectedTriageItem();
+  return `
+    <section class="triage-shell">
+      <aside class="triage-panel triage-filters">
+        <div class="panel-heading">Filters</div>
+        <label class="field">
+          <span>Search</span>
+          <input type="text" value="${escapeAttribute(state.triage.search || "")}" placeholder="file, tag, note" data-triage-search>
+        </label>
+        <label class="field">
+          <span>Tag</span>
+          <select data-triage-tag>
+            <option value="">All tags</option>
+            ${triageTagOptions().map((tag) => `<option value="${escapeAttribute(tag)}" ${tag === state.triage.selectedTag ? "selected" : ""}>${escapeHtml(tag)}</option>`).join("")}
+          </select>
+        </label>
+        <label class="field">
+          <span>File type</span>
+          <select data-triage-preview-kind>
+            <option value="">All types</option>
+            ${triagePreviewKindOptions().map((kind) => `<option value="${escapeAttribute(kind)}" ${kind === state.triage.selectedPreviewKind ? "selected" : ""}>${escapeHtml(kind)}</option>`).join("")}
+          </select>
+        </label>
+        <div class="triage-summary">${visible.length} item${visible.length === 1 ? "" : "s"}</div>
+      </aside>
+      <section class="triage-panel triage-queue">
+        <div class="panel-heading">Queue</div>
+        ${renderTriageQueue(visible)}
+      </section>
+      <section class="triage-panel triage-detail">
+        <div class="panel-heading">Detail</div>
+        ${renderTriageDetail(selected)}
+      </section>
+    </section>
+  `;
+}
+
+function renderTriageQueue(items) {
+  if (!items.length) {
+    return `<div class="empty-state"><div><div class="empty-mark">◇</div><div>No annotations match the current filters.</div></div></div>`;
+  }
+  return `
+    <div class="triage-list">
+      ${items.map((item) => `
+        <button class="triage-row ${item.annotation_id === state.triage.selectedAnnotationId ? "selected" : ""}" type="button" data-triage-select="${escapeAttribute(item.annotation_id)}" data-triage-open="${escapeAttribute(item.annotation_id)}">
+          <div class="triage-row-head">
+            <span class="badge">${escapeHtml(item.preview_kind)}</span>
+            <span class="triage-file">${escapeHtml(item.file_path)}</span>
+            <span class="triage-time">${escapeHtml(formatAnnotationTimestamp(item.updated_at))}</span>
+          </div>
+          <div class="triage-target">${escapeHtml(item.target_label || "File")}</div>
+          <div class="triage-note">${escapeHtml(item.note_preview || "(empty)")}</div>
+          <div class="annotation-tags">${(item.tags || []).map((tag) => `<span class="annotation-tag">${escapeHtml(tag)}</span>`).join("")}</div>
+        </button>
+      `).join("")}
+    </div>
+  `;
+}
+
+function renderTriageDetail(item) {
+  if (!item) {
+    return `<div class="empty-state"><div><div class="empty-mark">◇</div><div>No annotation selected.</div></div></div>`;
+  }
+  return `
+    <div class="detail-stack triage-detail-stack">
+      <div class="preview-card">
+        <div class="detail-meta">
+          <span class="path-pill">${escapeHtml(item.file_path)}</span>
+          <span class="badge">${escapeHtml(item.target_label || "File")}</span>
+          <span class="badge">${escapeHtml(item.preview_kind)}</span>
+        </div>
+      </div>
+      <div class="preview-card">
+        <div class="annotation-tags">${(item.tags || []).map((tag) => `<span class="annotation-tag">${escapeHtml(tag)}</span>`).join("")}</div>
+        <div class="preview-block"><div class="text-block">${escapeHtml(item.note_full || "(empty)")}</div></div>
+      </div>
+      <div class="preview-card">
+        <div class="detail-meta">
+          <span class="badge">${escapeHtml(`Created ${formatAnnotationTimestamp(item.created_at)}`)}</span>
+          <span class="badge">${escapeHtml(`Updated ${formatAnnotationTimestamp(item.updated_at)}`)}</span>
+        </div>
+        <div class="title-actions triage-actions">
+          <button class="title-button" type="button" data-triage-open="${escapeAttribute(item.annotation_id)}">Open</button>
+          <button class="title-button" type="button" data-triage-edit="${escapeAttribute(item.annotation_id)}">Edit</button>
+          <button class="title-button danger" type="button" data-triage-delete="${escapeAttribute(item.annotation_id)}">Delete</button>
+        </div>
+      </div>
+    </div>
+  `;
+}
+
+function triageItemById(annotationId) {
+  return state.triage.items.find((item) => item.annotation_id === annotationId) || null;
+}
+
+async function openTriageItem(annotationId) {
+  const item = triageItemById(annotationId);
+  if (!item) {
+    return null;
+  }
+  state.triage.selectedAnnotationId = item.annotation_id;
+  state.mode = "browse";
+  render();
+  await loadPreviewForPane(
+    item.file_path,
+    state.activePaneId,
+    item.target_kind === "json_path" ? { selectedJsonPath: item.target_path } : {},
+  );
+  return item;
+}
+
+function openTriageEditor(annotationId) {
+  const item = triageItemById(annotationId);
+  if (!item) {
+    return;
+  }
+  state.triage.selectedAnnotationId = item.annotation_id;
+  openModal({
+    paneId: state.activePaneId,
+    file: item.file_path,
+    path: item.target_kind === "file" ? "@file" : item.target_path,
+    annotations: [],
+    annotation: {
+      id: item.annotation_id,
+      created_at: item.created_at,
+      updated_at: item.updated_at,
+      tags: item.tags || [],
+      note: item.note_full,
+    },
+    annotationId: item.annotation_id,
+  });
+}
+
+async function deleteTriageItem(annotationId) {
+  const item = triageItemById(annotationId);
+  if (!item) {
+    return;
+  }
+  await apiJson("/api/annotations", {
+    method: "DELETE",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      file: item.file_path,
+      path: item.target_kind === "file" ? "@file" : item.target_path,
+      annotation_id: item.annotation_id,
+    }),
+  });
+  await loadTriage({ preserveSelection: true });
+  renderWorkspace();
+  renderStatusBar();
 }
 
 function toggleSidebar() {
@@ -1039,6 +1369,31 @@ async function onWorkspaceClick(event) {
   if (event.target.closest("[data-resize-split], [data-resize-pane-col], [data-resize-pane-row]")) {
     return;
   }
+  if (state.mode === "triage") {
+    const triageSelect = event.target.closest("[data-triage-select]");
+    if (triageSelect) {
+      state.triage.selectedAnnotationId = triageSelect.dataset.triageSelect || null;
+      renderWorkspace();
+      renderStatusBar();
+      return;
+    }
+    const triageOpen = event.target.closest("[data-triage-open]");
+    if (triageOpen) {
+      await openTriageItem(triageOpen.dataset.triageOpen || "");
+      return;
+    }
+    const triageEdit = event.target.closest("[data-triage-edit]");
+    if (triageEdit) {
+      openTriageEditor(triageEdit.dataset.triageEdit || "");
+      return;
+    }
+    const triageDelete = event.target.closest("[data-triage-delete]");
+    if (triageDelete) {
+      await deleteTriageItem(triageDelete.dataset.triageDelete || "");
+      return;
+    }
+    return;
+  }
   const closeButton = event.target.closest("[data-close-pane]");
   if (closeButton) {
     closePane(closeButton.dataset.closePane);
@@ -1053,6 +1408,32 @@ async function onWorkspaceClick(event) {
 
   if (paneId) {
     await onPreviewClick(event, paneId);
+  }
+}
+
+function onWorkspaceInput(event) {
+  if (state.mode !== "triage") {
+    return;
+  }
+  const search = event.target.closest("[data-triage-search]");
+  if (search) {
+    state.triage.search = search.value || "";
+    renderWorkspace();
+    renderStatusBar();
+    return;
+  }
+  const tag = event.target.closest("[data-triage-tag]");
+  if (tag) {
+    state.triage.selectedTag = tag.value || "";
+    renderWorkspace();
+    renderStatusBar();
+    return;
+  }
+  const previewKind = event.target.closest("[data-triage-preview-kind]");
+  if (previewKind) {
+    state.triage.selectedPreviewKind = previewKind.value || "";
+    renderWorkspace();
+    renderStatusBar();
   }
 }
 
@@ -1963,6 +2344,9 @@ function selectedAnnotationEntry(pane, annotationPath, annotations) {
   if (!pane || !annotationPath) {
     return annotations[0];
   }
+  if (!pane.selectedAnnotationIds) {
+    pane.selectedAnnotationIds = {};
+  }
   const selectedId = pane.selectedAnnotationIds?.[annotationPath];
   const selected = annotations.find((entry) => entry.id === selectedId) || annotations[0];
   pane.selectedAnnotationIds[annotationPath] = selected.id;
@@ -2002,50 +2386,67 @@ async function onSaveAnnotation(event) {
   if (!state.modal) {
     return;
   }
+  const modal = state.modal;
   const tags = (elements.modalTags?.value || "")
     .split(",")
     .map((tag) => tag.trim())
     .filter(Boolean);
-  await apiJson("/api/annotations", {
+  const response = await apiJson("/api/annotations", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
-      file: state.modal.file,
-      path: state.modal.path,
-      ...(state.modal.annotationId ? { annotation_id: state.modal.annotationId } : {}),
+      file: modal.file,
+      path: modal.path,
+      ...(modal.annotationId ? { annotation_id: modal.annotationId } : {}),
       tags,
       note: elements.modalNote?.value || "",
     }),
   });
-  const pane = paneById(state.modal.paneId);
+  const pane = paneById(modal.paneId);
   const selectedJsonPath = pane?.selectedJsonPath;
   const selectedStepId = pane?.selectedStepId;
-  const paneId = state.modal.paneId;
-  const file = state.modal.file;
+  const paneId = modal.paneId;
+  const file = modal.file;
   closeModal();
-  await globalThis.loadPreviewForPane(file, paneId, { selectedJsonPath, selectedStepId });
+  await loadTriage({
+    preserveSelection: true,
+    preferredAnnotationId: response.annotation?.id || modal.annotationId || null,
+  });
+  if (state.mode === "browse" && paneId && file) {
+    await globalThis.loadPreviewForPane(file, paneId, { selectedJsonPath, selectedStepId });
+  } else {
+    renderWorkspace();
+    renderStatusBar();
+  }
 }
 
 async function onDeleteAnnotation() {
   if (!state.modal) {
     return;
   }
+  const modal = state.modal;
   await apiJson("/api/annotations", {
     method: "DELETE",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
-      file: state.modal.file,
-      path: state.modal.path,
-      annotation_id: state.modal.annotationId,
+      file: modal.file,
+      path: modal.path,
+      annotation_id: modal.annotationId,
     }),
   });
-  const pane = paneById(state.modal.paneId);
+  const pane = paneById(modal.paneId);
   const selectedJsonPath = pane?.selectedJsonPath;
   const selectedStepId = pane?.selectedStepId;
-  const paneId = state.modal.paneId;
-  const file = state.modal.file;
+  const paneId = modal.paneId;
+  const file = modal.file;
   closeModal();
-  await globalThis.loadPreviewForPane(file, paneId, { selectedJsonPath, selectedStepId });
+  await loadTriage({ preserveSelection: true });
+  if (state.mode === "browse" && paneId && file) {
+    await globalThis.loadPreviewForPane(file, paneId, { selectedJsonPath, selectedStepId });
+  } else {
+    renderWorkspace();
+    renderStatusBar();
+  }
 }
 
 function openPalette() {

--- a/src/skim/web/app.js
+++ b/src/skim/web/app.js
@@ -684,10 +684,15 @@ async function openTriageItem(annotationId) {
   state.triage.selectedAnnotationId = item.annotation_id;
   state.mode = "browse";
   render();
+  const options = item.target_kind === "json_path"
+    ? { selectedJsonPath: item.target_path }
+    : item.target_kind === "file"
+      ? { selectedAnnotationPath: "@file", selectedAnnotationId: item.annotation_id }
+      : {};
   await loadPreviewForPane(
     item.file_path,
     state.activePaneId,
-    item.target_kind === "json_path" ? { selectedJsonPath: item.target_path } : {},
+    options,
   );
   return item;
 }
@@ -1574,6 +1579,9 @@ async function loadPreviewForPane(path, paneId, options = {}) {
       initializeWorkbookState(pane);
     } else {
       pane.selectedWorkbookSheetName = null;
+    }
+    if (options.selectedAnnotationPath && options.selectedAnnotationId) {
+      pane.selectedAnnotationIds[options.selectedAnnotationPath] = options.selectedAnnotationId;
     }
     renderTree();
     renderWorkspace();

--- a/src/skim/web/app.js
+++ b/src/skim/web/app.js
@@ -192,6 +192,7 @@ function renderViewToggle() {
   elements.modeBrowse?.setAttribute("aria-pressed", state.mode === "browse" ? "true" : "false");
   elements.modeTriage?.classList.toggle("active", state.mode === "triage");
   elements.modeTriage?.setAttribute("aria-pressed", state.mode === "triage" ? "true" : "false");
+  elements.splitPane?.classList.toggle("hidden", state.mode === "triage");
 }
 
 function renderTree() {
@@ -400,11 +401,11 @@ function renderPaneContent(pane) {
 
   switch (pane.preview.kind) {
     case "text":
-      return renderTextPreview(pane.preview);
+      return renderTextPreview(pane);
     case "markdown":
-      return renderMarkdownPreview(pane.preview);
+      return renderMarkdownPreview(pane);
     case "csv":
-      return renderCsvPreview(pane.preview);
+      return renderCsvPreview(pane);
     case "xlsx":
       return renderXlsxPreview(pane);
     case "json_inspector":
@@ -412,7 +413,7 @@ function renderPaneContent(pane) {
     case "trajectory":
       return renderTrajectoryPreview(pane);
     case "notebook":
-      return renderNotebookPreview(pane.preview);
+      return renderNotebookPreview(pane);
     case "too_large":
     case "error":
       return `<div class="notice">${escapeHtml(pane.preview.message)}</div>`;
@@ -1310,6 +1311,9 @@ function onPreviewPointerDown(event) {
 }
 
 function splitActivePane() {
+  if (state.mode === "triage") {
+    return null;
+  }
   if (state.panes.length >= MAX_PANES) {
     return null;
   }
@@ -1480,6 +1484,9 @@ async function onPreviewClick(event, paneId = state.activePaneId) {
         updateJsonInspectorPreview(paneId);
       } else if (pane.preview?.kind === "trajectory") {
         updateTrajectoryPreview(paneId);
+      } else {
+        renderWorkspace();
+        renderStatusBar();
       }
     }
     return;
@@ -1611,40 +1618,67 @@ function initializeWorkbookState(pane) {
   pane.selectedWorkbookSheetName = preferred.name;
 }
 
+function resolvePreviewInput(input) {
+  if (input?.preview) {
+    return { pane: input, preview: input.preview };
+  }
+  return { pane: null, preview: input };
+}
+
+function renderFileAnnotationPanel(pane, preview) {
+  if (!pane || !preview?.annotation_path) {
+    return "";
+  }
+  const annotations = normalizeAnnotations(preview.annotations, preview.annotation);
+  const selected = selectedAnnotationEntry(pane, preview.annotation_path, annotations);
+  return renderAnnotationPanel(
+    annotations,
+    true,
+    selected ? selected.id : null,
+    pane.id,
+    preview.annotation_path,
+  );
+}
+
 function renderTextPreview(preview) {
+  const ctx = resolvePreviewInput(preview);
   return `
     <div class="preview-card">
       <div class="detail-meta">
-        <span class="path-pill">${escapeHtml(preview.path)}</span>
-        ${preview.language ? `<span class="badge">${escapeHtml(preview.language)}</span>` : ""}
+        <span class="path-pill">${escapeHtml(ctx.preview.path)}</span>
+        ${ctx.preview.language ? `<span class="badge">${escapeHtml(ctx.preview.language)}</span>` : ""}
       </div>
-      ${renderRenderValue(preview.render || { kind: "text", value: preview.content })}
+      ${renderFileAnnotationPanel(ctx.pane, ctx.preview)}
+      ${renderRenderValue(ctx.preview.render || { kind: "text", value: ctx.preview.content })}
     </div>
   `;
 }
 
 function renderMarkdownPreview(preview) {
+  const ctx = resolvePreviewInput(preview);
   return `
     <div class="preview-card">
       <div class="detail-meta">
-        <span class="path-pill">${escapeHtml(preview.path)}</span>
+        <span class="path-pill">${escapeHtml(ctx.preview.path)}</span>
         <span class="badge">markdown</span>
       </div>
-      ${renderMarkdown(preview.content)}
+      ${renderFileAnnotationPanel(ctx.pane, ctx.preview)}
+      ${renderMarkdown(ctx.preview.content)}
     </div>
   `;
 }
 
 function renderCsvPreview(preview) {
-  const table = preview.columns.length
+  const ctx = resolvePreviewInput(preview);
+  const table = ctx.preview.columns.length
     ? `
       <div class="table-wrap">
         <table>
           <thead>
-            <tr>${preview.columns.map((column) => `<th>${escapeHtml(column)}</th>`).join("")}</tr>
+            <tr>${ctx.preview.columns.map((column) => `<th>${escapeHtml(column)}</th>`).join("")}</tr>
           </thead>
           <tbody>
-            ${preview.rows.map((row) => `<tr>${row.map((cell) => `<td>${escapeHtml(cell)}</td>`).join("")}</tr>`).join("")}
+            ${ctx.preview.rows.map((row) => `<tr>${row.map((cell) => `<td>${escapeHtml(cell)}</td>`).join("")}</tr>`).join("")}
           </tbody>
         </table>
       </div>
@@ -1652,22 +1686,23 @@ function renderCsvPreview(preview) {
     : `<p class="selection-subtitle">No tabular rows available.</p>`;
 
   const truncation = [
-    preview.truncated_rows ? "rows truncated" : "",
-    preview.truncated_columns ? "columns truncated" : "",
+    ctx.preview.truncated_rows ? "rows truncated" : "",
+    ctx.preview.truncated_columns ? "columns truncated" : "",
   ].filter(Boolean).join(" · ");
 
   return `
     <div class="preview-card">
       <div class="detail-meta">
-        <span class="path-pill">${escapeHtml(preview.path)}</span>
-        <span class="badge">${escapeHtml(preview.summary)}</span>
-        ${preview.parse_error ? `<span class="badge">${escapeHtml(preview.parse_error)}</span>` : ""}
+        <span class="path-pill">${escapeHtml(ctx.preview.path)}</span>
+        <span class="badge">${escapeHtml(ctx.preview.summary)}</span>
+        ${ctx.preview.parse_error ? `<span class="badge">${escapeHtml(ctx.preview.parse_error)}</span>` : ""}
         ${truncation ? `<span class="badge">${escapeHtml(truncation)}</span>` : ""}
       </div>
+      ${renderFileAnnotationPanel(ctx.pane, ctx.preview)}
       <div class="preview-block">${table}</div>
       <details class="raw-toggle">
         <summary>Raw CSV</summary>
-        ${renderRenderValue(preview.raw_render || { kind: "text", value: preview.raw })}
+        ${renderRenderValue(ctx.preview.raw_render || { kind: "text", value: ctx.preview.raw })}
       </details>
     </div>
   `;
@@ -1725,6 +1760,7 @@ function renderXlsxPreview(pane) {
           <span class="badge">${escapeHtml(preview.summary?.title || "Workbook Preview")}</span>
           <span class="badge">${escapeHtml(`${preview.summary?.sheet_count ?? sheets.length} sheets`)}</span>
         </div>
+        ${renderFileAnnotationPanel(pane, preview)}
       </div>
       ${tabs}
       <section class="preview-card">
@@ -2095,10 +2131,11 @@ function renderTrajectoryItem(item, pane) {
 }
 
 function renderNotebookPreview(preview) {
-  const version = preview.summary.nbformat_minor != null
-    ? `${preview.summary.nbformat}.${preview.summary.nbformat_minor}`
-    : String(preview.summary.nbformat ?? "");
-  const cells = preview.cells || [];
+  const ctx = resolvePreviewInput(preview);
+  const version = ctx.preview.summary.nbformat_minor != null
+    ? `${ctx.preview.summary.nbformat}.${ctx.preview.summary.nbformat_minor}`
+    : String(ctx.preview.summary.nbformat ?? "");
+  const cells = ctx.preview.cells || [];
   const body = cells.length
     ? cells.map(renderNotebookCell).join("")
     : `<div class="preview-card"><div class="selection-subtitle">Empty notebook.</div></div>`;
@@ -2108,11 +2145,12 @@ function renderNotebookPreview(preview) {
       <section class="preview-card">
         <div class="notebook-title">Notebook Preview</div>
         <div class="notebook-meta">
-          <span class="badge">${escapeHtml(preview.path)}</span>
-          <span class="badge">${escapeHtml(`${preview.summary.cell_count} cells`)}</span>
+          <span class="badge">${escapeHtml(ctx.preview.path)}</span>
+          <span class="badge">${escapeHtml(`${ctx.preview.summary.cell_count} cells`)}</span>
           ${version ? `<span class="badge">nbformat ${escapeHtml(version)}</span>` : ""}
-          <span class="badge">${escapeHtml(preview.language || "python")}</span>
+          <span class="badge">${escapeHtml(ctx.preview.language || "python")}</span>
         </div>
+        ${renderFileAnnotationPanel(ctx.pane, ctx.preview)}
       </section>
       ${body}
     </div>

--- a/src/skim/web/app.js
+++ b/src/skim/web/app.js
@@ -551,6 +551,22 @@ function triagePreviewKindOptions() {
   return Array.from(kinds).sort((left, right) => left.localeCompare(right));
 }
 
+function groupedTriageItems(items) {
+  const groups = new Map();
+  for (const item of items) {
+    if (!groups.has(item.file_path)) {
+      groups.set(item.file_path, []);
+    }
+    groups.get(item.file_path).push(item);
+  }
+  return Array.from(groups.entries()).map(([file_path, groupedItems]) => ({
+    file_path,
+    preview_kind: groupedItems[0]?.preview_kind || "",
+    updated_at: groupedItems[0]?.updated_at || "",
+    items: groupedItems,
+  }));
+}
+
 function renderTriageView() {
   const visible = visibleTriageItems();
   const selected = selectedTriageItem();
@@ -594,19 +610,30 @@ function renderTriageQueue(items) {
   if (!items.length) {
     return `<div class="empty-state"><div><div class="empty-mark">◇</div><div>No annotations match the current filters.</div></div></div>`;
   }
+  const groups = groupedTriageItems(items);
   return `
-    <div class="triage-list">
-      ${items.map((item) => `
-        <button class="triage-row ${item.annotation_id === state.triage.selectedAnnotationId ? "selected" : ""}" type="button" data-triage-select="${escapeAttribute(item.annotation_id)}" data-triage-open="${escapeAttribute(item.annotation_id)}">
-          <div class="triage-row-head">
-            <span class="badge">${escapeHtml(item.preview_kind)}</span>
-            <span class="triage-file">${escapeHtml(item.file_path)}</span>
-            <span class="triage-time">${escapeHtml(formatAnnotationTimestamp(item.updated_at))}</span>
+    <div class="triage-file-groups">
+      ${groups.map((group) => `
+        <section class="triage-file-group">
+          <div class="triage-file-group-header">
+            <div class="triage-row-head">
+              <span class="triage-file">${escapeHtml(group.file_path)}</span>
+              <span class="badge">${escapeHtml(group.preview_kind)}</span>
+            </div>
+            <div class="triage-file-group-meta">
+              <span>${escapeHtml(`${group.items.length} item${group.items.length === 1 ? "" : "s"}`)}</span>
+              <span>${escapeHtml(formatAnnotationTimestamp(group.updated_at))}</span>
+            </div>
           </div>
-          <div class="triage-target">${escapeHtml(item.target_label || "File")}</div>
-          <div class="triage-note">${escapeHtml(item.note_preview || "(empty)")}</div>
-          <div class="annotation-tags">${(item.tags || []).map((tag) => `<span class="annotation-tag">${escapeHtml(tag)}</span>`).join("")}</div>
-        </button>
+          <div class="triage-annotation-list">
+            ${group.items.map((item) => `
+              <button class="triage-annotation-row ${item.annotation_id === state.triage.selectedAnnotationId ? "selected" : ""}" type="button" data-triage-select="${escapeAttribute(item.annotation_id)}">
+                <div class="triage-target">${escapeHtml(item.target_label || "File")}</div>
+                <div class="triage-note">${escapeHtml(item.note_preview || "(empty)")}</div>
+              </button>
+            `).join("")}
+          </div>
+        </section>
       `).join("")}
     </div>
   `;
@@ -2810,3 +2837,4 @@ globalThis.isStackedLayout = isStackedLayout;
 globalThis.canResizePaneLayout = canResizePaneLayout;
 globalThis.canResizeSplitViews = canResizeSplitViews;
 globalThis.onWorkspaceClick = onWorkspaceClick;
+globalThis.groupedTriageItems = groupedTriageItems;

--- a/src/skim/web/index.html
+++ b/src/skim/web/index.html
@@ -17,6 +17,10 @@
       </div>
     </div>
     <div class="title-actions">
+      <div class="view-toggle" role="group" aria-label="View mode">
+        <button class="title-button" id="mode-browse" type="button" aria-pressed="true">Browse</button>
+        <button class="title-button" id="mode-triage" type="button" aria-pressed="false">Triage</button>
+      </div>
       <button class="title-button search-button" id="palette-toggle" type="button">Search ⌘K</button>
       <button class="title-button" id="split-pane" type="button">Split</button>
       <button class="title-button" id="theme-toggle" type="button" aria-label="Toggle theme">◐</button>

--- a/src/skim/web/styles.css
+++ b/src/skim/web/styles.css
@@ -128,14 +128,16 @@ body {
 body,
 button,
 input,
-textarea {
+textarea,
+select {
   font-family: var(--font-mono);
   font-size: 13px;
 }
 
 button,
 input,
-textarea {
+textarea,
+select {
   font: inherit;
 }
 
@@ -200,6 +202,11 @@ button {
   min-width: 0;
 }
 
+.view-toggle {
+  display: inline-flex;
+  gap: 6px;
+}
+
 .status-left,
 .status-right {
   color: var(--fg-secondary);
@@ -241,6 +248,11 @@ button {
   color: var(--fg-primary);
 }
 
+.title-button.active {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
 .title-button:hover,
 .solid-button:hover,
 .tree-row:hover,
@@ -272,6 +284,10 @@ button {
   overflow: hidden;
 }
 
+.workspace.triage-mode {
+  grid-template-columns: minmax(0, 1fr);
+}
+
 .workspace.sidebar-hidden {
   grid-template-columns: 0 0 minmax(0, 1fr);
 }
@@ -285,6 +301,11 @@ button {
 }
 
 .workspace.sidebar-hidden .sidebar {
+  display: none;
+}
+
+.workspace.triage-mode .sidebar,
+.workspace.triage-mode .sidebar-resizer {
   display: none;
 }
 
@@ -385,6 +406,74 @@ button {
   min-height: 0;
   height: 100%;
   overflow: hidden;
+}
+
+.triage-shell {
+  height: 100%;
+  display: grid;
+  grid-template-columns: minmax(220px, 0.8fr) minmax(320px, 1.2fr) minmax(320px, 1.2fr);
+  gap: 12px;
+  padding: 12px;
+}
+
+.triage-panel {
+  min-height: 0;
+  overflow: auto;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-secondary);
+  padding: 12px;
+}
+
+.triage-summary {
+  color: var(--fg-secondary);
+}
+
+.triage-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.triage-row {
+  width: 100%;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-surface);
+  color: inherit;
+  text-align: left;
+  padding: 10px;
+}
+
+.triage-row.selected {
+  border-color: var(--accent);
+  background: var(--bg-highlight);
+}
+
+.triage-row-head,
+.triage-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.triage-file {
+  flex: 1;
+  min-width: 0;
+}
+
+.triage-time,
+.triage-target {
+  color: var(--fg-secondary);
+}
+
+.triage-note {
+  margin: 6px 0;
+}
+
+.triage-detail-stack {
+  gap: 10px;
 }
 
 .pane-grid {

--- a/src/skim/web/styles.css
+++ b/src/skim/web/styles.css
@@ -429,25 +429,34 @@ button {
   color: var(--fg-secondary);
 }
 
-.triage-list {
+.triage-file-groups {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 12px;
 }
 
-.triage-row {
-  width: 100%;
+.triage-file-group {
   border: 1px solid var(--border);
   border-radius: 6px;
   background: var(--bg-surface);
-  color: inherit;
-  text-align: left;
-  padding: 10px;
+  overflow: hidden;
 }
 
-.triage-row.selected {
-  border-color: var(--accent);
-  background: var(--bg-highlight);
+.triage-file-group-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 10px;
+  padding: 10px;
+  border-bottom: 1px solid var(--border-subtle);
+  background: var(--bg-secondary);
+}
+
+.triage-file-group-meta {
+  display: flex;
+  gap: 10px;
+  color: var(--fg-secondary);
+  font-size: 13px;
 }
 
 .triage-row-head,
@@ -463,13 +472,36 @@ button {
   min-width: 0;
 }
 
-.triage-time,
+.triage-annotation-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.triage-annotation-row {
+  width: 100%;
+  border: 0;
+  border-top: 1px solid var(--border-subtle);
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  padding: 10px;
+}
+
+.triage-annotation-row:first-child {
+  border-top: 0;
+}
+
+.triage-annotation-row.selected {
+  background: var(--bg-highlight);
+}
+
 .triage-target {
   color: var(--fg-secondary);
+  font-size: 13px;
 }
 
 .triage-note {
-  margin: 6px 0;
+  margin: 4px 0 0;
 }
 
 .triage-detail-stack {

--- a/src/skim/web_preview.py
+++ b/src/skim/web_preview.py
@@ -36,9 +36,9 @@ from .preview import (
     _notebook_text,
     _parse_csv,
 )
+from .review import FILE_ANNOTATION_KEY, AnnotationStore
 from .trajectory import (
     AnnotationRecord,
-    AnnotationStore,
     JsonInspectorItem,
     _bundle_summary,
     _decode_nested_json,
@@ -86,6 +86,7 @@ def serialize_preview(
     resolved = path.resolve()
     root = (browse_root or resolved.parent).resolve()
     relative_path = _relative_path(resolved, root)
+    store = annotation_store or AnnotationStore(root)
 
     if not resolved.is_file():
         return {
@@ -111,7 +112,11 @@ def serialize_preview(
         }
 
     if suffix in XLSX_EXTENSIONS:
-        return _serialize_xlsx_file(resolved, relative_path=relative_path)
+        return _with_file_annotation_payload(
+            _serialize_xlsx_file(resolved, relative_path=relative_path),
+            source_path=resolved,
+            annotation_store=store,
+        )
 
     try:
         content = resolved.read_text(errors="replace")
@@ -124,18 +129,23 @@ def serialize_preview(
         }
 
     if suffix in MARKDOWN_EXTENSIONS:
-        return {
-            "kind": "markdown",
-            "name": resolved.name,
-            "path": relative_path,
-            "content": content,
-        }
+        return _with_file_annotation_payload(
+            {
+                "kind": "markdown",
+                "name": resolved.name,
+                "path": relative_path,
+                "content": content,
+            },
+            source_path=resolved,
+            annotation_store=store,
+        )
 
     if suffix in NOTEBOOK_EXTENSIONS:
         return _serialize_notebook_file(
             content,
             source_path=resolved,
             relative_path=relative_path,
+            annotation_store=store,
         )
 
     if suffix in JSON_EXTENSIONS:
@@ -143,22 +153,30 @@ def serialize_preview(
             content,
             source_path=resolved,
             review_root=root,
-            annotation_store=annotation_store,
+            annotation_store=store,
             relative_path=relative_path,
         )
 
     if suffix == ".csv":
-        return _serialize_csv_preview(
-            content,
-            name=resolved.name,
-            relative_path=relative_path,
+        return _with_file_annotation_payload(
+            _serialize_csv_preview(
+                content,
+                name=resolved.name,
+                relative_path=relative_path,
+            ),
+            source_path=resolved,
+            annotation_store=store,
         )
 
-    return _text_payload(
-        resolved.name,
-        relative_path,
-        content,
-        language=SYNTAX_MAP.get(suffix),
+    return _with_file_annotation_payload(
+        _text_payload(
+            resolved.name,
+            relative_path,
+            content,
+            language=SYNTAX_MAP.get(suffix),
+        ),
+        source_path=resolved,
+        annotation_store=store,
     )
 
 
@@ -232,6 +250,7 @@ def _serialize_notebook_file(
     *,
     source_path: Path,
     relative_path: str,
+    annotation_store: AnnotationStore,
 ) -> dict[str, Any]:
     try:
         parsed = json.loads(content)
@@ -255,6 +274,8 @@ def _serialize_notebook_file(
         parsed,
         name=source_path.name,
         relative_path=relative_path,
+        source_path=source_path,
+        annotation_store=annotation_store,
     )
 
 
@@ -263,6 +284,8 @@ def _serialize_notebook_preview(
     *,
     name: str,
     relative_path: str,
+    source_path: Path,
+    annotation_store: AnnotationStore,
 ) -> dict[str, Any]:
     cells = notebook.get("cells")
     if not isinstance(cells, list):
@@ -276,19 +299,23 @@ def _serialize_notebook_preview(
         for index, cell in enumerate(cells, start=1)
     ]
 
-    return {
-        "kind": "notebook",
-        "name": name,
-        "path": relative_path,
-        "language": language,
-        "summary": {
-            "title": "Notebook Preview",
-            "cell_count": len(cells),
-            "nbformat": nbformat,
-            "nbformat_minor": nbformat_minor,
+    return _with_file_annotation_payload(
+        {
+            "kind": "notebook",
+            "name": name,
+            "path": relative_path,
+            "language": language,
+            "summary": {
+                "title": "Notebook Preview",
+                "cell_count": len(cells),
+                "nbformat": nbformat,
+                "nbformat_minor": nbformat_minor,
+            },
+            "cells": serialized_cells,
         },
-        "cells": serialized_cells,
-    }
+        source_path=source_path,
+        annotation_store=annotation_store,
+    )
 
 
 def _serialize_notebook_cell(cell: Any, *, index: int, language: str) -> dict[str, Any]:
@@ -859,6 +886,27 @@ def _text_payload(
         "content": content,
         "render": _syntax_payload(content, language=language, line_numbers=True),
     }
+
+
+def _with_file_annotation_payload(
+    payload: dict[str, Any],
+    *,
+    source_path: Path,
+    annotation_store: AnnotationStore,
+) -> dict[str, Any]:
+    """Attach file-level annotation metadata to non-JSON preview payloads."""
+    annotations = annotation_store.annotations_for_path(source_path, FILE_ANNOTATION_KEY)
+    serialized = [_annotation_payload(record) for record in annotations]
+    payload.update(
+        {
+            "annotatable": True,
+            "annotation_path": FILE_ANNOTATION_KEY,
+            "annotations": serialized,
+            "annotation": serialized[0] if serialized else None,
+            "annotation_count": len(serialized),
+        }
+    )
+    return payload
 
 
 def _detail_payload_for_item(item: JsonInspectorItem) -> dict[str, Any]:

--- a/src/skim/web_preview.py
+++ b/src/skim/web_preview.py
@@ -255,19 +255,27 @@ def _serialize_notebook_file(
     try:
         parsed = json.loads(content)
     except json.JSONDecodeError:
-        return _text_payload(
-            source_path.name,
-            relative_path,
-            content,
-            language="json",
+        return _with_file_annotation_payload(
+            _text_payload(
+                source_path.name,
+                relative_path,
+                content,
+                language="json",
+            ),
+            source_path=source_path,
+            annotation_store=annotation_store,
         )
 
     if not _looks_like_notebook(parsed):
-        return _text_payload(
-            source_path.name,
-            relative_path,
-            content,
-            language="json",
+        return _with_file_annotation_payload(
+            _text_payload(
+                source_path.name,
+                relative_path,
+                content,
+                language="json",
+            ),
+            source_path=source_path,
+            annotation_store=annotation_store,
         )
 
     return _serialize_notebook_preview(

--- a/tests/test_app_shell.py
+++ b/tests/test_app_shell.py
@@ -21,6 +21,55 @@ async def test_app_launches():
         assert app.grid == [["pane-0"]]
 
 
+async def test_app_launches_in_triage_mode():
+    """The triage flag should start skim in the dedicated triage view."""
+    app = SkimApp(path=".", triage=True)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        assert app.app_mode == "triage"
+        assert app.query_one("#triage-queue", Static).has_focus
+
+
+async def test_triage_enter_opens_selected_item_in_browse_mode(tmp_path):
+    """Enter in triage mode should open the selected file back into browse."""
+    review_file = tmp_path / ".skim" / "review.json"
+    review_file.parent.mkdir()
+    review_file.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "files": {
+                    "plain.json": {
+                        "annotations": {
+                            "$.hello": [
+                                {
+                                    "id": "ann-1",
+                                    "created_at": "2026-04-21T14:00:00Z",
+                                    "updated_at": "2026-04-21T14:05:00Z",
+                                    "tags": ["important"],
+                                    "note": "keep this",
+                                }
+                            ]
+                        }
+                    }
+                },
+            }
+        )
+    )
+    (tmp_path / "plain.json").write_text(json.dumps({"hello": "world"}))
+    app = SkimApp(path=str(tmp_path), triage=True)
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await pilot.press("enter")
+        await pilot.pause()
+
+        pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
+        assert app.app_mode == "browse"
+        assert pane.current_path == tmp_path / "plain.json"
+
+
 async def test_split_right():
     """Pressing s then right creates a second pane."""
     app = SkimApp(path=".")

--- a/tests/test_app_shell.py
+++ b/tests/test_app_shell.py
@@ -266,6 +266,77 @@ async def test_triage_down_moves_selection_exactly_one_item(tmp_path):
         assert app.triage_selected_annotation_id == "ann-result"
 
 
+async def test_triage_selection_follows_grouped_render_order_across_files(tmp_path):
+    """Triage movement should follow the grouped queue order, not the flat payload order."""
+    review_file = tmp_path / ".skim" / "review.json"
+    review_file.parent.mkdir()
+    review_file.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "files": {
+                    "a.md": {
+                        "annotations": {
+                            "@file": [
+                                {
+                                    "id": "a-newer",
+                                    "created_at": "2026-04-21T14:40:00Z",
+                                    "updated_at": "2026-04-21T14:40:00Z",
+                                    "tags": ["one"],
+                                    "note": "a newer",
+                                },
+                                {
+                                    "id": "a-older",
+                                    "created_at": "2026-04-21T14:10:00Z",
+                                    "updated_at": "2026-04-21T14:10:00Z",
+                                    "tags": ["two"],
+                                    "note": "a older",
+                                },
+                            ]
+                        }
+                    },
+                    "b.md": {
+                        "annotations": {
+                            "@file": [
+                                {
+                                    "id": "b-newer",
+                                    "created_at": "2026-04-21T14:30:00Z",
+                                    "updated_at": "2026-04-21T14:30:00Z",
+                                    "tags": ["three"],
+                                    "note": "b newer",
+                                },
+                                {
+                                    "id": "b-older",
+                                    "created_at": "2026-04-21T14:20:00Z",
+                                    "updated_at": "2026-04-21T14:20:00Z",
+                                    "tags": ["four"],
+                                    "note": "b older",
+                                },
+                            ]
+                        }
+                    },
+                },
+            }
+        )
+    )
+    (tmp_path / "a.md").write_text("# A\n")
+    (tmp_path / "b.md").write_text("# B\n")
+    app = SkimApp(path=str(tmp_path), triage=True)
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        assert app.triage_selected_annotation_id == "a-newer"
+
+        await pilot.press("down")
+        await pilot.pause()
+        assert app.triage_selected_annotation_id == "a-older"
+
+        await pilot.press("down")
+        await pilot.pause()
+        assert app.triage_selected_annotation_id == "b-newer"
+
+
 async def test_triage_does_not_enter_split_mode(tmp_path):
     """Split mode should stay disabled while the triage shell is active."""
     review_file = tmp_path / ".skim" / "review.json"

--- a/tests/test_app_shell.py
+++ b/tests/test_app_shell.py
@@ -208,6 +208,109 @@ async def test_triage_queue_groups_annotations_by_file(tmp_path):
         assert "result summary" in content
 
 
+async def test_triage_down_moves_selection_exactly_one_item(tmp_path):
+    """One down-arrow press in triage should advance by exactly one annotation."""
+    review_file = tmp_path / ".skim" / "review.json"
+    review_file.parent.mkdir()
+    review_file.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "files": {
+                    "output.json": {
+                        "annotations": {
+                            "$.task": [
+                                {
+                                    "id": "ann-task",
+                                    "created_at": "2026-04-21T14:10:00Z",
+                                    "updated_at": "2026-04-21T14:15:00Z",
+                                    "tags": ["bug"],
+                                    "note": "task summary",
+                                }
+                            ],
+                            "$.result": [
+                                {
+                                    "id": "ann-result",
+                                    "created_at": "2026-04-21T14:20:00Z",
+                                    "updated_at": "2026-04-21T14:25:00Z",
+                                    "tags": ["followup"],
+                                    "note": "result summary",
+                                }
+                            ],
+                            "$.other": [
+                                {
+                                    "id": "ann-other",
+                                    "created_at": "2026-04-21T14:30:00Z",
+                                    "updated_at": "2026-04-21T14:35:00Z",
+                                    "tags": ["later"],
+                                    "note": "other summary",
+                                }
+                            ],
+                        }
+                    }
+                },
+            }
+        )
+    )
+    (tmp_path / "output.json").write_text(json.dumps({"task": "x", "result": "y", "other": "z"}))
+    app = SkimApp(path=str(tmp_path), triage=True)
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        assert app.triage_selected_annotation_id == "ann-other"
+
+        await pilot.press("down")
+        await pilot.pause()
+
+        assert app.triage_selected_annotation_id == "ann-result"
+
+
+async def test_triage_does_not_enter_split_mode(tmp_path):
+    """Split mode should stay disabled while the triage shell is active."""
+    review_file = tmp_path / ".skim" / "review.json"
+    review_file.parent.mkdir()
+    review_file.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "files": {
+                    "notes.md": {
+                        "annotations": {
+                            "@file": [
+                                {
+                                    "id": "ann-file",
+                                    "created_at": "2026-04-21T14:00:00Z",
+                                    "updated_at": "2026-04-21T14:05:00Z",
+                                    "tags": ["important"],
+                                    "note": "rollout wording",
+                                }
+                            ]
+                        }
+                    }
+                },
+            }
+        )
+    )
+    (tmp_path / "notes.md").write_text("# Notes\n")
+    app = SkimApp(path=str(tmp_path), triage=True)
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        await pilot.press("s")
+        await pilot.pause()
+
+        assert not app.split_mode
+        assert app._total_panes() == 1
+
+        await pilot.press("right")
+        await pilot.pause()
+
+        assert not app.split_mode
+        assert app._total_panes() == 1
+
+
 async def test_split_right():
     """Pressing s then right creates a second pane."""
     app = SkimApp(path=".")

--- a/tests/test_app_shell.py
+++ b/tests/test_app_shell.py
@@ -85,6 +85,59 @@ async def test_triage_enter_opens_selected_item_in_browse_mode(tmp_path):
         assert pane.current_path == tmp_path / "plain.json"
 
 
+async def test_triage_enter_preserves_selected_file_annotation(tmp_path):
+    """Opening a file-level triage item should keep that annotation selected in browse."""
+    review_file = tmp_path / ".skim" / "review.json"
+    review_file.parent.mkdir()
+    review_file.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "files": {
+                    "notes.md": {
+                        "annotations": {
+                            "@file": [
+                                {
+                                    "id": "older",
+                                    "created_at": "2026-04-21T14:00:00Z",
+                                    "updated_at": "2026-04-21T14:00:00Z",
+                                    "tags": ["older"],
+                                    "note": "older note",
+                                },
+                                {
+                                    "id": "newer",
+                                    "created_at": "2026-04-21T14:05:00Z",
+                                    "updated_at": "2026-04-21T14:05:00Z",
+                                    "tags": ["newer"],
+                                    "note": "newer note",
+                                },
+                            ]
+                        }
+                    }
+                },
+            }
+        )
+    )
+    (tmp_path / "notes.md").write_text("# Notes\n")
+    app = SkimApp(path=str(tmp_path), triage=True)
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        assert app.triage_selected_annotation_id == "newer"
+
+        await pilot.press("down")
+        await pilot.pause()
+        await pilot.press("enter")
+        await pilot.pause()
+
+        pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
+        annotations = app.review_store.annotations_for_path(tmp_path / "notes.md", "@file")
+        assert pane.current_path == tmp_path / "notes.md"
+        assert pane.selected_file_annotation_id(annotations) == "older"
+        assert "Note: older note" in _static_content(pane.query(Static).first()).plain
+
+
 async def test_triage_toggle_returns_to_selected_queue_item(tmp_path):
     """Returning to triage should preserve the queue selection from the prior open."""
     review_file = tmp_path / ".skim" / "review.json"

--- a/tests/test_app_shell.py
+++ b/tests/test_app_shell.py
@@ -31,6 +31,21 @@ async def test_app_launches_in_triage_mode():
         assert app.query_one("#triage-queue", Static).has_focus
 
 
+async def test_app_uses_custom_titlebar_instead_of_textual_header():
+    """The app should use skim-owned chrome instead of Textual's settings header."""
+    app = SkimApp(path=".")
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        assert len(app.query("Header")) == 0
+        titlebar = app.query_one("#app-titlebar", Static)
+        content = _static_content(titlebar)
+        assert isinstance(content, str)
+        assert "skim" in content
+        assert "Browse" in content
+
+
 async def test_triage_enter_opens_selected_item_in_browse_mode(tmp_path):
     """Enter in triage mode should open the selected file back into browse."""
     review_file = tmp_path / ".skim" / "review.json"
@@ -68,6 +83,129 @@ async def test_triage_enter_opens_selected_item_in_browse_mode(tmp_path):
         pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
         assert app.app_mode == "browse"
         assert pane.current_path == tmp_path / "plain.json"
+
+
+async def test_triage_toggle_returns_to_selected_queue_item(tmp_path):
+    """Returning to triage should preserve the queue selection from the prior open."""
+    review_file = tmp_path / ".skim" / "review.json"
+    review_file.parent.mkdir()
+    review_file.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "files": {
+                    "docs/spec.md": {
+                        "annotations": {
+                            "@file": [
+                                {
+                                    "id": "ann-file",
+                                    "created_at": "2026-04-21T14:00:00Z",
+                                    "updated_at": "2026-04-21T14:05:00Z",
+                                    "tags": ["important"],
+                                    "note": "rollout wording",
+                                }
+                            ]
+                        }
+                    }
+                },
+            }
+        )
+    )
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "spec.md").write_text("# Spec\n")
+    app = SkimApp(path=str(tmp_path), triage=True)
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert app.app_mode == "browse"
+
+        await pilot.press("t")
+        await pilot.pause()
+
+        queue = app.query_one("#triage-queue", Static)
+        content = _static_content(queue)
+        assert app.app_mode == "triage"
+        assert "ann-file" not in content
+        assert "docs/spec.md" in content
+        assert "> File" in content
+        assert app.triage_selected_annotation_id == "ann-file"
+
+
+async def test_browse_shortcut_restores_browser_without_resetting_active_pane(tmp_path):
+    """Switching through triage should preserve the current browse pane content."""
+    test_file = tmp_path / "hello.txt"
+    test_file.write_text("hello world")
+    app = SkimApp(path=str(tmp_path))
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
+        pane.show_file(test_file)
+        await pilot.pause()
+
+        await pilot.press("t")
+        await pilot.pause()
+        assert app.app_mode == "triage"
+
+        await pilot.press("b")
+        await pilot.pause()
+
+        assert app.app_mode == "browse"
+        assert pane.current_path == test_file
+
+
+async def test_triage_queue_groups_annotations_by_file(tmp_path):
+    """The TUI triage queue should group visible annotations under one file header."""
+    review_file = tmp_path / ".skim" / "review.json"
+    review_file.parent.mkdir()
+    review_file.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "files": {
+                    "output.json": {
+                        "annotations": {
+                            "$.task": [
+                                {
+                                    "id": "ann-task",
+                                    "created_at": "2026-04-21T14:10:00Z",
+                                    "updated_at": "2026-04-21T14:15:00Z",
+                                    "tags": ["bug"],
+                                    "note": "task summary",
+                                }
+                            ],
+                            "$.result": [
+                                {
+                                    "id": "ann-result",
+                                    "created_at": "2026-04-21T14:20:00Z",
+                                    "updated_at": "2026-04-21T14:25:00Z",
+                                    "tags": ["followup"],
+                                    "note": "result summary",
+                                }
+                            ],
+                        }
+                    }
+                },
+            }
+        )
+    )
+    (tmp_path / "output.json").write_text(json.dumps({"task": "x", "result": "y"}))
+    app = SkimApp(path=str(tmp_path), triage=True)
+
+    async with app.run_test() as pilot:
+        await pilot.pause()
+
+        queue = app.query_one("#triage-queue", Static)
+        content = _static_content(queue)
+
+        assert content.count("output.json") == 1
+        assert "$.task" in content
+        assert "$.result" in content
+        assert "task summary" in content
+        assert "result summary" in content
 
 
 async def test_split_right():

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -1426,10 +1426,7 @@ async def test_non_json_file_annotation_modal_saves_file_level_annotation(tmp_pa
 
         payload = json.loads((tmp_path / ".skim" / "review.json").read_text())
         saved = payload["files"]["note.md"]["annotations"][FILE_ANNOTATION_KEY]
-        pane_text = "\n".join(
-            str(_static_content(widget))
-            for widget in pane.query(Static)
-        )
+        pane_text = "\n".join(str(_static_content(widget)) for widget in pane.query(Static))
         assert len(saved) == 1
         assert saved[0]["tags"] == ["important"]
         assert saved[0]["note"] == "Review the whole file."

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -1433,6 +1433,195 @@ async def test_non_json_file_annotation_modal_saves_file_level_annotation(tmp_pa
         assert "File Annotation" in pane_text
 
 
+async def test_non_json_file_annotations_support_multiple_entries_and_selection_mode(tmp_path):
+    """Non-JSON previews should list and select multiple file annotations like JSON nodes."""
+    test_file = tmp_path / "note.md"
+    test_file.write_text("# Note\n")
+    review_file = tmp_path / ".skim" / "review.json"
+    review_file.parent.mkdir()
+    review_file.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "files": {
+                    "note.md": {
+                        "annotations": {
+                            FILE_ANNOTATION_KEY: [
+                                {
+                                    "id": "older",
+                                    "created_at": "2026-04-20T10:00:00Z",
+                                    "updated_at": "2026-04-20T10:00:00Z",
+                                    "tags": ["important"],
+                                    "note": "older file note",
+                                },
+                                {
+                                    "id": "newer",
+                                    "created_at": "2026-04-20T11:00:00Z",
+                                    "updated_at": "2026-04-20T11:30:00Z",
+                                    "tags": ["followup"],
+                                    "note": "newer file note",
+                                },
+                            ]
+                        }
+                    }
+                },
+            }
+        )
+    )
+    app = SkimApp(path=str(tmp_path))
+
+    async with app.run_test() as pilot:
+        pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
+        pane.show_file(test_file)
+        await pilot.pause()
+
+        annotation = "\n".join(str(_static_content(widget)) for widget in pane.query(Static))
+        assert "2 annotations" in annotation
+        assert "newer file note" in annotation
+
+        await pilot.press("enter")
+        await pilot.pause()
+        await pilot.press("down")
+        await pilot.pause()
+
+        annotation = "\n".join(str(_static_content(widget)) for widget in pane.query(Static))
+        assert "▶ 2." in annotation
+        assert "Note: older file note" in annotation
+
+
+async def test_non_json_file_annotation_selection_mode_edits_selected_entry(tmp_path):
+    """Enter from file-annotation selection mode should edit the selected older entry."""
+    test_file = tmp_path / "note.md"
+    test_file.write_text("# Note\n")
+    review_file = tmp_path / ".skim" / "review.json"
+    review_file.parent.mkdir()
+    review_file.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "files": {
+                    "note.md": {
+                        "annotations": {
+                            FILE_ANNOTATION_KEY: [
+                                {
+                                    "id": "older",
+                                    "created_at": "2026-04-20T10:00:00Z",
+                                    "updated_at": "2026-04-20T10:00:00Z",
+                                    "tags": ["important"],
+                                    "note": "older file note",
+                                },
+                                {
+                                    "id": "newer",
+                                    "created_at": "2026-04-20T11:00:00Z",
+                                    "updated_at": "2026-04-20T11:30:00Z",
+                                    "tags": ["followup"],
+                                    "note": "newer file note",
+                                },
+                            ]
+                        }
+                    }
+                },
+            }
+        )
+    )
+    app = SkimApp(path=str(tmp_path))
+
+    async with app.run_test() as pilot:
+        pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
+        pane.show_file(test_file)
+        await pilot.pause()
+
+        await pilot.press("enter")
+        await pilot.press("down")
+        await pilot.pause()
+        await pilot.press("enter")
+        await pilot.pause()
+
+        tags = app.screen.query_one("#annotation-tags", Input)
+        note = app.screen.query_one("#annotation-note", TextArea)
+        assert tags.value == "important"
+        assert note.text == "older file note"
+
+        note.load_text("older file note updated")
+        app.screen.action_save()
+        await pilot.pause()
+
+        payload = json.loads(review_file.read_text())
+        saved = payload["files"]["note.md"]["annotations"][FILE_ANNOTATION_KEY]
+        older = next(annotation for annotation in saved if annotation["id"] == "older")
+        assert older["note"] == "older file note updated"
+        annotation = "\n".join(str(_static_content(widget)) for widget in pane.query(Static))
+        assert "Note: older file note updated" in annotation
+
+
+async def test_non_json_file_annotation_add_and_delete_keep_selection_sensible(tmp_path):
+    """Deleting and adding file annotations should preserve a sensible selected entry."""
+    test_file = tmp_path / "note.md"
+    test_file.write_text("# Note\n")
+    review_file = tmp_path / ".skim" / "review.json"
+    review_file.parent.mkdir()
+    review_file.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "files": {
+                    "note.md": {
+                        "annotations": {
+                            FILE_ANNOTATION_KEY: [
+                                {
+                                    "id": "older",
+                                    "created_at": "2026-04-20T10:00:00Z",
+                                    "updated_at": "2026-04-20T10:00:00Z",
+                                    "tags": ["important"],
+                                    "note": "older file note",
+                                },
+                                {
+                                    "id": "newer",
+                                    "created_at": "2026-04-20T11:00:00Z",
+                                    "updated_at": "2026-04-20T11:30:00Z",
+                                    "tags": ["followup"],
+                                    "note": "newer file note",
+                                },
+                            ]
+                        }
+                    }
+                },
+            }
+        )
+    )
+    app = SkimApp(path=str(tmp_path))
+
+    async with app.run_test() as pilot:
+        pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
+        pane.show_file(test_file)
+        await pilot.pause()
+
+        await pilot.press("enter")
+        await pilot.press("down")
+        await pilot.pause()
+        await pilot.press("enter")
+        await pilot.pause()
+        app.screen.action_delete()
+        await pilot.pause()
+
+        annotation = "\n".join(str(_static_content(widget)) for widget in pane.query(Static))
+        assert "older file note" not in annotation
+        assert "▶ 1." in annotation
+        assert "Note: newer file note" in annotation
+
+        await pilot.press("a")
+        await pilot.pause()
+        app.screen.query_one("#annotation-tags", Input).value = "fresh"
+        app.screen.query_one("#annotation-note", TextArea).load_text("brand new file note")
+        app.screen.action_save()
+        await pilot.pause()
+
+        annotation = "\n".join(str(_static_content(widget)) for widget in pane.query(Static))
+        assert "brand new file note" in annotation
+        assert "▶ 1." in annotation
+        assert "Note: brand new file note" in annotation
+
+
 async def test_json_inspector_footer_shows_live_preview_controls(tmp_path):
     """The JSON footer should describe the always-visible detail model."""
     test_file = tmp_path / "plain.json"

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -28,6 +28,7 @@ from textual.widgets import Collapsible, Input, Markdown, Static, TextArea, Tree
 import skim.trajectory as trajectory_module
 from skim import JsonInspector, PreviewPane, SkimApp, render_file
 from skim.preview import CsvPreview, XlsxPreview, _xlsx_sheet_preview_data
+from skim.review import FILE_ANNOTATION_KEY
 from skim.scrolling import FocusableDetailWrap
 from skim.trajectory import AnnotationStore
 
@@ -1400,6 +1401,39 @@ async def test_annotation_modal_blocks_tree_and_pane_shortcuts(tmp_path):
         assert inspector._tree.cursor_node is first_node
         assert inspector._tree.cursor_node is not second_node
         assert app.active_pane_id == active_before
+
+
+async def test_non_json_file_annotation_modal_saves_file_level_annotation(tmp_path):
+    """Pressing a on a non-JSON preview should save a file-level annotation."""
+    test_file = tmp_path / "note.md"
+    test_file.write_text("# Note\n")
+    app = SkimApp(path=str(tmp_path))
+
+    async with app.run_test() as pilot:
+        pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
+        pane.show_file(test_file)
+        await pilot.pause()
+
+        await pilot.press("a")
+        await pilot.pause()
+
+        tags = app.screen.query_one("#annotation-tags", Input)
+        note = app.screen.query_one("#annotation-note", TextArea)
+        tags.value = "important"
+        note.load_text("Review the whole file.")
+        app.screen.action_save()
+        await pilot.pause()
+
+        payload = json.loads((tmp_path / ".skim" / "review.json").read_text())
+        saved = payload["files"]["note.md"]["annotations"][FILE_ANNOTATION_KEY]
+        pane_text = "\n".join(
+            str(_static_content(widget))
+            for widget in pane.query(Static)
+        )
+        assert len(saved) == 1
+        assert saved[0]["tags"] == ["important"]
+        assert saved[0]["note"] == "Review the whole file."
+        assert "File Annotation" in pane_text
 
 
 async def test_json_inspector_footer_shows_live_preview_controls(tmp_path):

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -1,0 +1,125 @@
+"""Tests for skim's shared review storage and triage helpers."""
+
+from __future__ import annotations
+
+import json
+
+from skim.review import (
+    FILE_ANNOTATION_KEY,
+    AnnotationStore,
+    triage_preview_kind,
+)
+
+
+def test_annotation_store_supports_file_level_annotation_round_trip(tmp_path):
+    """File-level annotations should persist under the reserved @file target key."""
+    source = tmp_path / "notes.md"
+    source.write_text("# Note\n")
+    store = AnnotationStore(tmp_path)
+
+    created = store.add_annotation(
+        source,
+        FILE_ANNOTATION_KEY,
+        tags=("important", "follow-up"),
+        note="Review the rollout wording.",
+    )
+
+    persisted = json.loads((tmp_path / ".skim" / "review.json").read_text())
+    saved = persisted["files"]["notes.md"]["annotations"][FILE_ANNOTATION_KEY]
+
+    assert len(saved) == 1
+    assert saved[0]["id"] == created.id
+    assert saved[0]["tags"] == ["important", "follow-up"]
+    assert store.get_annotation(source, FILE_ANNOTATION_KEY) is not None
+    assert store.get_annotation(source, FILE_ANNOTATION_KEY).note == "Review the rollout wording."
+
+
+def test_triage_items_normalize_and_sort_workspace_annotations(tmp_path):
+    """Triage rows should flatten per-file annotations into a stable review queue."""
+    review_file = tmp_path / ".skim" / "review.json"
+    review_file.parent.mkdir()
+    review_file.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "files": {
+                    "docs/spec.md": {
+                        "annotations": {
+                            FILE_ANNOTATION_KEY: [
+                                {
+                                    "id": "file-ann",
+                                    "created_at": "2026-04-21T14:20:00Z",
+                                    "updated_at": "2026-04-21T14:25:00Z",
+                                    "tags": ["important"],
+                                    "note": (
+                                        "Need to revisit rollout wording and clarify "
+                                        "stop conditions."
+                                    ),
+                                }
+                            ]
+                        }
+                    },
+                    "output.json": {
+                        "annotations": {
+                            "$.task": [
+                                {
+                                    "id": "json-ann",
+                                    "created_at": "2026-04-21T14:10:00Z",
+                                    "updated_at": "2026-04-21T14:15:00Z",
+                                    "tags": ["bug"],
+                                    "note": "The task node needs a better summary.",
+                                }
+                            ]
+                        }
+                    },
+                },
+            }
+        )
+    )
+
+    items = AnnotationStore(tmp_path).triage_items()
+
+    assert [item.annotation_id for item in items] == ["file-ann", "json-ann"]
+    assert items[0].file_path == "docs/spec.md"
+    assert items[0].target_kind == "file"
+    assert items[0].target_label == "File"
+    assert items[0].target_path is None
+    assert items[0].preview_kind == "markdown"
+    assert items[0].note_preview.startswith("Need to revisit rollout wording")
+    assert items[1].target_kind == "json_path"
+    assert items[1].target_label == "$.task"
+    assert items[1].target_path == "$.task"
+    assert items[1].preview_kind == "json"
+
+
+def test_annotation_store_reloads_when_review_file_changes_on_disk(tmp_path):
+    """Long-lived stores should invalidate caches when another process edits review.json."""
+    source = tmp_path / "plain.json"
+    source.write_text(json.dumps({"hello": "world"}))
+    first = AnnotationStore(tmp_path)
+    second = AnnotationStore(tmp_path)
+
+    created = second.add_annotation(
+        source,
+        "$.hello",
+        tags=("external",),
+        note="Saved from another surface.",
+    )
+
+    annotation = first.get_annotation(source, "$.hello")
+
+    assert annotation is not None
+    assert annotation.id == created.id
+    assert annotation.note == "Saved from another surface."
+
+
+def test_triage_preview_kind_uses_shared_bucket_mapping():
+    """Triage filter buckets should be derived from local file kinds in Python."""
+    assert triage_preview_kind("docs/spec.md") == "markdown"
+    assert triage_preview_kind("output.json") == "json"
+    assert triage_preview_kind("notebook.ipynb") == "notebook"
+    assert triage_preview_kind("table.csv") == "csv"
+    assert triage_preview_kind("workbook.xlsx") == "xlsx"
+    assert triage_preview_kind("src/app.py") == "code"
+    assert triage_preview_kind("README") == "text"
+    assert triage_preview_kind("artifact.foo") == "other"

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -34,6 +34,46 @@ def test_annotation_store_supports_file_level_annotation_round_trip(tmp_path):
     assert store.get_annotation(source, FILE_ANNOTATION_KEY).note == "Review the rollout wording."
 
 
+def test_annotation_store_supports_multiple_file_level_annotations_by_id(tmp_path):
+    """File-level annotations should support multi-entry update/delete like JSON nodes."""
+    source = tmp_path / "notes.md"
+    source.write_text("# Note\n")
+    store = AnnotationStore(tmp_path)
+
+    first = store.add_annotation(
+        source,
+        FILE_ANNOTATION_KEY,
+        tags=("important",),
+        note="Older file note.",
+    )
+    second = store.add_annotation(
+        source,
+        FILE_ANNOTATION_KEY,
+        tags=("follow-up",),
+        note="Newest file note.",
+    )
+
+    records = store.annotations_for_path(source, FILE_ANNOTATION_KEY)
+    assert [record.id for record in records] == [second.id, first.id]
+
+    updated = store.update_annotation(
+        source,
+        FILE_ANNOTATION_KEY,
+        first.id,
+        tags=("important", "edited"),
+        note="Older file note updated.",
+    )
+    assert updated is not None
+
+    after_update = store.annotations_for_path(source, FILE_ANNOTATION_KEY)
+    assert after_update[0].id == updated.id
+    assert after_update[0].note == "Older file note updated."
+
+    store.delete_annotation(source, FILE_ANNOTATION_KEY, second.id)
+    after_delete = store.annotations_for_path(source, FILE_ANNOTATION_KEY)
+    assert [record.id for record in after_delete] == [updated.id]
+
+
 def test_triage_items_normalize_and_sort_workspace_annotations(tmp_path):
     """Triage rows should flatten per-file annotations into a stable review queue."""
     review_file = tmp_path / ".skim" / "review.json"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from conftest import sample_hermes_transcript, sample_submission, sample_trajectory, write_test_xlsx
 
 from skim.preview import MAX_FILE_SIZE
+from skim.review import FILE_ANNOTATION_KEY
 from skim.server import AnnotationStore, SkimHandler
 from skim.web_preview import serialize_preview
 
@@ -526,6 +527,81 @@ def test_api_annotations_support_multi_entry_round_trip(tmp_path):
     assert delete_payload == {"ok": True}
     remaining = after_delete["files"]["plain.json"]["annotations"]["$.hello"]
     assert [entry["id"] for entry in remaining] == [first["annotation"]["id"]]
+
+
+def test_api_annotations_support_file_level_targets(tmp_path):
+    """File-level annotations should round-trip through the shared annotations API."""
+    test_file = tmp_path / "notes.md"
+    test_file.write_text("# Note\n")
+
+    with running_server(tmp_path) as base_url:
+        save_status, save_payload = request_json(
+            base_url,
+            "/api/annotations",
+            method="POST",
+            body={
+                "file": "notes.md",
+                "path": FILE_ANNOTATION_KEY,
+                "tags": ["important"],
+                "note": "Review this whole file.",
+            },
+        )
+        _, preview = request_json(
+            base_url,
+            "/api/preview?path=" + urllib.parse.quote("notes.md"),
+        )
+        _, triage = request_json(base_url, "/api/triage")
+        delete_status, _ = request_json(
+            base_url,
+            "/api/annotations",
+            method="DELETE",
+            body={
+                "file": "notes.md",
+                "path": FILE_ANNOTATION_KEY,
+                "annotation_id": save_payload["annotation"]["id"],
+            },
+        )
+
+    assert save_status == 200
+    assert preview["annotation_path"] == FILE_ANNOTATION_KEY
+    assert preview["annotation_count"] == 1
+    assert preview["annotations"][0]["id"] == save_payload["annotation"]["id"]
+    assert triage["items"][0]["target_kind"] == "file"
+    assert triage["items"][0]["target_path"] is None
+    assert triage["items"][0]["file_path"] == "notes.md"
+    assert delete_status == 200
+
+
+def test_api_annotation_version_and_triage_reflect_annotation_changes(tmp_path):
+    """The triage and version endpoints should move when annotations change."""
+    test_file = tmp_path / "plain.json"
+    test_file.write_text(json.dumps({"hello": "world"}))
+
+    with running_server(tmp_path) as base_url:
+        version_status, initial = request_json(base_url, "/api/annotation-version")
+        triage_status, empty_triage = request_json(base_url, "/api/triage")
+        _, save_payload = request_json(
+            base_url,
+            "/api/annotations",
+            method="POST",
+            body={
+                "file": "plain.json",
+                "path": "$.hello",
+                "tags": ["important"],
+                "note": "keep this",
+            },
+        )
+        _, updated = request_json(base_url, "/api/annotation-version")
+        _, triage = request_json(base_url, "/api/triage")
+
+    assert version_status == 200
+    assert triage_status == 200
+    assert empty_triage["items"] == []
+    assert updated["annotation_version"] != initial["annotation_version"]
+    assert triage["annotation_version"] == updated["annotation_version"]
+    assert triage["items"][0]["annotation_id"] == save_payload["annotation"]["id"]
+    assert triage["items"][0]["target_kind"] == "json_path"
+    assert triage["items"][0]["target_path"] == "$.hello"
 
 
 def test_root_serves_local_static_shell_without_cdn_dependencies(tmp_path):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -220,6 +220,35 @@ def test_api_preview_invalid_notebook_falls_back_to_text(tmp_path):
     assert payload["render"]["kind"] == "syntax"
 
 
+def test_api_preview_invalid_notebook_keeps_file_annotation_payload(tmp_path):
+    """Broken notebook previews should still expose file-level annotation metadata."""
+    test_file = tmp_path / "broken.ipynb"
+    test_file.write_text("{not json")
+
+    with running_server(tmp_path) as base_url:
+        _, save_payload = request_json(
+            base_url,
+            "/api/annotations",
+            method="POST",
+            body={
+                "file": "broken.ipynb",
+                "path": FILE_ANNOTATION_KEY,
+                "tags": ["important"],
+                "note": "review the broken notebook",
+            },
+        )
+        status, payload = request_json(
+            base_url,
+            "/api/preview?path=" + urllib.parse.quote("broken.ipynb"),
+        )
+
+    assert status == 200
+    assert payload["kind"] == "text"
+    assert payload["annotation_path"] == FILE_ANNOTATION_KEY
+    assert payload["annotation_count"] == 1
+    assert payload["annotations"][0]["id"] == save_payload["annotation"]["id"]
+
+
 def test_api_preview_returns_xlsx_payload(tmp_path):
     """Workbook files should get a dedicated xlsx preview payload."""
     test_file = tmp_path / "workbook.xlsx"

--- a/tests/test_web_app_contract.py
+++ b/tests/test_web_app_contract.py
@@ -456,6 +456,158 @@ console.log(JSON.stringify({
     }
 
 
+def test_render_pane_shell_includes_file_annotation_actions_for_non_json_previews():
+    """Non-JSON pane headers should expose file-level annotate/edit affordances."""
+    result = run_app_js(
+        """
+const plainHtml = ctx.renderPaneShell({
+  id: "pane-1",
+  path: "docs/spec.md",
+  preview: {
+    kind: "markdown",
+    name: "spec.md",
+    path: "docs/spec.md",
+    annotation_path: "@file",
+    annotations: [],
+    annotation_count: 0,
+  },
+});
+const annotatedHtml = ctx.renderPaneShell({
+  id: "pane-1",
+  path: "docs/spec.md",
+  preview: {
+    kind: "markdown",
+    name: "spec.md",
+    path: "docs/spec.md",
+    annotation_path: "@file",
+    annotations: [{
+      id: "ann-1",
+      created_at: "2026-04-21T14:00:00Z",
+      updated_at: "2026-04-21T14:05:00Z",
+      tags: ["important"],
+      note: "review",
+    }],
+    annotation_count: 1,
+  },
+});
+console.log(JSON.stringify({
+  plainHasAnnotate: plainHtml.includes('data-annotate="@file"') && plainHtml.includes(">Annotate<"),
+  annotatedHasEdit:
+    annotatedHtml.includes('data-annotation-id="ann-1"') &&
+    annotatedHtml.includes(">Edit annotation<"),
+}));
+"""
+        )
+
+    assert result == {"plainHasAnnotate": True, "annotatedHasEdit": True}
+
+
+def test_triage_visible_items_filter_and_selection_are_client_side():
+    """Triage filtering should stay client-side over search, tag, and file-type state."""
+    result = run_app_js(
+        """
+vm.runInContext(`
+state.triage = {
+  items: [
+    {
+      annotation_id: "ann-1",
+      file_path: "docs/spec.md",
+      target_kind: "file",
+      target_label: "File",
+      target_path: null,
+      preview_kind: "markdown",
+      tags: ["important"],
+      note_preview: "rollout wording",
+      note_full: "rollout wording",
+      created_at: "2026-04-21T14:00:00Z",
+      updated_at: "2026-04-21T14:05:00Z",
+    },
+    {
+      annotation_id: "ann-2",
+      file_path: "output.json",
+      target_kind: "json_path",
+      target_label: "$.task",
+      target_path: "$.task",
+      preview_kind: "json",
+      tags: ["bug"],
+      note_preview: "task summary",
+      note_full: "task summary",
+      created_at: "2026-04-21T14:10:00Z",
+      updated_at: "2026-04-21T14:15:00Z",
+    },
+  ],
+  search: "rollout",
+  selectedTag: "important",
+  selectedPreviewKind: "markdown",
+  selectedAnnotationId: "ann-1",
+  lastAnnotationVersion: "v1",
+};
+`, ctx);
+const visible = ctx.visibleTriageItems();
+console.log(JSON.stringify({
+  ids: visible.map((item) => item.annotation_id),
+  selected: ctx.selectedTriageItem()?.annotation_id || null,
+}));
+"""
+    )
+
+    assert result == {"ids": ["ann-1"], "selected": "ann-1"}
+
+
+def test_open_triage_item_switches_back_to_browse_and_routes_target():
+    """Opening a triage row should restore browse mode and route the selected target."""
+    result = run_app_js(
+        """
+vm.runInContext(`
+state.mode = "triage";
+state.panes = [createPaneState("pane-1")];
+state.activePaneId = "pane-1";
+state.triage = {
+  items: [{
+    annotation_id: "ann-1",
+    file_path: "output.json",
+    target_kind: "json_path",
+    target_label: "$.task",
+    target_path: "$.task",
+    preview_kind: "json",
+    tags: ["bug"],
+    note_preview: "task summary",
+    note_full: "task summary",
+    created_at: "2026-04-21T14:10:00Z",
+    updated_at: "2026-04-21T14:15:00Z",
+  }],
+  search: "",
+  selectedTag: "",
+  selectedPreviewKind: "",
+  selectedAnnotationId: "ann-1",
+  lastAnnotationVersion: "v1",
+};
+globalThis.__openCall = null;
+loadPreviewForPane = async function(path, paneId, options = {}) {
+  globalThis.__openCall = { path, paneId, options };
+  return { ok: true };
+};
+`, ctx);
+await ctx.openTriageItem("ann-1");
+console.log(JSON.stringify({
+  mode: vm.runInContext('state.mode', ctx),
+  selected: vm.runInContext('state.triage.selectedAnnotationId', ctx),
+  openCall: vm.runInContext('globalThis.__openCall', ctx),
+}));
+"""
+    )
+
+    assert result == {
+        "mode": "browse",
+        "selected": "ann-1",
+        "openCall": {
+            "path": "output.json",
+            "paneId": "pane-1",
+            "options": {"selectedJsonPath": "$.task"},
+        },
+    }
+
+
 def test_render_json_node_uses_structured_icon_key_and_value_segments():
     """JSON tree rows should render typed icons and separate key/value spans."""
     result = run_app_js(

--- a/tests/test_web_app_contract.py
+++ b/tests/test_web_app_contract.py
@@ -608,6 +608,69 @@ console.log(JSON.stringify({
     }
 
 
+def test_render_triage_queue_groups_annotations_by_file():
+    """Triage queue markup should show one file header with nested annotation rows."""
+    result = run_app_js(
+        """
+vm.runInContext(`
+state.triage = {
+  items: [
+    {
+      annotation_id: "ann-1",
+      file_path: "output.json",
+      target_kind: "json_path",
+      target_label: "$.task",
+      target_path: "$.task",
+      preview_kind: "json",
+      tags: ["bug"],
+      note_preview: "task summary",
+      note_full: "task summary",
+      created_at: "2026-04-21T14:10:00Z",
+      updated_at: "2026-04-21T14:15:00Z",
+    },
+    {
+      annotation_id: "ann-2",
+      file_path: "output.json",
+      target_kind: "json_path",
+      target_label: "$.result",
+      target_path: "$.result",
+      preview_kind: "json",
+      tags: ["followup"],
+      note_preview: "result summary",
+      note_full: "result summary",
+      created_at: "2026-04-21T14:20:00Z",
+      updated_at: "2026-04-21T14:25:00Z",
+    },
+  ],
+  search: "",
+  selectedTag: "",
+  selectedPreviewKind: "",
+  selectedAnnotationId: "ann-2",
+  lastAnnotationVersion: "v1",
+};
+`, ctx);
+const html = ctx.renderTriageQueue(ctx.visibleTriageItems());
+console.log(JSON.stringify({
+  fileOccurrences: html.split("output.json").length - 1,
+  hasGroup: html.includes("triage-file-group"),
+  hasHeader: html.includes("triage-file-group-header"),
+  hasRow: html.includes("triage-annotation-row"),
+  hasTask: html.includes("$.task"),
+  hasResult: html.includes("$.result"),
+}));
+"""
+    )
+
+    assert result == {
+        "fileOccurrences": 1,
+        "hasGroup": True,
+        "hasHeader": True,
+        "hasRow": True,
+        "hasTask": True,
+        "hasResult": True,
+    }
+
+
 def test_render_json_node_uses_structured_icon_key_and_value_segments():
     """JSON tree rows should render typed icons and separate key/value spans."""
     result = run_app_js(

--- a/tests/test_web_app_contract.py
+++ b/tests/test_web_app_contract.py
@@ -502,6 +502,55 @@ console.log(JSON.stringify({
     assert result == {"plainHasAnnotate": True, "annotatedHasEdit": True}
 
 
+def test_non_json_previews_render_file_annotation_panel_with_multiple_entries():
+    """Non-JSON previews should render the shared annotation panel for @file."""
+    result = run_app_js(
+        """
+const pane = ctx.createPaneState("pane-1");
+pane.path = "docs/spec.md";
+pane.preview = {
+  kind: "markdown",
+  name: "spec.md",
+  path: "docs/spec.md",
+  content: "# Spec",
+  annotation_path: "@file",
+  annotations: [
+    {
+      id: "newer",
+      created_at: "2026-04-20T11:00:00Z",
+      updated_at: "2026-04-20T11:30:00Z",
+      tags: ["bug"],
+      note: "newer file note",
+    },
+    {
+      id: "older",
+      created_at: "2026-04-20T10:00:00Z",
+      updated_at: "2026-04-20T10:00:00Z",
+      tags: ["evidence"],
+      note: "older file note",
+    },
+  ],
+  annotation_count: 2,
+};
+pane.selectedAnnotationIds = { "@file": "older" };
+const html = ctx.renderMarkdownPreview(pane);
+console.log(JSON.stringify({
+  hasPanel: html.includes('annotation-panel'),
+  hasCount: html.includes('2 annotations'),
+  hasOlderSelected: html.includes('annotation-entry selected'),
+  hasOlderNote: html.includes('older file note'),
+}));
+"""
+    )
+
+    assert result == {
+        "hasPanel": True,
+        "hasCount": True,
+        "hasOlderSelected": True,
+        "hasOlderNote": True,
+    }
+
+
 def test_triage_visible_items_filter_and_selection_are_client_side():
     """Triage filtering should stay client-side over search, tag, and file-type state."""
     result = run_app_js(
@@ -1125,6 +1174,26 @@ console.log(JSON.stringify({
         "activePaneId": "pane-6",
         "paneIds": ["pane-1", "pane-2", "pane-3", "pane-4", "pane-5", "pane-6"],
     }
+
+
+def test_split_active_pane_is_inert_in_triage_mode():
+    """Web triage mode should not allow pane splitting."""
+    result = run_app_js(
+        """
+vm.runInContext(`
+state.mode = "triage";
+state.panes = [createPaneState("pane-1")];
+state.activePaneId = "pane-1";
+`, ctx);
+ctx.splitActivePane();
+console.log(JSON.stringify({
+  paneCount: vm.runInContext('state.panes.length', ctx),
+  activePaneId: vm.runInContext('state.activePaneId', ctx),
+}));
+"""
+    )
+
+    assert result == {"paneCount": 1, "activePaneId": "pane-1"}
 
 
 def test_tree_click_opens_file_in_the_active_pane():

--- a/tests/test_web_app_contract.py
+++ b/tests/test_web_app_contract.py
@@ -497,7 +497,7 @@ console.log(JSON.stringify({
     annotatedHtml.includes(">Edit annotation<"),
 }));
 """
-        )
+    )
 
     assert result == {"plainHasAnnotate": True, "annotatedHasEdit": True}
 

--- a/tests/test_web_app_contract.py
+++ b/tests/test_web_app_contract.py
@@ -657,6 +657,103 @@ console.log(JSON.stringify({
     }
 
 
+def test_open_triage_item_routes_file_annotation_selection():
+    """Opening a file-level triage row should route the selected annotation id."""
+    result = run_app_js(
+        """
+vm.runInContext(`
+state.mode = "triage";
+state.panes = [createPaneState("pane-1")];
+state.activePaneId = "pane-1";
+state.triage = {
+  items: [{
+    annotation_id: "ann-file-older",
+    file_path: "docs/spec.md",
+    target_kind: "file",
+    target_label: "File",
+    target_path: null,
+    preview_kind: "markdown",
+    tags: ["important"],
+    note_preview: "older note",
+    note_full: "older note",
+    created_at: "2026-04-21T14:10:00Z",
+    updated_at: "2026-04-21T14:15:00Z",
+  }],
+  search: "",
+  selectedTag: "",
+  selectedPreviewKind: "",
+  selectedAnnotationId: "ann-file-older",
+  lastAnnotationVersion: "v1",
+};
+globalThis.__openCall = null;
+loadPreviewForPane = async function(path, paneId, options = {}) {
+  globalThis.__openCall = { path, paneId, options };
+  return { ok: true };
+};
+`, ctx);
+await ctx.openTriageItem("ann-file-older");
+console.log(JSON.stringify(vm.runInContext('globalThis.__openCall', ctx)));
+"""
+    )
+
+    assert result == {
+        "path": "docs/spec.md",
+        "paneId": "pane-1",
+        "options": {
+            "selectedAnnotationPath": "@file",
+            "selectedAnnotationId": "ann-file-older",
+        },
+    }
+
+
+def test_load_preview_for_pane_restores_selected_file_annotation_from_options():
+    """Preview loads should apply routed file-level annotation selection state."""
+    result = run_app_js(
+        """
+vm.runInContext(`
+state.panes = [createPaneState("pane-1")];
+state.activePaneId = "pane-1";
+apiJson = async function() {
+  return {
+    kind: "markdown",
+    name: "spec.md",
+    path: "docs/spec.md",
+    content: "# Spec",
+    annotation_path: "@file",
+    annotations: [
+      {
+        id: "newer",
+        tags: ["new"],
+        note: "newer",
+        created_at: "2026-04-21T14:10:00Z",
+        updated_at: "2026-04-21T14:10:00Z"
+      },
+      {
+        id: "older",
+        tags: ["old"],
+        note: "older",
+        created_at: "2026-04-21T14:00:00Z",
+        updated_at: "2026-04-21T14:00:00Z"
+      }
+    ],
+    annotation_count: 2,
+  };
+};
+renderTree = function() {};
+renderWorkspace = function() {};
+renderStatusBar = function() {};
+`, ctx);
+await ctx.loadPreviewForPane("docs/spec.md", "pane-1", {
+  selectedAnnotationPath: "@file",
+  selectedAnnotationId: "older",
+});
+console.log(JSON.stringify(vm.runInContext('state.panes[0].selectedAnnotationIds', ctx)));
+"""
+    )
+
+    assert result == {"@file": "older"}
+
+
 def test_render_triage_queue_groups_annotations_by_file():
     """Triage queue markup should show one file header with nested annotation rows."""
     result = run_app_js(


### PR DESCRIPTION
## Summary
- add a shared review layer for normalized triage rows, annotation versioning, and `@file` file-level annotations
- ship triage mode in both the web UI and the TUI, including grouped queues, polling refresh, and in-session browse/triage transitions
- give non-JSON previews JSON-style multi-entry file annotation behavior and disable pane splitting while triage is active

## Testing
- `uv run pytest -q`
- `uv run ruff check src/ tests/`