### PR TITLE
[codex] add opt-in rendered HTML previews

### DIFF
--- a/src/skim/web/app.js
+++ b/src/skim/web/app.js
@@ -61,6 +61,7 @@ function createPaneState(id) {
     selectedJsonPath: null,
     selectedStepId: null,
     selectedWorkbookSheetName: null,
+    htmlPreviewMode: "source",
     selectedAnnotationIds: {},
     jsonSplitRatio: loadStoredSplitRatio("json", DEFAULT_JSON_SPLIT_RATIO, id),
     trajectorySplitRatio: loadStoredSplitRatio("trajectory", DEFAULT_TRAJECTORY_SPLIT_RATIO, id),
@@ -1526,6 +1527,14 @@ async function onPreviewClick(event, paneId = state.activePaneId) {
     return;
   }
 
+  const htmlPreviewMode = event.target.closest("[data-html-preview-mode]");
+  if (htmlPreviewMode) {
+    const mode = htmlPreviewMode.dataset.htmlPreviewMode;
+    pane.htmlPreviewMode = mode === "rendered" ? "rendered" : "source";
+    renderWorkspace();
+    return;
+  }
+
   const jsonToggle = event.target.closest("[data-toggle-json]");
   if (jsonToggle) {
     const node = jsonNodeByPath(pane, jsonToggle.dataset.toggleJson);
@@ -1580,6 +1589,7 @@ async function loadPreviewForPane(path, paneId, options = {}) {
     } else {
       pane.selectedWorkbookSheetName = null;
     }
+    pane.htmlPreviewMode = "source";
     if (options.selectedAnnotationPath && options.selectedAnnotationId) {
       pane.selectedAnnotationIds[options.selectedAnnotationPath] = options.selectedAnnotationId;
     }
@@ -1650,6 +1660,8 @@ function renderFileAnnotationPanel(pane, preview) {
 
 function renderTextPreview(preview) {
   const ctx = resolvePreviewInput(preview);
+  const htmlRenderable = isRenderableHtmlPreview(ctx.preview);
+  const htmlMode = htmlRenderable && ctx.pane?.htmlPreviewMode === "rendered" ? "rendered" : "source";
   return `
     <div class="preview-card">
       <div class="detail-meta">
@@ -1658,9 +1670,92 @@ function renderTextPreview(preview) {
       </div>
       ${renderFileAnnotationPanel(ctx.pane, ctx.preview)}
       ${ctx.preview.notice ? `<div class="preview-notice">${escapeHtml(ctx.preview.notice)}</div>` : ""}
-      ${renderRenderValue(ctx.preview.render || { kind: "text", value: ctx.preview.content })}
+      ${htmlRenderable ? renderHtmlPreviewControls(htmlMode) : ""}
+      ${
+        htmlMode === "rendered"
+          ? renderHtmlDocumentPreview(ctx.preview.content)
+          : renderRenderValue(ctx.preview.render || { kind: "text", value: ctx.preview.content })
+      }
     </div>
   `;
+}
+
+function isRenderableHtmlPreview(preview) {
+  return Boolean(
+    preview &&
+      preview.html_renderable === true &&
+      preview.language === "html" &&
+      typeof preview.content === "string",
+  );
+}
+
+function renderHtmlPreviewControls(mode) {
+  return `
+    <div class="html-preview-toggle" role="group" aria-label="HTML preview mode">
+      <button
+        class="title-button html-preview-toggle-button"
+        type="button"
+        data-html-preview-mode="source"
+        aria-pressed="${mode !== "rendered" ? "true" : "false"}"
+      >Source</button>
+      <button
+        class="title-button html-preview-toggle-button"
+        type="button"
+        data-html-preview-mode="rendered"
+        aria-pressed="${mode === "rendered" ? "true" : "false"}"
+      >Rendered</button>
+    </div>
+  `;
+}
+
+function renderHtmlDocumentPreview(content) {
+  return `
+    <div class="html-rendered-preview">
+      <iframe
+        class="html-rendered-frame"
+        title="Rendered HTML preview"
+        sandbox
+        referrerpolicy="no-referrer"
+        srcdoc="${escapeAttribute(renderHtmlPreviewDocument(content || ""))}"
+      ></iframe>
+    </div>
+  `;
+}
+
+function renderHtmlPreviewDocument(content) {
+  const csp = [
+    "default-src 'none'",
+    "script-src 'none'",
+    "connect-src 'none'",
+    "form-action 'none'",
+    "base-uri 'none'",
+    "object-src 'none'",
+    "frame-src 'none'",
+    "img-src data: blob:",
+    "media-src data: blob:",
+    "font-src data:",
+    "style-src 'unsafe-inline'",
+    "navigate-to 'none'",
+  ].join("; ");
+  return `<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta http-equiv="Content-Security-Policy" content="${csp}">
+<base href="about:blank">
+<style>
+  html, body {
+    margin: 0;
+    min-height: 100%;
+    background: white;
+    color: black;
+  }
+</style>
+</head>
+<body>
+${content}
+</body>
+</html>`;
 }
 
 function renderMarkdownPreview(preview) {

--- a/src/skim/web/app.js
+++ b/src/skim/web/app.js
@@ -257,6 +257,7 @@ function renderWorkspace() {
   applySidebarWidth();
   elements.paneGrid.innerHTML = renderPaneGridMarkup(state.panes);
   applyPaneGridLayout();
+  installRenderedHtmlPreviewGuards(elements.paneGrid);
 }
 
 function renderPaneShell(pane) {
@@ -1714,8 +1715,9 @@ function renderHtmlDocumentPreview(content) {
       <iframe
         class="html-rendered-frame"
         title="Rendered HTML preview"
-        sandbox
+        sandbox="allow-same-origin"
         referrerpolicy="no-referrer"
+        data-rendered-html-preview="true"
         srcdoc="${escapeAttribute(renderHtmlPreviewDocument(content || ""))}"
       ></iframe>
     </div>
@@ -1728,7 +1730,7 @@ function renderHtmlPreviewDocument(content) {
     "script-src 'none'",
     "connect-src 'none'",
     "form-action 'none'",
-    "base-uri 'none'",
+    "base-uri about:",
     "object-src 'none'",
     "frame-src 'none'",
     "img-src data: blob:",
@@ -1742,7 +1744,7 @@ function renderHtmlPreviewDocument(content) {
 <head>
 <meta charset="utf-8">
 <meta http-equiv="Content-Security-Policy" content="${csp}">
-<base href="about:blank">
+<base href="about:srcdoc">
 <style>
   html, body {
     margin: 0;
@@ -1756,6 +1758,63 @@ function renderHtmlPreviewDocument(content) {
 ${content}
 </body>
 </html>`;
+}
+
+function installRenderedHtmlPreviewGuards(root = document) {
+  const frames = root?.querySelectorAll?.("[data-rendered-html-preview]") || [];
+  for (const frame of frames) {
+    if (frame.dataset.linkGuardInstalled === "true") {
+      continue;
+    }
+    frame.dataset.linkGuardInstalled = "true";
+    frame.addEventListener("load", () => installRenderedHtmlPreviewGuard(frame));
+    installRenderedHtmlPreviewGuard(frame);
+  }
+}
+
+function installRenderedHtmlPreviewGuard(frame) {
+  let frameDocument;
+  try {
+    frameDocument = frame.contentDocument;
+  } catch {
+    return;
+  }
+  if (!frameDocument?.addEventListener || frameDocument.__skimRenderedHtmlLinkGuard) {
+    return;
+  }
+  frameDocument.__skimRenderedHtmlLinkGuard = true;
+  frameDocument.addEventListener(
+    "click",
+    (event) => handleRenderedHtmlPreviewDocumentClick(event, frameDocument),
+    true,
+  );
+}
+
+function handleRenderedHtmlPreviewDocumentClick(event, frameDocument) {
+  const link = event.target?.closest?.("a[href]");
+  if (!link) {
+    return false;
+  }
+  event.preventDefault();
+  const href = link.getAttribute("href") || "";
+  if (!href.startsWith("#") || href === "#") {
+    return true;
+  }
+  const targetName = decodeUrlFragment(href.slice(1));
+  const target =
+    frameDocument.getElementById?.(targetName) ||
+    frameDocument.getElementsByName?.(targetName)?.[0] ||
+    null;
+  target?.scrollIntoView?.({ block: "start" });
+  return true;
+}
+
+function decodeUrlFragment(value) {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
 }
 
 function renderMarkdownPreview(preview) {
@@ -2980,3 +3039,4 @@ globalThis.canResizePaneLayout = canResizePaneLayout;
 globalThis.canResizeSplitViews = canResizeSplitViews;
 globalThis.onWorkspaceClick = onWorkspaceClick;
 globalThis.groupedTriageItems = groupedTriageItems;
+globalThis.handleRenderedHtmlPreviewDocumentClick = handleRenderedHtmlPreviewDocumentClick;

--- a/src/skim/web/styles.css
+++ b/src/skim/web/styles.css
@@ -1225,6 +1225,40 @@ button {
   margin: 0 0 10px;
 }
 
+.html-preview-toggle {
+  display: inline-flex;
+  align-self: flex-start;
+  gap: 0;
+  margin-bottom: 12px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.html-preview-toggle-button {
+  border: 0;
+  border-radius: 0;
+}
+
+.html-preview-toggle-button[aria-pressed="true"] {
+  background: var(--bg-highlight);
+  color: var(--fg-primary);
+}
+
+.html-rendered-preview {
+  min-height: 320px;
+  border: 1px solid var(--border-subtle);
+  background: white;
+}
+
+.html-rendered-frame {
+  display: block;
+  width: 100%;
+  min-height: 520px;
+  border: 0;
+  background: white;
+}
+
 .table-wrap {
   overflow: auto;
 }

--- a/src/skim/web/styles.css
+++ b/src/skim/web/styles.css
@@ -1246,7 +1246,7 @@ button {
 }
 
 .html-rendered-preview {
-  min-height: 320px;
+  height: clamp(640px, calc(100vh - 260px), 1200px);
   border: 1px solid var(--border-subtle);
   background: white;
 }
@@ -1254,7 +1254,7 @@ button {
 .html-rendered-frame {
   display: block;
   width: 100%;
-  min-height: 520px;
+  height: 100%;
   border: 0;
   background: white;
 }

--- a/src/skim/webui/preview_serializer.py
+++ b/src/skim/webui/preview_serializer.py
@@ -198,6 +198,7 @@ def serialize_preview(
             relative_path,
             content,
             language=SYNTAX_MAP.get(suffix),
+            html_renderable=suffix == ".html",
         ),
         source_path=resolved,
         annotation_store=store,
@@ -949,8 +950,9 @@ def _text_payload(
     content: str,
     *,
     language: str | None,
+    html_renderable: bool = False,
 ) -> dict[str, Any]:
-    return {
+    payload = {
         "kind": "text",
         "name": name,
         "path": relative_path,
@@ -958,6 +960,9 @@ def _text_payload(
         "content": content,
         "render": _syntax_payload(content, language=language, line_numbers=True),
     }
+    if html_renderable:
+        payload["html_renderable"] = True
+    return payload
 
 
 def _with_file_annotation_payload(

--- a/src/skim/webui/preview_serializer.py
+++ b/src/skim/webui/preview_serializer.py
@@ -256,9 +256,11 @@ def _plain_text_fallback_payload(
             "path": relative_path,
             "message": f"Could not read {path.name}: {error}",
         }
-    notice = (
-        "Plain text preview: "
-        f"{path.name} is {size:,} bytes, above the rich preview limit of {rich_limit:,} bytes."
+    notice = _plain_text_fallback_notice(
+        path.name,
+        size=size,
+        rich_limit=rich_limit,
+        html_renderable=html_renderable,
     )
     payload = {
         "kind": "text",
@@ -273,6 +275,26 @@ def _plain_text_fallback_payload(
     if html_renderable:
         payload["html_renderable"] = True
     return payload
+
+
+def _plain_text_fallback_notice(
+    name: str,
+    *,
+    size: int,
+    rich_limit: int,
+    html_renderable: bool,
+) -> str:
+    """Return the user-facing notice for a degraded text preview."""
+    if html_renderable:
+        return (
+            "Source preview: syntax highlighting skipped because "
+            f"{name} is {size:,} bytes, above the rich source preview limit of "
+            f"{rich_limit:,} bytes."
+        )
+    return (
+        "Plain text preview: "
+        f"{name} is {size:,} bytes, above the rich preview limit of {rich_limit:,} bytes."
+    )
 
 
 def _serialize_json_file(

--- a/src/skim/webui/preview_serializer.py
+++ b/src/skim/webui/preview_serializer.py
@@ -120,6 +120,7 @@ def serialize_preview(
                 relative_path=relative_path,
                 size=size,
                 rich_limit=max_size,
+                html_renderable=suffix == ".html",
             )
             if payload["kind"] != "error":
                 return _with_file_annotation_payload(
@@ -243,6 +244,7 @@ def _plain_text_fallback_payload(
     relative_path: str,
     size: int,
     rich_limit: int,
+    html_renderable: bool = False,
 ) -> dict[str, Any]:
     """Return a plain-text payload for files too large for rich rendering."""
     try:
@@ -258,7 +260,7 @@ def _plain_text_fallback_payload(
         "Plain text preview: "
         f"{path.name} is {size:,} bytes, above the rich preview limit of {rich_limit:,} bytes."
     )
-    return {
+    payload = {
         "kind": "text",
         "name": path.name,
         "path": relative_path,
@@ -268,6 +270,9 @@ def _plain_text_fallback_payload(
         "degraded": True,
         "notice": notice,
     }
+    if html_renderable:
+        payload["html_renderable"] = True
+    return payload
 
 
 def _serialize_json_file(

--- a/src/skim/webui/static/app.js
+++ b/src/skim/webui/static/app.js
@@ -61,6 +61,7 @@ function createPaneState(id) {
     selectedJsonPath: null,
     selectedStepId: null,
     selectedWorkbookSheetName: null,
+    htmlPreviewMode: "source",
     selectedAnnotationIds: {},
     jsonSplitRatio: loadStoredSplitRatio("json", DEFAULT_JSON_SPLIT_RATIO, id),
     trajectorySplitRatio: loadStoredSplitRatio("trajectory", DEFAULT_TRAJECTORY_SPLIT_RATIO, id),
@@ -1526,6 +1527,14 @@ async function onPreviewClick(event, paneId = state.activePaneId) {
     return;
   }
 
+  const htmlPreviewMode = event.target.closest("[data-html-preview-mode]");
+  if (htmlPreviewMode) {
+    const mode = htmlPreviewMode.dataset.htmlPreviewMode;
+    pane.htmlPreviewMode = mode === "rendered" ? "rendered" : "source";
+    renderWorkspace();
+    return;
+  }
+
   const jsonToggle = event.target.closest("[data-toggle-json]");
   if (jsonToggle) {
     const node = jsonNodeByPath(pane, jsonToggle.dataset.toggleJson);
@@ -1580,6 +1589,7 @@ async function loadPreviewForPane(path, paneId, options = {}) {
     } else {
       pane.selectedWorkbookSheetName = null;
     }
+    pane.htmlPreviewMode = "source";
     if (options.selectedAnnotationPath && options.selectedAnnotationId) {
       pane.selectedAnnotationIds[options.selectedAnnotationPath] = options.selectedAnnotationId;
     }
@@ -1650,6 +1660,8 @@ function renderFileAnnotationPanel(pane, preview) {
 
 function renderTextPreview(preview) {
   const ctx = resolvePreviewInput(preview);
+  const htmlRenderable = isRenderableHtmlPreview(ctx.preview);
+  const htmlMode = htmlRenderable && ctx.pane?.htmlPreviewMode === "rendered" ? "rendered" : "source";
   return `
     <div class="preview-card">
       <div class="detail-meta">
@@ -1658,9 +1670,92 @@ function renderTextPreview(preview) {
       </div>
       ${renderFileAnnotationPanel(ctx.pane, ctx.preview)}
       ${ctx.preview.notice ? `<div class="preview-notice">${escapeHtml(ctx.preview.notice)}</div>` : ""}
-      ${renderRenderValue(ctx.preview.render || { kind: "text", value: ctx.preview.content })}
+      ${htmlRenderable ? renderHtmlPreviewControls(htmlMode) : ""}
+      ${
+        htmlMode === "rendered"
+          ? renderHtmlDocumentPreview(ctx.preview.content)
+          : renderRenderValue(ctx.preview.render || { kind: "text", value: ctx.preview.content })
+      }
     </div>
   `;
+}
+
+function isRenderableHtmlPreview(preview) {
+  return Boolean(
+    preview &&
+      preview.html_renderable === true &&
+      preview.language === "html" &&
+      typeof preview.content === "string",
+  );
+}
+
+function renderHtmlPreviewControls(mode) {
+  return `
+    <div class="html-preview-toggle" role="group" aria-label="HTML preview mode">
+      <button
+        class="title-button html-preview-toggle-button"
+        type="button"
+        data-html-preview-mode="source"
+        aria-pressed="${mode !== "rendered" ? "true" : "false"}"
+      >Source</button>
+      <button
+        class="title-button html-preview-toggle-button"
+        type="button"
+        data-html-preview-mode="rendered"
+        aria-pressed="${mode === "rendered" ? "true" : "false"}"
+      >Rendered</button>
+    </div>
+  `;
+}
+
+function renderHtmlDocumentPreview(content) {
+  return `
+    <div class="html-rendered-preview">
+      <iframe
+        class="html-rendered-frame"
+        title="Rendered HTML preview"
+        sandbox
+        referrerpolicy="no-referrer"
+        srcdoc="${escapeAttribute(renderHtmlPreviewDocument(content || ""))}"
+      ></iframe>
+    </div>
+  `;
+}
+
+function renderHtmlPreviewDocument(content) {
+  const csp = [
+    "default-src 'none'",
+    "script-src 'none'",
+    "connect-src 'none'",
+    "form-action 'none'",
+    "base-uri 'none'",
+    "object-src 'none'",
+    "frame-src 'none'",
+    "img-src data: blob:",
+    "media-src data: blob:",
+    "font-src data:",
+    "style-src 'unsafe-inline'",
+    "navigate-to 'none'",
+  ].join("; ");
+  return `<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta http-equiv="Content-Security-Policy" content="${csp}">
+<base href="about:blank">
+<style>
+  html, body {
+    margin: 0;
+    min-height: 100%;
+    background: white;
+    color: black;
+  }
+</style>
+</head>
+<body>
+${content}
+</body>
+</html>`;
 }
 
 function renderMarkdownPreview(preview) {

--- a/src/skim/webui/static/app.js
+++ b/src/skim/webui/static/app.js
@@ -257,6 +257,7 @@ function renderWorkspace() {
   applySidebarWidth();
   elements.paneGrid.innerHTML = renderPaneGridMarkup(state.panes);
   applyPaneGridLayout();
+  installRenderedHtmlPreviewGuards(elements.paneGrid);
 }
 
 function renderPaneShell(pane) {
@@ -1714,8 +1715,9 @@ function renderHtmlDocumentPreview(content) {
       <iframe
         class="html-rendered-frame"
         title="Rendered HTML preview"
-        sandbox
+        sandbox="allow-same-origin"
         referrerpolicy="no-referrer"
+        data-rendered-html-preview="true"
         srcdoc="${escapeAttribute(renderHtmlPreviewDocument(content || ""))}"
       ></iframe>
     </div>
@@ -1728,7 +1730,7 @@ function renderHtmlPreviewDocument(content) {
     "script-src 'none'",
     "connect-src 'none'",
     "form-action 'none'",
-    "base-uri 'none'",
+    "base-uri about:",
     "object-src 'none'",
     "frame-src 'none'",
     "img-src data: blob:",
@@ -1742,7 +1744,7 @@ function renderHtmlPreviewDocument(content) {
 <head>
 <meta charset="utf-8">
 <meta http-equiv="Content-Security-Policy" content="${csp}">
-<base href="about:blank">
+<base href="about:srcdoc">
 <style>
   html, body {
     margin: 0;
@@ -1756,6 +1758,63 @@ function renderHtmlPreviewDocument(content) {
 ${content}
 </body>
 </html>`;
+}
+
+function installRenderedHtmlPreviewGuards(root = document) {
+  const frames = root?.querySelectorAll?.("[data-rendered-html-preview]") || [];
+  for (const frame of frames) {
+    if (frame.dataset.linkGuardInstalled === "true") {
+      continue;
+    }
+    frame.dataset.linkGuardInstalled = "true";
+    frame.addEventListener("load", () => installRenderedHtmlPreviewGuard(frame));
+    installRenderedHtmlPreviewGuard(frame);
+  }
+}
+
+function installRenderedHtmlPreviewGuard(frame) {
+  let frameDocument;
+  try {
+    frameDocument = frame.contentDocument;
+  } catch {
+    return;
+  }
+  if (!frameDocument?.addEventListener || frameDocument.__skimRenderedHtmlLinkGuard) {
+    return;
+  }
+  frameDocument.__skimRenderedHtmlLinkGuard = true;
+  frameDocument.addEventListener(
+    "click",
+    (event) => handleRenderedHtmlPreviewDocumentClick(event, frameDocument),
+    true,
+  );
+}
+
+function handleRenderedHtmlPreviewDocumentClick(event, frameDocument) {
+  const link = event.target?.closest?.("a[href]");
+  if (!link) {
+    return false;
+  }
+  event.preventDefault();
+  const href = link.getAttribute("href") || "";
+  if (!href.startsWith("#") || href === "#") {
+    return true;
+  }
+  const targetName = decodeUrlFragment(href.slice(1));
+  const target =
+    frameDocument.getElementById?.(targetName) ||
+    frameDocument.getElementsByName?.(targetName)?.[0] ||
+    null;
+  target?.scrollIntoView?.({ block: "start" });
+  return true;
+}
+
+function decodeUrlFragment(value) {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
 }
 
 function renderMarkdownPreview(preview) {
@@ -2980,3 +3039,4 @@ globalThis.canResizePaneLayout = canResizePaneLayout;
 globalThis.canResizeSplitViews = canResizeSplitViews;
 globalThis.onWorkspaceClick = onWorkspaceClick;
 globalThis.groupedTriageItems = groupedTriageItems;
+globalThis.handleRenderedHtmlPreviewDocumentClick = handleRenderedHtmlPreviewDocumentClick;

--- a/src/skim/webui/static/main.js
+++ b/src/skim/webui/static/main.js
@@ -61,6 +61,7 @@ function createPaneState(id) {
     selectedJsonPath: null,
     selectedStepId: null,
     selectedWorkbookSheetName: null,
+    htmlPreviewMode: "source",
     selectedAnnotationIds: {},
     jsonSplitRatio: loadStoredSplitRatio("json", DEFAULT_JSON_SPLIT_RATIO, id),
     trajectorySplitRatio: loadStoredSplitRatio("trajectory", DEFAULT_TRAJECTORY_SPLIT_RATIO, id),
@@ -1526,6 +1527,14 @@ async function onPreviewClick(event, paneId = state.activePaneId) {
     return;
   }
 
+  const htmlPreviewMode = event.target.closest("[data-html-preview-mode]");
+  if (htmlPreviewMode) {
+    const mode = htmlPreviewMode.dataset.htmlPreviewMode;
+    pane.htmlPreviewMode = mode === "rendered" ? "rendered" : "source";
+    renderWorkspace();
+    return;
+  }
+
   const jsonToggle = event.target.closest("[data-toggle-json]");
   if (jsonToggle) {
     const node = jsonNodeByPath(pane, jsonToggle.dataset.toggleJson);
@@ -1580,6 +1589,7 @@ async function loadPreviewForPane(path, paneId, options = {}) {
     } else {
       pane.selectedWorkbookSheetName = null;
     }
+    pane.htmlPreviewMode = "source";
     if (options.selectedAnnotationPath && options.selectedAnnotationId) {
       pane.selectedAnnotationIds[options.selectedAnnotationPath] = options.selectedAnnotationId;
     }
@@ -1650,6 +1660,8 @@ function renderFileAnnotationPanel(pane, preview) {
 
 function renderTextPreview(preview) {
   const ctx = resolvePreviewInput(preview);
+  const htmlRenderable = isRenderableHtmlPreview(ctx.preview);
+  const htmlMode = htmlRenderable && ctx.pane?.htmlPreviewMode === "rendered" ? "rendered" : "source";
   return `
     <div class="preview-card">
       <div class="detail-meta">
@@ -1658,9 +1670,92 @@ function renderTextPreview(preview) {
       </div>
       ${renderFileAnnotationPanel(ctx.pane, ctx.preview)}
       ${ctx.preview.notice ? `<div class="preview-notice">${escapeHtml(ctx.preview.notice)}</div>` : ""}
-      ${renderRenderValue(ctx.preview.render || { kind: "text", value: ctx.preview.content })}
+      ${htmlRenderable ? renderHtmlPreviewControls(htmlMode) : ""}
+      ${
+        htmlMode === "rendered"
+          ? renderHtmlDocumentPreview(ctx.preview.content)
+          : renderRenderValue(ctx.preview.render || { kind: "text", value: ctx.preview.content })
+      }
     </div>
   `;
+}
+
+function isRenderableHtmlPreview(preview) {
+  return Boolean(
+    preview &&
+      preview.html_renderable === true &&
+      preview.language === "html" &&
+      typeof preview.content === "string",
+  );
+}
+
+function renderHtmlPreviewControls(mode) {
+  return `
+    <div class="html-preview-toggle" role="group" aria-label="HTML preview mode">
+      <button
+        class="title-button html-preview-toggle-button"
+        type="button"
+        data-html-preview-mode="source"
+        aria-pressed="${mode !== "rendered" ? "true" : "false"}"
+      >Source</button>
+      <button
+        class="title-button html-preview-toggle-button"
+        type="button"
+        data-html-preview-mode="rendered"
+        aria-pressed="${mode === "rendered" ? "true" : "false"}"
+      >Rendered</button>
+    </div>
+  `;
+}
+
+function renderHtmlDocumentPreview(content) {
+  return `
+    <div class="html-rendered-preview">
+      <iframe
+        class="html-rendered-frame"
+        title="Rendered HTML preview"
+        sandbox
+        referrerpolicy="no-referrer"
+        srcdoc="${escapeAttribute(renderHtmlPreviewDocument(content || ""))}"
+      ></iframe>
+    </div>
+  `;
+}
+
+function renderHtmlPreviewDocument(content) {
+  const csp = [
+    "default-src 'none'",
+    "script-src 'none'",
+    "connect-src 'none'",
+    "form-action 'none'",
+    "base-uri 'none'",
+    "object-src 'none'",
+    "frame-src 'none'",
+    "img-src data: blob:",
+    "media-src data: blob:",
+    "font-src data:",
+    "style-src 'unsafe-inline'",
+    "navigate-to 'none'",
+  ].join("; ");
+  return `<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta http-equiv="Content-Security-Policy" content="${csp}">
+<base href="about:blank">
+<style>
+  html, body {
+    margin: 0;
+    min-height: 100%;
+    background: white;
+    color: black;
+  }
+</style>
+</head>
+<body>
+${content}
+</body>
+</html>`;
 }
 
 function renderMarkdownPreview(preview) {

--- a/src/skim/webui/static/main.js
+++ b/src/skim/webui/static/main.js
@@ -257,6 +257,7 @@ function renderWorkspace() {
   applySidebarWidth();
   elements.paneGrid.innerHTML = renderPaneGridMarkup(state.panes);
   applyPaneGridLayout();
+  installRenderedHtmlPreviewGuards(elements.paneGrid);
 }
 
 function renderPaneShell(pane) {
@@ -1714,8 +1715,9 @@ function renderHtmlDocumentPreview(content) {
       <iframe
         class="html-rendered-frame"
         title="Rendered HTML preview"
-        sandbox
+        sandbox="allow-same-origin"
         referrerpolicy="no-referrer"
+        data-rendered-html-preview="true"
         srcdoc="${escapeAttribute(renderHtmlPreviewDocument(content || ""))}"
       ></iframe>
     </div>
@@ -1728,7 +1730,7 @@ function renderHtmlPreviewDocument(content) {
     "script-src 'none'",
     "connect-src 'none'",
     "form-action 'none'",
-    "base-uri 'none'",
+    "base-uri about:",
     "object-src 'none'",
     "frame-src 'none'",
     "img-src data: blob:",
@@ -1742,7 +1744,7 @@ function renderHtmlPreviewDocument(content) {
 <head>
 <meta charset="utf-8">
 <meta http-equiv="Content-Security-Policy" content="${csp}">
-<base href="about:blank">
+<base href="about:srcdoc">
 <style>
   html, body {
     margin: 0;
@@ -1756,6 +1758,63 @@ function renderHtmlPreviewDocument(content) {
 ${content}
 </body>
 </html>`;
+}
+
+function installRenderedHtmlPreviewGuards(root = document) {
+  const frames = root?.querySelectorAll?.("[data-rendered-html-preview]") || [];
+  for (const frame of frames) {
+    if (frame.dataset.linkGuardInstalled === "true") {
+      continue;
+    }
+    frame.dataset.linkGuardInstalled = "true";
+    frame.addEventListener("load", () => installRenderedHtmlPreviewGuard(frame));
+    installRenderedHtmlPreviewGuard(frame);
+  }
+}
+
+function installRenderedHtmlPreviewGuard(frame) {
+  let frameDocument;
+  try {
+    frameDocument = frame.contentDocument;
+  } catch {
+    return;
+  }
+  if (!frameDocument?.addEventListener || frameDocument.__skimRenderedHtmlLinkGuard) {
+    return;
+  }
+  frameDocument.__skimRenderedHtmlLinkGuard = true;
+  frameDocument.addEventListener(
+    "click",
+    (event) => handleRenderedHtmlPreviewDocumentClick(event, frameDocument),
+    true,
+  );
+}
+
+function handleRenderedHtmlPreviewDocumentClick(event, frameDocument) {
+  const link = event.target?.closest?.("a[href]");
+  if (!link) {
+    return false;
+  }
+  event.preventDefault();
+  const href = link.getAttribute("href") || "";
+  if (!href.startsWith("#") || href === "#") {
+    return true;
+  }
+  const targetName = decodeUrlFragment(href.slice(1));
+  const target =
+    frameDocument.getElementById?.(targetName) ||
+    frameDocument.getElementsByName?.(targetName)?.[0] ||
+    null;
+  target?.scrollIntoView?.({ block: "start" });
+  return true;
+}
+
+function decodeUrlFragment(value) {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
 }
 
 function renderMarkdownPreview(preview) {
@@ -2980,6 +3039,7 @@ globalThis.canResizePaneLayout = canResizePaneLayout;
 globalThis.canResizeSplitViews = canResizeSplitViews;
 globalThis.onWorkspaceClick = onWorkspaceClick;
 globalThis.groupedTriageItems = groupedTriageItems;
+globalThis.handleRenderedHtmlPreviewDocumentClick = handleRenderedHtmlPreviewDocumentClick;
 
 export {
   activePane,
@@ -3014,6 +3074,7 @@ export {
   flattenTreeFiles,
   fuzzyScore,
   groupedTriageItems,
+  handleRenderedHtmlPreviewDocumentClick,
   initializeJsonState,
   initializeWorkbookState,
   isStackedLayout,

--- a/src/skim/webui/static/styles.css
+++ b/src/skim/webui/static/styles.css
@@ -1225,6 +1225,40 @@ button {
   margin: 0 0 10px;
 }
 
+.html-preview-toggle {
+  display: inline-flex;
+  align-self: flex-start;
+  gap: 0;
+  margin-bottom: 12px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.html-preview-toggle-button {
+  border: 0;
+  border-radius: 0;
+}
+
+.html-preview-toggle-button[aria-pressed="true"] {
+  background: var(--bg-highlight);
+  color: var(--fg-primary);
+}
+
+.html-rendered-preview {
+  min-height: 320px;
+  border: 1px solid var(--border-subtle);
+  background: white;
+}
+
+.html-rendered-frame {
+  display: block;
+  width: 100%;
+  min-height: 520px;
+  border: 0;
+  background: white;
+}
+
 .table-wrap {
   overflow: auto;
 }

--- a/src/skim/webui/static/styles.css
+++ b/src/skim/webui/static/styles.css
@@ -1246,7 +1246,7 @@ button {
 }
 
 .html-rendered-preview {
-  min-height: 320px;
+  height: clamp(640px, calc(100vh - 260px), 1200px);
   border: 1px solid var(--border-subtle);
   background: white;
 }
@@ -1254,7 +1254,7 @@ button {
 .html-rendered-frame {
   display: block;
   width: 100%;
-  min-height: 520px;
+  height: 100%;
   border: 0;
   background: white;
 }

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -225,7 +225,10 @@ def test_api_preview_large_html_fallback_still_allows_rendered_mode(tmp_path, mo
     assert payload["path"] == "large.html"
     assert payload["language"] == "html"
     assert payload["degraded"] is True
-    assert "Plain text preview" in payload["notice"]
+    assert payload["notice"] == (
+        "Source preview: syntax highlighting skipped because large.html is 112 bytes, "
+        "above the rich source preview limit of 24 bytes."
+    )
     assert payload["html_renderable"] is True
     assert payload["render"] == {"kind": "text", "value": content}
     assert "html" not in payload["render"]

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -211,6 +211,26 @@ def test_api_preview_large_text_falls_back_to_plain_payload(tmp_path, monkeypatc
     }
 
 
+def test_api_preview_large_html_fallback_still_allows_rendered_mode(tmp_path, monkeypatch):
+    """Large readable HTML should skip syntax source but keep rendered HTML available."""
+    monkeypatch.setattr(web_preview_module, "MAX_FILE_SIZE", 24)
+    monkeypatch.setattr(web_preview_module, "MAX_PLAIN_FALLBACK_FILE_SIZE", 512)
+    content = "<!doctype html><html><body><h1>Hello</h1></body></html>\n" * 2
+    test_file = tmp_path / "large.html"
+    test_file.write_text(content)
+
+    payload = serialize_preview(test_file, browse_root=tmp_path)
+
+    assert payload["kind"] == "text"
+    assert payload["path"] == "large.html"
+    assert payload["language"] == "html"
+    assert payload["degraded"] is True
+    assert "Plain text preview" in payload["notice"]
+    assert payload["html_renderable"] is True
+    assert payload["render"] == {"kind": "text", "value": content}
+    assert "html" not in payload["render"]
+
+
 def test_api_preview_large_json_falls_back_to_plain_payload(tmp_path, monkeypatch):
     """Large JSON should avoid building a browser JSON tree."""
     monkeypatch.setattr(web_preview_module, "MAX_JSON_FILE_SIZE", 24)
@@ -796,6 +816,19 @@ def test_stylesheet_increases_preview_readability_defaults(tmp_path):
     assert ".detail-panel,\n.step-detail" in css or ".detail-panel,\r\n.step-detail" in css
     assert ".tree-row" in css
     assert "padding: 9px 12px;" in css
+
+
+def test_stylesheet_gives_rendered_html_a_viewport_sized_frame(tmp_path):
+    """Rendered HTML should use a substantial viewport-aware document frame."""
+    with running_server(tmp_path) as base_url:
+        request = urllib.request.Request(base_url + "/styles.css")
+        with urllib.request.urlopen(request) as response:
+            css = response.read().decode()
+
+    assert ".html-rendered-preview" in css
+    assert "height: clamp(640px, calc(100vh - 260px), 1200px);" in css
+    assert ".html-rendered-frame" in css
+    assert "height: 100%;" in css
 
 
 def test_stylesheet_defines_file_and_json_color_tokens(tmp_path):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -113,6 +113,35 @@ def test_api_preview_returns_text_payload_for_plain_file(tmp_path):
     assert "tok-nb" in payload["render"]["html"] or "tok-n" in payload["render"]["html"]
 
 
+def test_api_preview_marks_html_as_renderable_without_changing_source_payload(tmp_path):
+    """HTML previews should keep source rendering while advertising rendered mode."""
+    test_file = tmp_path / "example.html"
+    test_file.write_text("<!doctype html><html><body><h1>Hi</h1></body></html>\n")
+
+    payload = serialize_preview(test_file, browse_root=tmp_path)
+
+    assert payload["kind"] == "text"
+    assert payload["path"] == "example.html"
+    assert payload["language"] == "html"
+    assert payload["content"].startswith("<!doctype html>")
+    assert payload["render"]["kind"] == "syntax"
+    assert payload["render"]["language"] == "html"
+    assert payload["render"]["line_numbers"] is True
+    assert payload["html_renderable"] is True
+
+
+def test_api_preview_does_not_mark_non_html_text_as_renderable(tmp_path):
+    """Only HTML files should advertise the rendered HTML option."""
+    test_file = tmp_path / "example.css"
+    test_file.write_text("body { color: red; }\n")
+
+    payload = serialize_preview(test_file, browse_root=tmp_path)
+
+    assert payload["kind"] == "text"
+    assert payload["language"] == "css"
+    assert "html_renderable" not in payload
+
+
 def test_api_preview_omits_wildcard_cors_headers(tmp_path):
     """Local API responses should not be exposed cross-origin to arbitrary websites."""
     test_file = tmp_path / "example.py"

--- a/tests/test_web_app_contract.py
+++ b/tests/test_web_app_contract.py
@@ -181,6 +181,12 @@ console.log(JSON.stringify({
   hasCsp: html.includes('Content-Security-Policy'),
   blocksScripts: html.includes("script-src &#39;none&#39;"),
   blocksForms: html.includes("form-action &#39;none&#39;"),
+  allowsSrcdocBase: html.includes("base-uri about:"),
+  blocksBaseNone: html.includes("base-uri &#39;none&#39;"),
+  hasSrcdocBase: html.includes("&lt;base href=&quot;about:srcdoc&quot;&gt;"),
+  hasSameOriginSandbox: html.includes('sandbox="allow-same-origin"'),
+  allowsScriptsSandbox: html.includes("allow-scripts"),
+  marksRenderedFrame: html.includes('data-rendered-html-preview="true"'),
   blocksRemoteResources: html.includes("img-src data: blob:"),
   hidesSyntax: !html.includes("syntax-block"),
 }));
@@ -195,8 +201,84 @@ console.log(JSON.stringify({
         "hasCsp": True,
         "blocksScripts": True,
         "blocksForms": True,
+        "allowsSrcdocBase": True,
+        "blocksBaseNone": False,
+        "hasSrcdocBase": True,
+        "hasSameOriginSandbox": True,
+        "allowsScriptsSandbox": False,
+        "marksRenderedFrame": True,
         "blocksRemoteResources": True,
         "hidesSyntax": True,
+    }
+
+
+def test_rendered_html_link_guard_scrolls_fragment_targets():
+    """Rendered HTML fragment links should scroll inside the iframe document."""
+    result = run_app_js(
+        """
+let prevented = 0;
+let scrolled = 0;
+const target = { scrollIntoView(options) { scrolled += options.block === "start" ? 1 : 10; } };
+const doc = {
+  getElementById(id) { return id === "step-1" ? target : null; },
+  getElementsByName() { return []; },
+};
+const link = {
+  getAttribute(name) { return name === "href" ? "#step-1" : null; },
+};
+const event = {
+  target: { closest(selector) { return selector === "a[href]" ? link : null; } },
+  preventDefault() { prevented += 1; },
+};
+const handled = ctx.handleRenderedHtmlPreviewDocumentClick(event, doc);
+console.log(JSON.stringify({ handled, prevented, scrolled }));
+"""
+    )
+
+    assert result == {"handled": True, "prevented": 1, "scrolled": 1}
+
+
+def test_rendered_html_link_guard_blocks_non_fragment_links():
+    """Rendered HTML links should not navigate to external or relative targets."""
+    result = run_app_js(
+        """
+let prevented = 0;
+let scrolled = 0;
+const doc = {
+  getElementById() { return { scrollIntoView() { scrolled += 1; } }; },
+  getElementsByName() { return []; },
+};
+function run(href) {
+  const link = {
+    getAttribute(name) { return name === "href" ? href : null; },
+  };
+  return ctx.handleRenderedHtmlPreviewDocumentClick({
+    target: { closest(selector) { return selector === "a[href]" ? link : null; } },
+    preventDefault() { prevented += 1; },
+  }, doc);
+}
+const externalHandled = run("https://example.com/");
+const relativeHandled = run("local/page.html");
+const nonLinkHandled = ctx.handleRenderedHtmlPreviewDocumentClick({
+  target: { closest() { return null; } },
+  preventDefault() { prevented += 100; },
+}, doc);
+console.log(JSON.stringify({
+  externalHandled,
+  relativeHandled,
+  nonLinkHandled,
+  prevented,
+  scrolled,
+}));
+"""
+    )
+
+    assert result == {
+        "externalHandled": True,
+        "relativeHandled": True,
+        "nonLinkHandled": False,
+        "prevented": 2,
+        "scrolled": 0,
     }
 
 

--- a/tests/test_web_app_contract.py
+++ b/tests/test_web_app_contract.py
@@ -200,6 +200,48 @@ console.log(JSON.stringify({
     }
 
 
+def test_render_degraded_html_preview_keeps_notice_toggle_and_rendered_mode():
+    """Large HTML source fallback should still be switchable to rendered mode."""
+    result = run_app_js(
+        """
+const pane = ctx.createPaneState("pane-1");
+pane.preview = {
+  kind: "text",
+  path: "large.html",
+  language: "html",
+  content: "<!doctype html><h1>Large</h1>",
+  html_renderable: true,
+  degraded: true,
+  notice: "Plain text preview: rich rendering skipped.",
+  render: { kind: "text", value: "<!doctype html><h1>Large</h1>" },
+};
+const sourceHtml = ctx.renderTextPreview(pane);
+pane.htmlPreviewMode = "rendered";
+const renderedHtml = ctx.renderTextPreview(pane);
+console.log(JSON.stringify({
+  sourceHasNotice: sourceHtml.includes("Plain text preview"),
+  sourceHasToggle: sourceHtml.includes('data-html-preview-mode="source"') &&
+    sourceHtml.includes('data-html-preview-mode="rendered"'),
+  sourceUsesTextFallback: sourceHtml.includes("text-block"),
+  sourceHasFrame: sourceHtml.includes("<iframe"),
+  renderedHasFrame: renderedHtml.includes("<iframe"),
+  renderedHasCsp: renderedHtml.includes("Content-Security-Policy"),
+  renderedHidesTextFallback: !renderedHtml.includes("text-block"),
+}));
+"""
+    )
+
+    assert result == {
+        "sourceHasNotice": True,
+        "sourceHasToggle": True,
+        "sourceUsesTextFallback": True,
+        "sourceHasFrame": False,
+        "renderedHasFrame": True,
+        "renderedHasCsp": True,
+        "renderedHidesTextFallback": True,
+    }
+
+
 def test_render_non_html_text_preview_omits_html_toggle_and_frame():
     """Non-HTML text previews should keep the existing single source view."""
     result = run_app_js(

--- a/tests/test_web_app_contract.py
+++ b/tests/test_web_app_contract.py
@@ -120,6 +120,115 @@ console.log(JSON.stringify({
     }
 
 
+def test_render_html_preview_defaults_to_source_with_toggle():
+    """Renderable HTML previews should keep source mode as the default."""
+    result = run_app_js(
+        """
+const pane = ctx.createPaneState("pane-1");
+pane.preview = {
+  kind: "text",
+  path: "example.html",
+  language: "html",
+  content: "<!doctype html><h1>Hello</h1>",
+  html_renderable: true,
+  render: {
+    kind: "syntax",
+    html: '<div class="syntax-block"><span class="tok-nt">h1</span></div>',
+    value: "<!doctype html><h1>Hello</h1>",
+  },
+};
+const html = ctx.renderTextPreview(pane);
+console.log(JSON.stringify({
+  hasToggle: html.includes('data-html-preview-mode="source"') &&
+    html.includes('data-html-preview-mode="rendered"'),
+  sourcePressed: html.includes('data-html-preview-mode="source"') &&
+    html.includes('aria-pressed="true"'),
+  hasSyntax: html.includes("syntax-block"),
+  hasFrame: html.includes("<iframe"),
+}));
+"""
+    )
+
+    assert result == {
+        "hasToggle": True,
+        "sourcePressed": True,
+        "hasSyntax": True,
+        "hasFrame": False,
+    }
+
+
+def test_render_html_preview_rendered_mode_uses_sandboxed_srcdoc_iframe():
+    """Rendered HTML mode should isolate document content in a sandboxed iframe."""
+    result = run_app_js(
+        """
+const pane = ctx.createPaneState("pane-1");
+pane.htmlPreviewMode = "rendered";
+pane.preview = {
+  kind: "text",
+  path: "example.html",
+  language: "html",
+  content: '<h1>Hello</h1><script>globalThis.bad = true</script><form action="/x"></form>',
+  html_renderable: true,
+  render: { kind: "syntax", html: '<div class="syntax-block"></div>', value: "" },
+};
+const html = ctx.renderTextPreview(pane);
+console.log(JSON.stringify({
+  renderedPressed: html.includes('data-html-preview-mode="rendered"') &&
+    html.includes('aria-pressed="true"'),
+  hasFrame: html.includes('<iframe'),
+  hasSandbox: html.includes(' sandbox'),
+  hasSrcdoc: html.includes('srcdoc='),
+  hasCsp: html.includes('Content-Security-Policy'),
+  blocksScripts: html.includes("script-src &#39;none&#39;"),
+  blocksForms: html.includes("form-action &#39;none&#39;"),
+  blocksRemoteResources: html.includes("img-src data: blob:"),
+  hidesSyntax: !html.includes("syntax-block"),
+}));
+"""
+    )
+
+    assert result == {
+        "renderedPressed": True,
+        "hasFrame": True,
+        "hasSandbox": True,
+        "hasSrcdoc": True,
+        "hasCsp": True,
+        "blocksScripts": True,
+        "blocksForms": True,
+        "blocksRemoteResources": True,
+        "hidesSyntax": True,
+    }
+
+
+def test_render_non_html_text_preview_omits_html_toggle_and_frame():
+    """Non-HTML text previews should keep the existing single source view."""
+    result = run_app_js(
+        """
+const pane = ctx.createPaneState("pane-1");
+pane.htmlPreviewMode = "rendered";
+pane.preview = {
+  kind: "text",
+  path: "example.py",
+  language: "python",
+  content: "print('hello')",
+  render: {
+    kind: "syntax",
+    html: '<div class="syntax-block"><span class="tok-nb">print</span></div>',
+    value: "print('hello')",
+  },
+};
+const html = ctx.renderTextPreview(pane);
+console.log(JSON.stringify({
+  hasToggle: html.includes("data-html-preview-mode"),
+  hasFrame: html.includes("<iframe"),
+  hasSyntax: html.includes("syntax-block"),
+}));
+"""
+    )
+
+    assert result == {"hasToggle": False, "hasFrame": False, "hasSyntax": True}
+
+
 def test_render_detail_block_supports_syntax_payloads():
     """Structured detail blocks should render syntax HTML fragments directly."""
     result = run_app_js(

--- a/tests/test_web_app_contract.py
+++ b/tests/test_web_app_contract.py
@@ -212,14 +212,16 @@ pane.preview = {
   content: "<!doctype html><h1>Large</h1>",
   html_renderable: true,
   degraded: true,
-  notice: "Plain text preview: rich rendering skipped.",
+  notice: "Source preview: syntax highlighting skipped because large.html is 112 bytes, " +
+    "above the rich source preview limit of 24 bytes.",
   render: { kind: "text", value: "<!doctype html><h1>Large</h1>" },
 };
 const sourceHtml = ctx.renderTextPreview(pane);
 pane.htmlPreviewMode = "rendered";
 const renderedHtml = ctx.renderTextPreview(pane);
 console.log(JSON.stringify({
-  sourceHasNotice: sourceHtml.includes("Plain text preview"),
+  sourceHasNotice: sourceHtml.includes("Source preview: syntax highlighting skipped"),
+  sourceHasPlainTextNotice: sourceHtml.includes("Plain text preview"),
   sourceHasToggle: sourceHtml.includes('data-html-preview-mode="source"') &&
     sourceHtml.includes('data-html-preview-mode="rendered"'),
   sourceUsesTextFallback: sourceHtml.includes("text-block"),
@@ -233,6 +235,7 @@ console.log(JSON.stringify({
 
     assert result == {
         "sourceHasNotice": True,
+        "sourceHasPlainTextNotice": False,
         "sourceHasToggle": True,
         "sourceUsesTextFallback": True,
         "sourceHasFrame": False,


### PR DESCRIPTION
## Summary
- add a web-only rendered HTML mode for `.html` previews while keeping source as the default
- support rendered mode for large readable HTML files that fall back from syntax highlighting
- guard rendered iframe links so fragment anchors scroll inside the preview and non-fragment navigation stays blocked

## User impact
- HTML files still open as highlighted source by default
- users can opt into a sandboxed rendered preview in the web UI
- trajectory HTML table-of-contents links no longer navigate the iframe into the Skim shell

## Validation
- `uv run ruff format .`
- `uv run ruff check .`
- `uv run pytest -v` (`242 passed`)
- manual `uv run skim-web .` validation with `data/response_a_trajectory.html`, including rendered anchor clicks for Preamble, Step 1, and Step 204