### PR TITLE
[codex] clean up pyright attribute diagnostics

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,11 @@ convention = "google"
     "D",
 ]
 
+[tool.pyright]
+typeCheckingMode = "basic"
+pythonVersion = "3.12"
+include = ["src", "tests"]
+
 [tool.pytest.ini_options]
 minversion = "8.0"
 testpaths = ["tests"]

--- a/src/skim/app.py
+++ b/src/skim/app.py
@@ -1,7 +1,5 @@
-"""Compatibility alias for the Textual app shell module."""
+"""Compatibility exports for the Textual app shell module."""
 
-import sys
+from .tui.app import ReviewAnnotationEditor, SkimApp, TriageDetail, TriageQueue, dev, main
 
-from .tui import app as _app
-
-sys.modules[__name__] = _app
+__all__ = ["ReviewAnnotationEditor", "SkimApp", "TriageDetail", "TriageQueue", "dev", "main"]

--- a/src/skim/app.py
+++ b/src/skim/app.py
@@ -1,5 +1,20 @@
-"""Compatibility exports for the Textual app shell module."""
+"""Compatibility alias for the Textual app shell module."""
 
-from .tui.app import ReviewAnnotationEditor, SkimApp, TriageDetail, TriageQueue, dev, main
+from __future__ import annotations
 
-__all__ = ["ReviewAnnotationEditor", "SkimApp", "TriageDetail", "TriageQueue", "dev", "main"]
+import sys
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .tui import app as _app
+
+    ReviewAnnotationEditor = _app.ReviewAnnotationEditor
+    SkimApp = _app.SkimApp
+    TriageDetail = _app.TriageDetail
+    TriageQueue = _app.TriageQueue
+    dev = _app.dev
+    main = _app.main
+else:
+    from .tui import app as _app
+
+    sys.modules[__name__] = _app

--- a/src/skim/preview.py
+++ b/src/skim/preview.py
@@ -1,7 +1,43 @@
-"""Compatibility alias for the TUI preview module."""
+"""Compatibility exports for the TUI preview module."""
 
-import sys
+from .tui.preview import (
+    JSON_EXTENSIONS,
+    MARKDOWN_EXTENSIONS,
+    MAX_CSV_CELL_WIDTH,
+    MAX_CSV_COLS,
+    MAX_CSV_ROWS,
+    MAX_FILE_SIZE,
+    MAX_JSON_FILE_SIZE,
+    NOTEBOOK_EXTENSIONS,
+    SYNTAX_MAP,
+    XLSX_EXTENSIONS,
+    CsvPreview,
+    FileAnnotationStatus,
+    PreviewPane,
+    XlsxPreview,
+    XlsxPreviewData,
+    XlsxSheetPreviewData,
+    _xlsx_sheet_preview_data,
+    render_file,
+)
 
-from .tui import preview as _preview
-
-sys.modules[__name__] = _preview
+__all__ = [
+    "CsvPreview",
+    "FileAnnotationStatus",
+    "JSON_EXTENSIONS",
+    "MARKDOWN_EXTENSIONS",
+    "MAX_CSV_CELL_WIDTH",
+    "MAX_CSV_COLS",
+    "MAX_CSV_ROWS",
+    "MAX_FILE_SIZE",
+    "MAX_JSON_FILE_SIZE",
+    "NOTEBOOK_EXTENSIONS",
+    "PreviewPane",
+    "SYNTAX_MAP",
+    "XLSX_EXTENSIONS",
+    "XlsxPreview",
+    "XlsxPreviewData",
+    "XlsxSheetPreviewData",
+    "_xlsx_sheet_preview_data",
+    "render_file",
+]

--- a/src/skim/preview.py
+++ b/src/skim/preview.py
@@ -1,43 +1,32 @@
-"""Compatibility exports for the TUI preview module."""
+"""Compatibility alias for the TUI preview module."""
 
-from .tui.preview import (
-    JSON_EXTENSIONS,
-    MARKDOWN_EXTENSIONS,
-    MAX_CSV_CELL_WIDTH,
-    MAX_CSV_COLS,
-    MAX_CSV_ROWS,
-    MAX_FILE_SIZE,
-    MAX_JSON_FILE_SIZE,
-    NOTEBOOK_EXTENSIONS,
-    SYNTAX_MAP,
-    XLSX_EXTENSIONS,
-    CsvPreview,
-    FileAnnotationStatus,
-    PreviewPane,
-    XlsxPreview,
-    XlsxPreviewData,
-    XlsxSheetPreviewData,
-    _xlsx_sheet_preview_data,
-    render_file,
-)
+from __future__ import annotations
 
-__all__ = [
-    "CsvPreview",
-    "FileAnnotationStatus",
-    "JSON_EXTENSIONS",
-    "MARKDOWN_EXTENSIONS",
-    "MAX_CSV_CELL_WIDTH",
-    "MAX_CSV_COLS",
-    "MAX_CSV_ROWS",
-    "MAX_FILE_SIZE",
-    "MAX_JSON_FILE_SIZE",
-    "NOTEBOOK_EXTENSIONS",
-    "PreviewPane",
-    "SYNTAX_MAP",
-    "XLSX_EXTENSIONS",
-    "XlsxPreview",
-    "XlsxPreviewData",
-    "XlsxSheetPreviewData",
-    "_xlsx_sheet_preview_data",
-    "render_file",
-]
+import sys
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .tui import preview as _preview
+
+    JSON_EXTENSIONS = _preview.JSON_EXTENSIONS
+    MARKDOWN_EXTENSIONS = _preview.MARKDOWN_EXTENSIONS
+    MAX_CSV_CELL_WIDTH = _preview.MAX_CSV_CELL_WIDTH
+    MAX_CSV_COLS = _preview.MAX_CSV_COLS
+    MAX_CSV_ROWS = _preview.MAX_CSV_ROWS
+    MAX_FILE_SIZE = _preview.MAX_FILE_SIZE
+    MAX_JSON_FILE_SIZE = _preview.MAX_JSON_FILE_SIZE
+    NOTEBOOK_EXTENSIONS = _preview.NOTEBOOK_EXTENSIONS
+    SYNTAX_MAP = _preview.SYNTAX_MAP
+    XLSX_EXTENSIONS = _preview.XLSX_EXTENSIONS
+    CsvPreview = _preview.CsvPreview
+    FileAnnotationStatus = _preview.FileAnnotationStatus
+    PreviewPane = _preview.PreviewPane
+    XlsxPreview = _preview.XlsxPreview
+    XlsxPreviewData = _preview.XlsxPreviewData
+    XlsxSheetPreviewData = _preview.XlsxSheetPreviewData
+    _xlsx_sheet_preview_data = _preview._xlsx_sheet_preview_data
+    render_file = _preview.render_file
+else:
+    from .tui import preview as _preview
+
+    sys.modules[__name__] = _preview

--- a/src/skim/scrolling.py
+++ b/src/skim/scrolling.py
@@ -1,17 +1,19 @@
-"""Compatibility exports for Textual scrolling helpers."""
+"""Compatibility alias for Textual scrolling helpers."""
 
-from .tui.scrolling import (
-    AnnotationStatusWrap,
-    DirectoryTree,
-    DragScrollMixin,
-    DragTree,
-    FocusableDetailWrap,
-)
+from __future__ import annotations
 
-__all__ = [
-    "AnnotationStatusWrap",
-    "DirectoryTree",
-    "DragScrollMixin",
-    "DragTree",
-    "FocusableDetailWrap",
-]
+import sys
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .tui import scrolling as _scrolling
+
+    AnnotationStatusWrap = _scrolling.AnnotationStatusWrap
+    DirectoryTree = _scrolling.DirectoryTree
+    DragScrollMixin = _scrolling.DragScrollMixin
+    DragTree = _scrolling.DragTree
+    FocusableDetailWrap = _scrolling.FocusableDetailWrap
+else:
+    from .tui import scrolling as _scrolling
+
+    sys.modules[__name__] = _scrolling

--- a/src/skim/scrolling.py
+++ b/src/skim/scrolling.py
@@ -1,7 +1,17 @@
-"""Compatibility alias for Textual scrolling helpers."""
+"""Compatibility exports for Textual scrolling helpers."""
 
-import sys
+from .tui.scrolling import (
+    AnnotationStatusWrap,
+    DirectoryTree,
+    DragScrollMixin,
+    DragTree,
+    FocusableDetailWrap,
+)
 
-from .tui import scrolling as _scrolling
-
-sys.modules[__name__] = _scrolling
+__all__ = [
+    "AnnotationStatusWrap",
+    "DirectoryTree",
+    "DragScrollMixin",
+    "DragTree",
+    "FocusableDetailWrap",
+]

--- a/src/skim/trajectory.py
+++ b/src/skim/trajectory.py
@@ -1,7 +1,35 @@
-"""Compatibility alias for the TUI trajectory module."""
+"""Compatibility exports for the TUI trajectory module."""
 
-import sys
+from .tui.trajectory import (
+    AnnotationEditor,
+    AnnotationEditorResult,
+    AnnotationStore,
+    JsonInspector,
+    JsonInspectorItem,
+    StepTimelineItem,
+    TrajectoryEvent,
+    TrajectoryTreeItem,
+    TrajectoryViewer,
+    extract_trajectory,
+    normalize_events,
+    normalize_step_events,
+    normalize_step_overlay,
+    normalize_step_timeline,
+)
 
-from .tui import trajectory as _trajectory
-
-sys.modules[__name__] = _trajectory
+__all__ = [
+    "AnnotationEditor",
+    "AnnotationEditorResult",
+    "AnnotationStore",
+    "JsonInspector",
+    "JsonInspectorItem",
+    "StepTimelineItem",
+    "TrajectoryEvent",
+    "TrajectoryTreeItem",
+    "TrajectoryViewer",
+    "extract_trajectory",
+    "normalize_events",
+    "normalize_step_events",
+    "normalize_step_overlay",
+    "normalize_step_timeline",
+]

--- a/src/skim/trajectory.py
+++ b/src/skim/trajectory.py
@@ -1,35 +1,28 @@
-"""Compatibility exports for the TUI trajectory module."""
+"""Compatibility alias for the TUI trajectory module."""
 
-from .tui.trajectory import (
-    AnnotationEditor,
-    AnnotationEditorResult,
-    AnnotationStore,
-    JsonInspector,
-    JsonInspectorItem,
-    StepTimelineItem,
-    TrajectoryEvent,
-    TrajectoryTreeItem,
-    TrajectoryViewer,
-    extract_trajectory,
-    normalize_events,
-    normalize_step_events,
-    normalize_step_overlay,
-    normalize_step_timeline,
-)
+from __future__ import annotations
 
-__all__ = [
-    "AnnotationEditor",
-    "AnnotationEditorResult",
-    "AnnotationStore",
-    "JsonInspector",
-    "JsonInspectorItem",
-    "StepTimelineItem",
-    "TrajectoryEvent",
-    "TrajectoryTreeItem",
-    "TrajectoryViewer",
-    "extract_trajectory",
-    "normalize_events",
-    "normalize_step_events",
-    "normalize_step_overlay",
-    "normalize_step_timeline",
-]
+import sys
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .tui import trajectory as _trajectory
+
+    AnnotationEditor = _trajectory.AnnotationEditor
+    AnnotationEditorResult = _trajectory.AnnotationEditorResult
+    AnnotationStore = _trajectory.AnnotationStore
+    JsonInspector = _trajectory.JsonInspector
+    JsonInspectorItem = _trajectory.JsonInspectorItem
+    StepTimelineItem = _trajectory.StepTimelineItem
+    TrajectoryEvent = _trajectory.TrajectoryEvent
+    TrajectoryTreeItem = _trajectory.TrajectoryTreeItem
+    TrajectoryViewer = _trajectory.TrajectoryViewer
+    extract_trajectory = _trajectory.extract_trajectory
+    normalize_events = _trajectory.normalize_events
+    normalize_step_events = _trajectory.normalize_step_events
+    normalize_step_overlay = _trajectory.normalize_step_overlay
+    normalize_step_timeline = _trajectory.normalize_step_timeline
+else:
+    from .tui import trajectory as _trajectory
+
+    sys.modules[__name__] = _trajectory

--- a/src/skim/tui/app.py
+++ b/src/skim/tui/app.py
@@ -934,7 +934,7 @@ class SkimApp(App):
             return False
         return super().check_action(action, parameters)
 
-    def action_quit(self) -> None:
+    async def action_quit(self) -> None:
         """Quit the app unless a modal screen is active."""
         if self._modal_is_active():
             return

--- a/src/skim/tui/preview.py
+++ b/src/skim/tui/preview.py
@@ -184,8 +184,9 @@ class PreviewPane(DragScrollMixin, VerticalScroll, can_focus=True):
 
     def on_click(self) -> None:
         """Mark this pane as the active preview when clicked."""
-        if self.id is not None and hasattr(self.app, "set_active_pane"):
-            self.app.set_active_pane(self.id)
+        set_active_pane = getattr(self.app, "set_active_pane", None)
+        if self.id is not None and callable(set_active_pane):
+            set_active_pane(self.id)
 
     def scroll_content(self, delta: int) -> None:
         """Scroll specialized inner content when present, else scroll the pane."""

--- a/src/skim/tui/scrolling.py
+++ b/src/skim/tui/scrolling.py
@@ -7,7 +7,7 @@ semantics; higher-level modules compose these widgets into the app.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Protocol, cast
 
 from textual import events
 from textual.containers import VerticalScroll
@@ -16,6 +16,27 @@ from textual.widgets import DirectoryTree as TextualDirectoryTree
 from textual.widgets import Tree as TextualTree
 
 DRAG_SCROLL_THRESHOLD = 2
+
+
+class _DragScrollable(Protocol):
+    """Widget protocol expected by the drag-scroll mixin."""
+
+    app: Any
+    max_scroll_y: int
+    scroll_y: int
+
+    def capture_mouse(self) -> None: ...
+
+    def release_mouse(self) -> None: ...
+
+    def scroll_to(
+        self,
+        *,
+        y: float,
+        animate: bool,
+        force: bool,
+        immediate: bool,
+    ) -> None: ...
 
 
 class DragScrollMixin:
@@ -37,7 +58,8 @@ class DragScrollMixin:
 
     def _can_start_drag_scroll(self, event: events.MouseDown) -> bool:
         """Return whether a drag-scroll gesture should start for this event."""
-        if event.button != 1 or self.max_scroll_y <= 0:  # type: ignore[attr-defined]
+        widget = cast(_DragScrollable, self)
+        if event.button != 1 or widget.max_scroll_y <= 0:
             return False
         if self._drag_scroll_requires_self_target() and event.widget is not self:
             return False
@@ -47,21 +69,23 @@ class DragScrollMixin:
         """Capture mouse input so a vertical drag can scroll the widget."""
         if not self._can_start_drag_scroll(event):
             return
-        self._drag_scroll_start_y = self.scroll_y  # type: ignore[attr-defined]
+        widget = cast(_DragScrollable, self)
+        self._drag_scroll_start_y = widget.scroll_y
         self._drag_scroll_origin_y = event.screen_y
         self._drag_scrolling = False
-        self.capture_mouse()  # type: ignore[attr-defined]
+        widget.capture_mouse()
 
     async def on_mouse_move(self, event: events.MouseMove) -> None:
         """Translate vertical mouse movement into vertical scrolling."""
-        if self.app.mouse_captured is not self or self._drag_scroll_origin_y is None:
+        widget = cast(_DragScrollable, self)
+        if widget.app.mouse_captured is not self or self._drag_scroll_origin_y is None:
             return
         delta = event.screen_y - self._drag_scroll_origin_y
         if not self._drag_scrolling and abs(delta) < DRAG_SCROLL_THRESHOLD:
             return
         self._drag_scrolling = True
         start_y = self._drag_scroll_start_y or 0
-        self.scroll_to(  # type: ignore[attr-defined]
+        widget.scroll_to(
             y=start_y - delta,
             animate=False,
             force=True,
@@ -71,8 +95,9 @@ class DragScrollMixin:
 
     async def on_mouse_up(self, event: events.MouseUp) -> None:
         """Release captured drag-scroll state."""
-        if self.app.mouse_captured is self:
-            self.release_mouse()  # type: ignore[attr-defined]
+        widget = cast(_DragScrollable, self)
+        if widget.app.mouse_captured is self:
+            widget.release_mouse()
         if self._drag_scrolling:
             event.stop()
         self._drag_scroll_start_y = None
@@ -81,8 +106,9 @@ class DragScrollMixin:
 
     def on_hide(self) -> None:
         """Release mouse capture if the widget hides mid-drag."""
-        if self.app.mouse_captured is self:
-            self.release_mouse()  # type: ignore[attr-defined]
+        widget = cast(_DragScrollable, self)
+        if widget.app.mouse_captured is self:
+            widget.release_mouse()
         self._drag_scroll_start_y = None
         self._drag_scroll_origin_y = None
         self._drag_scrolling = False

--- a/src/skim/tui/trajectory.py
+++ b/src/skim/tui/trajectory.py
@@ -8,7 +8,7 @@ shell; those stay in the preview router and app modules.
 from __future__ import annotations
 
 import json
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -22,6 +22,7 @@ from textual.screen import ModalScreen
 from textual.widget import Widget
 from textual.widgets import Button, Collapsible, Input, Markdown, Static, TextArea
 from textual.widgets import Tree as TextualTree
+from textual.widgets.tree import TreeNode
 
 from ..core.review import AnnotationRecord, AnnotationStore
 from .scrolling import AnnotationStatusWrap, DragTree, FocusableDetailWrap
@@ -672,7 +673,7 @@ def _normalize_text_wrapper(value: Any) -> Any:
     return {key: _normalize_text_wrapper(item) for key, item in decoded.items()}
 
 
-def _metadata_fields(fields: list[tuple[str, str | None]]) -> list[Widget]:
+def _metadata_fields(fields: Sequence[tuple[str, str | None]]) -> list[Widget]:
     widgets: list[Widget] = []
     for label, value in fields:
         if value in (None, ""):
@@ -1596,7 +1597,7 @@ class JsonInspector(Vertical):
 
     def _add_overlay_children(
         self,
-        parent: TextualTree.Node[JsonInspectorItem],
+        parent: TreeNode[JsonInspectorItem],
         value: Any,
         raw_path: tuple[str | int, ...],
     ) -> None:
@@ -1652,7 +1653,7 @@ class JsonInspector(Vertical):
 
     def _add_trajectory_overlay(
         self,
-        parent: TextualTree.Node[JsonInspectorItem],
+        parent: TreeNode[JsonInspectorItem],
         trajectory: dict[str, Any],
         base_path: tuple[str | int, ...],
     ) -> None:
@@ -1799,7 +1800,7 @@ class JsonInspector(Vertical):
 
     def _add_raw_children(
         self,
-        parent: TextualTree.Node[JsonInspectorItem],
+        parent: TreeNode[JsonInspectorItem],
         value: Any,
         raw_path: tuple[str | int, ...],
     ) -> None:
@@ -2109,8 +2110,8 @@ def _json_tree_label(root_data: Any, item: JsonInspectorItem) -> Text:
 
 
 def _walk_tree_nodes(
-    node: TextualTree.Node[JsonInspectorItem],
-) -> list[TextualTree.Node[JsonInspectorItem]]:
+    node: TreeNode[JsonInspectorItem],
+) -> list[TreeNode[JsonInspectorItem]]:
     """Return the supplied node and all descendants."""
     nodes = [node]
     for child in node.children:

--- a/src/skim/web_preview.py
+++ b/src/skim/web_preview.py
@@ -1,7 +1,5 @@
-"""Compatibility alias for the web preview serializer module."""
+"""Compatibility exports for the web preview serializer module."""
 
-import sys
+from .webui.preview_serializer import serialize_preview
 
-from .webui import preview_serializer as _preview_serializer
-
-sys.modules[__name__] = _preview_serializer
+__all__ = ["serialize_preview"]

--- a/src/skim/web_preview.py
+++ b/src/skim/web_preview.py
@@ -1,5 +1,16 @@
-"""Compatibility exports for the web preview serializer module."""
+"""Compatibility alias for the web preview serializer module."""
 
-from .webui.preview_serializer import serialize_preview
+from __future__ import annotations
 
-__all__ = ["serialize_preview"]
+import sys
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .webui import preview_serializer as _preview_serializer
+
+    serialize_json_inspector_preview = _preview_serializer.serialize_json_inspector_preview
+    serialize_preview = _preview_serializer.serialize_preview
+else:
+    from .webui import preview_serializer as _preview_serializer
+
+    sys.modules[__name__] = _preview_serializer

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ trajectory viewer.
 """
 
 import json
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
 from xml.sax.saxutils import escape
@@ -151,7 +152,9 @@ def sample_hermes_transcript() -> dict[str, Any]:
     }
 
 
-def write_test_xlsx(path: Path, sheets: list[tuple[str, list[list[object | None]]]]) -> None:
+def write_test_xlsx(
+    path: Path, sheets: Sequence[tuple[str, Sequence[Sequence[object | None]]]]
+) -> None:
     """Write a minimal `.xlsx` workbook fixture with inline-string cells."""
     workbook_xml = """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
@@ -200,7 +203,7 @@ def write_test_xlsx(path: Path, sheets: list[tuple[str, list[list[object | None]
         text = escape(str(value))
         return f'<c r="{cell_ref}" t="inlineStr"><is><t>{text}</t></is></c>'
 
-    def sheet_xml(rows: list[list[object | None]]) -> str:
+    def sheet_xml(rows: Sequence[Sequence[object | None]]) -> str:
         row_xml: list[str] = []
         for row_index, row in enumerate(rows, start=1):
             cells = "".join(
@@ -251,14 +254,20 @@ def write_test_xlsx(path: Path, sheets: list[tuple[str, list[list[object | None]
             archive.writestr(name, payload)
 
 
-def _static_content(widget: Static) -> object:
-    """Return the private Static content object for focused test inspection."""
-    return widget._Static__content
+def _static_content(widget: Any) -> Any:
+    """Return the Static content object for focused test inspection."""
+    return widget.content
 
 
 def _tree_labels(tree: Tree) -> list[str]:
     """Return the root child labels from a Textual tree widget."""
-    return [child.label.plain for child in tree.root.children]
+    return [_node_label(child) for child in tree.root.children]
+
+
+def _node_label(node: Any) -> str:
+    """Return a plain label for a Textual tree node."""
+    label = node.label
+    return label.plain if isinstance(label, Text) else str(label)
 
 
 def _detail_text(viewer: TrajectoryViewer | JsonInspector) -> str:
@@ -306,11 +315,12 @@ def _modal_preview_text(screen) -> str:
 
 def _detail_syntax_blocks(viewer: TrajectoryViewer | JsonInspector) -> list[Syntax]:
     """Return all Syntax renderables mounted inside the detail pane."""
-    return [
-        _static_content(widget)
-        for widget in viewer._detail_wrap.query(Static)
-        if isinstance(_static_content(widget), Syntax)
-    ]
+    blocks: list[Syntax] = []
+    for widget in viewer._detail_wrap.query(Static):
+        content = _static_content(widget)
+        if isinstance(content, Syntax):
+            blocks.append(content)
+    return blocks
 
 
 def _top_level_collapsible_titles(viewer: TrajectoryViewer | JsonInspector) -> list[str]:

--- a/tests/test_app_shell.py
+++ b/tests/test_app_shell.py
@@ -11,6 +11,7 @@ from conftest import _static_content
 from textual.widgets import Static
 
 from skim import JsonInspector, PreviewPane, SkimApp
+from skim.scrolling import DirectoryTree
 
 
 async def test_app_launches():
@@ -521,7 +522,7 @@ async def test_f_enters_file_tree_mode(tmp_path):
     async with app.run_test() as pilot:
         await pilot.pause()
         pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
-        tree = app.query_one("DirectoryTree")
+        tree = app.query_one(DirectoryTree)
 
         assert app.focused is pane
         assert not app.file_tree_mode
@@ -541,7 +542,7 @@ async def test_f_toggles_back_to_active_pane(tmp_path):
     async with app.run_test() as pilot:
         await pilot.pause()
         pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
-        tree = app.query_one("DirectoryTree")
+        tree = app.query_one(DirectoryTree)
 
         await pilot.press("f")
         await pilot.pause()
@@ -563,7 +564,7 @@ async def test_file_tree_mode_up_down_moves_tree_cursor(tmp_path):
 
     async with app.run_test() as pilot:
         await pilot.pause()
-        tree = app.query_one("DirectoryTree")
+        tree = app.query_one(DirectoryTree)
 
         await pilot.press("f")
         await pilot.pause()
@@ -686,7 +687,7 @@ async def test_file_tree_mode_right_expands_directory(tmp_path):
 
     async with app.run_test() as pilot:
         await pilot.pause()
-        tree = app.query_one("DirectoryTree")
+        tree = app.query_one(DirectoryTree)
         folder_node = tree.root.children[0]
 
         await pilot.press("f")
@@ -712,7 +713,7 @@ async def test_file_tree_mode_left_collapses_directory_then_moves_to_parent(tmp_
 
     async with app.run_test() as pilot:
         await pilot.pause()
-        tree = app.query_one("DirectoryTree")
+        tree = app.query_one(DirectoryTree)
         folder_node = tree.root.children[0]
 
         await pilot.press("f")
@@ -745,7 +746,7 @@ async def test_file_tree_mode_right_on_file_opens_it_and_returns_to_pane(tmp_pat
     async with app.run_test() as pilot:
         await pilot.pause()
         pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
-        tree = app.query_one("DirectoryTree")
+        tree = app.query_one(DirectoryTree)
         file_node = tree.root.children[0]
 
         await pilot.press("f")
@@ -771,7 +772,7 @@ async def test_down_outside_file_tree_mode_still_scrolls_preview_pane(tmp_path):
     async with app.run_test() as pilot:
         await pilot.pause()
         pane = app.query_one(f"#{app.active_pane_id}", PreviewPane)
-        tree = app.query_one("DirectoryTree")
+        tree = app.query_one(DirectoryTree)
         pane.show_file(test_file)
         await pilot.pause()
 
@@ -792,7 +793,7 @@ async def test_shift_down_still_moves_file_tree_cursor(tmp_path):
 
     async with app.run_test() as pilot:
         await pilot.pause()
-        tree = app.query_one("DirectoryTree")
+        tree = app.query_one(DirectoryTree)
         before = tree.cursor_line
 
         await pilot.press("shift+down")
@@ -890,7 +891,7 @@ async def test_mouse_drag_scrolls_directory_tree(tmp_path):
 
     async with app.run_test() as pilot:
         await pilot.pause()
-        tree = app.query_one("DirectoryTree")
+        tree = app.query_one(DirectoryTree)
         before = tree.scroll_y
 
         await pilot.mouse_down(tree, offset=(5, 10))

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -13,6 +13,7 @@ from conftest import (
     _annotation_text,
     _detail_text,
     _modal_preview_text,
+    _node_label,
     _static_content,
     _tree_labels,
     sample_bundle,
@@ -25,12 +26,20 @@ from rich.syntax import Syntax
 from rich.text import Text
 from textual.widgets import Collapsible, Input, Markdown, Static, TextArea, Tree
 
-import skim.trajectory as trajectory_module
+import skim.tui.trajectory as trajectory_module
 from skim import JsonInspector, PreviewPane, SkimApp, render_file
+from skim.app import ReviewAnnotationEditor
 from skim.preview import CsvPreview, XlsxPreview, _xlsx_sheet_preview_data
 from skim.review import FILE_ANNOTATION_KEY
 from skim.scrolling import FocusableDetailWrap
-from skim.trajectory import AnnotationStore
+from skim.trajectory import AnnotationEditor, AnnotationStore
+
+
+def _annotation_screen(app: SkimApp) -> AnnotationEditor | ReviewAnnotationEditor:
+    """Return the active annotation modal with its action methods typed."""
+    screen = app.screen
+    assert isinstance(screen, AnnotationEditor | ReviewAnnotationEditor)
+    return screen
 
 
 def test_generic_json_uses_json_inspector(tmp_path):
@@ -659,7 +668,7 @@ async def test_persisted_annotations_mark_tree_and_detail_on_reload(tmp_path):
     widgets = render_file(test_file, browse_root=tmp_path)
     inspector = widgets[0]
     assert isinstance(inspector, JsonInspector)
-    assert inspector._tree.root.children[0].label.plain.startswith("* ")
+    assert _node_label(inspector._tree.root.children[0]).startswith("* ")
 
     app = SkimApp(path=str(tmp_path))
     async with app.run_test() as pilot:
@@ -1022,7 +1031,7 @@ async def test_annotation_mode_edits_selected_non_newest_annotation(tmp_path):
         assert note.text == "older note"
 
         note.load_text("older note updated")
-        app.screen.action_save()
+        _annotation_screen(app).action_save()
         await pilot.pause()
 
         payload = json.loads(review_file.read_text())
@@ -1081,7 +1090,7 @@ async def test_annotation_mode_delete_and_add_keep_selection_stable(tmp_path):
         await pilot.pause()
         await pilot.press("enter")
         await pilot.pause()
-        app.screen.action_delete()
+        _annotation_screen(app).action_delete()
         await pilot.pause()
 
         annotation = _annotation_text(pane.query_one(JsonInspector))
@@ -1093,7 +1102,7 @@ async def test_annotation_mode_delete_and_add_keep_selection_stable(tmp_path):
         await pilot.pause()
         app.screen.query_one("#annotation-tags", Input).value = "followup"
         app.screen.query_one("#annotation-note", TextArea).load_text("brand new note")
-        app.screen.action_save()
+        _annotation_screen(app).action_save()
         await pilot.pause()
 
         annotation = _annotation_text(pane.query_one(JsonInspector))
@@ -1143,7 +1152,7 @@ async def test_annotation_modal_saves_selected_node_annotation(tmp_path):
         note = app.screen.query_one("#annotation-note", TextArea)
         tags.value = "evidence, bug"
         note.load_text("First concrete failure appears here.")
-        app.screen.action_save()
+        _annotation_screen(app).action_save()
         await pilot.pause()
 
         review_file = tmp_path / ".skim" / "review.json"
@@ -1155,7 +1164,7 @@ async def test_annotation_modal_saves_selected_node_annotation(tmp_path):
         assert saved[0]["id"]
         assert saved[0]["created_at"]
         assert saved[0]["updated_at"]
-        assert inspector._tree.root.children[0].label.plain.startswith("* ")
+        assert _node_label(inspector._tree.root.children[0]).startswith("* ")
         annotation = _annotation_text(inspector)
         detail = _detail_text(inspector)
         assert "1 annotation" in annotation
@@ -1204,12 +1213,12 @@ async def test_annotation_modal_delete_removes_selected_node_annotation(tmp_path
         await pilot.pause()
         await pilot.press("enter")
         await pilot.pause()
-        app.screen.action_delete()
+        _annotation_screen(app).action_delete()
         await pilot.pause()
 
         payload = json.loads(review_file.read_text())
         assert payload["files"]["plain.json"]["annotations"] == {}
-        assert not inspector._tree.root.children[0].label.plain.startswith("* ")
+        assert not _node_label(inspector._tree.root.children[0]).startswith("* ")
         annotation = _annotation_text(inspector)
         detail = _detail_text(inspector)
         assert "No annotation yet" in annotation
@@ -1449,7 +1458,7 @@ async def test_non_json_file_annotation_modal_saves_file_level_annotation(tmp_pa
         note = app.screen.query_one("#annotation-note", TextArea)
         tags.value = "important"
         note.load_text("Review the whole file.")
-        app.screen.action_save()
+        _annotation_screen(app).action_save()
         await pilot.pause()
 
         payload = json.loads((tmp_path / ".skim" / "review.json").read_text())
@@ -1571,7 +1580,7 @@ async def test_non_json_file_annotation_selection_mode_edits_selected_entry(tmp_
         assert note.text == "older file note"
 
         note.load_text("older file note updated")
-        app.screen.action_save()
+        _annotation_screen(app).action_save()
         await pilot.pause()
 
         payload = json.loads(review_file.read_text())
@@ -1629,7 +1638,7 @@ async def test_non_json_file_annotation_add_and_delete_keep_selection_sensible(t
         await pilot.pause()
         await pilot.press("enter")
         await pilot.pause()
-        app.screen.action_delete()
+        _annotation_screen(app).action_delete()
         await pilot.pause()
 
         annotation = "\n".join(str(_static_content(widget)) for widget in pane.query(Static))
@@ -1641,7 +1650,7 @@ async def test_non_json_file_annotation_add_and_delete_keep_selection_sensible(t
         await pilot.pause()
         app.screen.query_one("#annotation-tags", Input).value = "fresh"
         app.screen.query_one("#annotation-note", TextArea).load_text("brand new file note")
-        app.screen.action_save()
+        _annotation_screen(app).action_save()
         await pilot.pause()
 
         annotation = "\n".join(str(_static_content(widget)) for widget in pane.query(Static))
@@ -1725,9 +1734,9 @@ def test_hermes_json_uses_json_inspector_with_transcript_labels(tmp_path):
     conversations_node = next(
         child
         for child in inspector._tree.root.children
-        if child.label.plain.startswith("Conversations ")
+        if _node_label(child).startswith("Conversations ")
     )
-    conversation_labels = [child.label.plain for child in conversations_node.children]
+    conversation_labels = [_node_label(child) for child in conversations_node.children]
     assert conversation_labels[0].startswith("[0] System")
     assert conversation_labels[1].startswith("[1] Human")
 
@@ -1744,8 +1753,10 @@ async def test_output_json_exposes_raw_path_on_selectable_nodes(tmp_path):
     trajectory_node = next(
         child
         for child in inspector._tree.root.children
-        if child.label.plain.startswith("Trajectory ")
+        if _node_label(child).startswith("Trajectory ")
     )
+    assert metadata_node.data is not None
+    assert trajectory_node.data is not None
     assert metadata_node.data.raw_path == ("trajectory", "metadata")
     assert trajectory_node.data.raw_path == ("trajectory",)
 
@@ -1772,6 +1783,7 @@ def test_text_formats_use_expected_syntax_preview(tmp_path, filename, lexer, con
     assert isinstance(widgets[0], Static)
     content = _static_content(widgets[0])
     assert isinstance(content, Syntax)
+    assert content.lexer is not None
     assert content.lexer.name.lower() == lexer
 
 
@@ -1819,6 +1831,7 @@ def test_synthetic_readme_formats_route_to_expected_syntax_preview(
     assert isinstance(widgets[0], Static)
     renderable = _static_content(widgets[0])
     assert isinstance(renderable, Syntax)
+    assert renderable.lexer is not None
     assert renderable.lexer.name.lower() == lexer
 
 

--- a/tests/test_refactor_contracts.py
+++ b/tests/test_refactor_contracts.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import runpy
+import sys
 
 import skim
 import skim.app as legacy_app
@@ -54,6 +55,7 @@ def test_python_m_skim_server_executes_web_entrypoint(monkeypatch) -> None:
     called: list[str] = []
 
     monkeypatch.setattr(server, "main", lambda: called.append("called"))
+    monkeypatch.delitem(sys.modules, "skim.server", raising=False)
 
     runpy.run_module("skim.server", run_name="__main__", alter_sys=True)
 

--- a/tests/test_refactor_contracts.py
+++ b/tests/test_refactor_contracts.py
@@ -30,6 +30,12 @@ def test_cli_module_exposes_console_entrypoints() -> None:
 
 def test_legacy_python_modules_are_thin_compatibility_shims() -> None:
     """Top-level modules should re-export symbols from the new adapter/core packages."""
+    assert legacy_app is app
+    assert legacy_preview is preview
+    assert legacy_scrolling is scrolling
+    assert legacy_trajectory is trajectory
+    assert legacy_web_preview is preview_serializer
+
     assert legacy_app.SkimApp is app.SkimApp
     assert legacy_preview.PreviewPane is preview.PreviewPane
     assert legacy_trajectory.TrajectoryViewer is trajectory.TrajectoryViewer
@@ -37,6 +43,10 @@ def test_legacy_python_modules_are_thin_compatibility_shims() -> None:
     assert legacy_scrolling.DirectoryTree is scrolling.DirectoryTree
     assert legacy_server.serve is server.serve
     assert legacy_web_preview.serialize_preview is preview_serializer.serialize_preview
+    assert (
+        legacy_web_preview.serialize_json_inspector_preview
+        is preview_serializer.serialize_json_inspector_preview
+    )
 
 
 def test_legacy_review_module_reexports_extension_constants() -> None:

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -30,8 +30,9 @@ def test_annotation_store_supports_file_level_annotation_round_trip(tmp_path):
     assert len(saved) == 1
     assert saved[0]["id"] == created.id
     assert saved[0]["tags"] == ["important", "follow-up"]
-    assert store.get_annotation(source, FILE_ANNOTATION_KEY) is not None
-    assert store.get_annotation(source, FILE_ANNOTATION_KEY).note == "Review the rollout wording."
+    stored = store.get_annotation(source, FILE_ANNOTATION_KEY)
+    assert stored is not None
+    assert stored.note == "Review the rollout wording."
 
 
 def test_annotation_store_supports_multiple_file_level_annotations_by_id(tmp_path):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import json
 import threading
+import urllib.error
 import urllib.parse
 import urllib.request
 from contextlib import contextmanager
 from functools import partial
 from http.server import HTTPServer
 from pathlib import Path
+from typing import Any, cast
 
 from conftest import sample_hermes_transcript, sample_submission, sample_trajectory, write_test_xlsx
 
@@ -35,7 +37,7 @@ def running_server(root: Path):
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     try:
-        host, port = server.server_address
+        host, port = cast(tuple[str, int], server.server_address)
         yield f"http://{host}:{port}"
     finally:
         server.shutdown()
@@ -48,8 +50,8 @@ def request_json(
     path: str,
     *,
     method: str = "GET",
-    body: dict | None = None,
-) -> tuple[int, dict]:
+    body: dict[str, Any] | None = None,
+) -> tuple[int, dict[str, Any]]:
     """Return the JSON response body for one request."""
     data = json.dumps(body).encode() if body is not None else None
     request = urllib.request.Request(
@@ -61,10 +63,10 @@ def request_json(
     try:
         with urllib.request.urlopen(request) as response:
             status = response.status
-            payload = json.loads(response.read().decode())
+            payload = cast(dict[str, Any], json.loads(response.read().decode()))
     except urllib.error.HTTPError as error:
         status = error.code
-        payload = json.loads(error.read().decode())
+        payload = cast(dict[str, Any], json.loads(error.read().decode()))
     return status, payload
 
 
@@ -73,17 +75,17 @@ def request_json_with_headers(
     path: str,
     *,
     method: str = "GET",
-) -> tuple[int, dict, object]:
+) -> tuple[int, dict[str, Any], Any]:
     """Return the JSON response body plus response headers for one request."""
     request = urllib.request.Request(base_url + path, method=method)
     try:
         with urllib.request.urlopen(request) as response:
             status = response.status
-            payload = json.loads(response.read().decode())
+            payload = cast(dict[str, Any], json.loads(response.read().decode()))
             headers = response.headers
     except urllib.error.HTTPError as error:
         status = error.code
-        payload = json.loads(error.read().decode())
+        payload = cast(dict[str, Any], json.loads(error.read().decode()))
         headers = error.headers
     return status, payload, headers
 

--- a/tests/test_trajectory_viewer.py
+++ b/tests/test_trajectory_viewer.py
@@ -12,6 +12,7 @@ from conftest import (
     _collapsible_by_title,
     _detail_syntax_blocks,
     _detail_text,
+    _node_label,
     _static_content,
     _top_level_collapsible_titles,
     _tree_labels,
@@ -46,12 +47,12 @@ def test_trajectory_tree_groups_step_events():
     step = viewer._tree.root.children[2]
 
     assert _tree_labels(viewer._tree) == ["Metadata", "Final Output", "Step 1"]
-    event_labels = [child.label.plain for child in step.children]
+    event_labels = [_node_label(child) for child in step.children]
     assert event_labels[0].startswith("001 Reasoning")
     assert event_labels[1].startswith("002 Assistant")
     assert event_labels[2].startswith("003 executeBash #")
     tool_node = step.children[2]
-    assert [child.label.plain for child in tool_node.children] == ["Input", "Output"]
+    assert [_node_label(child) for child in tool_node.children] == ["Input", "Output"]
 
 
 async def test_selecting_trajectory_tree_node_updates_detail():
@@ -337,9 +338,9 @@ async def test_unmatched_function_call_result_still_renders_safely():
     viewer = TrajectoryViewer(sample_trajectory(include_call=False))
     step = viewer._tree.root.children[2]
 
-    assert step.children[2].label.plain.startswith("003 executeBash #")
-    assert step.children[2].label.plain.endswith(" Output")
-    assert [child.label.plain for child in step.children[2].children] == ["Input", "Output"]
+    assert _node_label(step.children[2]).startswith("003 executeBash #")
+    assert _node_label(step.children[2]).endswith(" Output")
+    assert [_node_label(child) for child in step.children[2].children] == ["Input", "Output"]
 
 
 async def test_scroll_keys_scroll_trajectory_detail_panel():


### PR DESCRIPTION
## Summary
- Add shared Pyright basic-mode configuration for `src` and `tests` without adding Pyright as a dependency.
- Replace legacy dynamic shim modules with explicit re-export modules while preserving imports.
- Tighten source and test typing around Textual app access, preview widgets, JSON tree nodes, static content, server helpers, and optional values.

## Validation
- `uv run --with pyright pyright`
- `uv run ruff format .`
- `uv run ruff check .`
- `uv run pytest -v`
- `uv run pytest tests/test_app_shell.py tests/test_preview.py tests/test_trajectory_viewer.py tests/test_web_app_contract.py -v` (`174 passed`)
- Manual TUI smoke against `/private/tmp/skim-smoke.xASEHy`: shell/tree/preview, JSON navigation, split pane, pane cycle, quit.
- Manual web smoke at localhost: initial shell, tree expansion, JSON/Markdown/Text/CSV previews, split pane, theme toggle, command palette, Browse/Triage switch, empty console logs.

## Notes
- No Pyright dev dependency or lockfile change is included.
- Validation used temporary files under `/private/tmp`; no repo-tracked files changed during smoke testing.